### PR TITLE
Code cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerquery-parser",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A parser for the Power Query langauge.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -51,7 +51,7 @@ export namespace CommonError {
         );
     }
 
-    export function ensureWrappedError(err: Error): CommonError {
+    export function ensureCommonError(err: Error): CommonError {
         if (isTInnerCommonError(err)) {
             return new CommonError(err);
         }

--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -21,9 +21,8 @@ export namespace CommonError {
         constructor(
             readonly invariantBroken: string,
             readonly maybeDetails: Option<any> = undefined,
-            readonly message = Localization.Error.invariantError(invariantBroken, maybeDetails),
         ) {
-            super(message);
+            super(Localization.Error.invariantError(invariantBroken, maybeDetails));
         }
     }
 
@@ -31,18 +30,16 @@ export namespace CommonError {
         constructor(
             readonly reason: string,
             readonly maybeDetails: Option<any> = undefined,
-            readonly message = Localization.Error.notYetImplemented(reason, maybeDetails),
         ) {
-            super(message);
+            super(Localization.Error.notYetImplemented(reason, maybeDetails));
         }
     }
 
     export class UnknownError extends Error {
         constructor(
             readonly innerError: any,
-            readonly message = Localization.Error.unknownError(innerError),
         ) {
-            super(message);
+            super(Localization.Error.unknownError(innerError));
         }
     }
 

--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -20,8 +20,8 @@ export namespace CommonError {
     export class InvariantError extends Error {
         constructor(
             readonly invariantBroken: string,
-            readonly maybeJsonfyable: Option<any> = undefined,
-            readonly message = Localization.Error.invariantError(invariantBroken, maybeJsonfyable),
+            readonly maybeDetails: Option<any> = undefined,
+            readonly message = Localization.Error.invariantError(invariantBroken, maybeDetails),
         ) {
             super(message);
         }
@@ -30,8 +30,8 @@ export namespace CommonError {
     export class NotYetImplementedError extends Error {
         constructor(
             readonly reason: string,
-            readonly maybeJsonfyable: Option<any> = undefined,
-            readonly message = Localization.Error.notYetImplemented(reason, maybeJsonfyable),
+            readonly maybeDetails: Option<any> = undefined,
+            readonly message = Localization.Error.notYetImplemented(reason, maybeDetails),
         ) {
             super(message);
         }

--- a/src/common/partialResult.ts
+++ b/src/common/partialResult.ts
@@ -1,5 +1,5 @@
-// similar to Result, except there's a third 'Partial' state added
-// which represents a job being partially completed before an error occured
+// similar to Result, except there's a third in-between state
+// representing when a job was partially completed before an error occured
 export type PartialResult<T, E> = (
     | PartialOk<T>
     | PartialMixed<T, E>

--- a/src/common/stringHelpers.ts
+++ b/src/common/stringHelpers.ts
@@ -33,7 +33,7 @@ export namespace StringHelpers {
     }
 
     export function maybeNewlineKindAt(str: string, index: number): Option<NewlineKind> {
-        if (regexMatchLength(Pattern.RegExpNewline, str, index)) {
+        if (maybeRegexMatchLength(Pattern.RegExpNewline, str, index)) {
             // test for CARRIAGE RETURN + LINE FEED
             if (str[index] === "\r" && str[index + 1] === "\n") {
                 return NewlineKind.DoubleCharacter;
@@ -47,7 +47,7 @@ export namespace StringHelpers {
         }
     }
 
-    export function regexMatchLength(pattern: RegExp, str: string, index: number): Option<number> {
+    export function maybeRegexMatchLength(pattern: RegExp, str: string, index: number): Option<number> {
         pattern.lastIndex = index;
         const matches = pattern.exec(str);
 

--- a/src/common/traversal.ts
+++ b/src/common/traversal.ts
@@ -5,13 +5,12 @@ import { Option } from "./option";
 import { Result, ResultKind } from "./result";
 
 // Adds some structure / helper functions for traversing an AST.
-// A traversal should have a function which creates an IRequest,
-// which is then consumed by runTraverseRequest.
 //
 // By default a traversal visits every node and calls a visit function.
-// A traversal visit nodes either using a depth-first or breadth-first strategy.
-// It can prune branches if an optional early exit fn is given.
-// Any values needed during a traversal should be stored on an IState instance.
+// A traversal can visit nodes either using a depth-first or breadth-first strategy.
+// Branches can be pruned if an optional early exit fn is given.
+//
+// Review the traversals used in tests for an example.
 
 export namespace Traverse {
 
@@ -19,8 +18,8 @@ export namespace Traverse {
     export type TVisitChildNodeFn<State, StateType, Return> = (parent: Ast.TNode, node: Ast.TNode, state: State & Traverse.IState<StateType>) => Return;
 
     export const enum VisitNodeStrategy {
-        BreadthFirst,
-        DepthFirst,
+        BreadthFirst = "BreadthFirst",
+        DepthFirst = "DepthFirst",
     }
 
     export interface IRequest<State, StateType> {

--- a/src/common/traversal.ts
+++ b/src/common/traversal.ts
@@ -49,7 +49,7 @@ export namespace Traverse {
         catch (e) {
             return {
                 kind: ResultKind.Err,
-                error: CommonError.ensureWrappedError(e),
+                error: CommonError.ensureCommonError(e),
             };
         }
         return {

--- a/src/common/traversal.ts
+++ b/src/common/traversal.ts
@@ -523,7 +523,7 @@ function maybeTraverse<State, StateType, Return>(
 }
 
 function traverseArray<State, StateType, Return>(
-    collection: Ast.TNode[],
+    collection: ReadonlyArray<Ast.TNode>,
     state: State & Traverse.IState<StateType>,
     visitFn: Traverse.TVisitNodeFn<State, StateType, Return>,
     strategy: Traverse.VisitNodeStrategy,
@@ -546,7 +546,7 @@ function traversePairedConstant<State, StateType, Return>(
 }
 
 function traverseUnaryExpressionHelpers<State, StateType, Return>(
-    nodes: Ast.TUnaryExpressionHelper[],
+    nodes: ReadonlyArray<Ast.TUnaryExpressionHelper>,
     state: State & Traverse.IState<StateType>,
     visitFn: Traverse.TVisitNodeFn<State, StateType, Return>,
     strategy: Traverse.VisitNodeStrategy,
@@ -582,7 +582,7 @@ function maybeTraverseChild<State, StateType, Return>(
 
 function traverseChildArray<State, StateType, Return>(
     parent: Ast.TNode,
-    collection: Ast.TNode[],
+    collection: ReadonlyArray<Ast.TNode>,
     state: State & Traverse.IState<StateType>,
     visitFn: Traverse.TVisitChildNodeFn<State, StateType, Return>,
 ) {
@@ -592,7 +592,7 @@ function traverseChildArray<State, StateType, Return>(
 }
 
 function traverseUnaryExpressionHelperChildren<State, StateType, Return>(
-    nodes: Ast.TUnaryExpressionHelper[],
+    nodes: ReadonlyArray<Ast.TUnaryExpressionHelper>,
     state: State & Traverse.IState<StateType>,
     visitFn: Traverse.TVisitChildNodeFn<State, StateType, Return>,
 ) {

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -4,7 +4,7 @@ import { Ast, Parser, ParserError } from "./parser";
 
 export interface LexAndParseSuccess {
     readonly ast: Ast.TDocument,
-    readonly comments: TComment[],
+    readonly comments: ReadonlyArray<TComment>,
 }
 
 export function lexAndParse(document: string): Result<LexAndParseSuccess, LexerError.TLexerError | ParserError.TParserError> {

--- a/src/lexer/comment.ts
+++ b/src/lexer/comment.ts
@@ -18,10 +18,10 @@ export interface IComment {
 }
 
 export interface LineComment extends IComment {
-    readonly kind: CommentKind.Line;
+    readonly kind: CommentKind.Line,
     readonly containsNewline: true,
 }
 
 export interface MultilineComment extends IComment {
-    readonly kind: CommentKind.Multiline;
+    readonly kind: CommentKind.Multiline,
 }

--- a/src/lexer/error.ts
+++ b/src/lexer/error.ts
@@ -30,7 +30,7 @@ export namespace LexerError {
 
     export class BadStateError extends Error {
         constructor(
-            readonly lastError: TLexerError,
+            readonly innerError: TLexerError,
         ) {
             super(Localization.Error.lexerBadState());
         }

--- a/src/lexer/error.ts
+++ b/src/lexer/error.ts
@@ -31,80 +31,70 @@ export namespace LexerError {
     export class BadStateError extends Error {
         constructor(
             readonly lastError: TLexerError,
-            readonly message = Localization.Error.lexerBadState(),
         ) {
-            super(message);
+            super(Localization.Error.lexerBadState());
         }
     }
 
     export class EndOfStreamError extends Error {
-        constructor(
-            readonly message = Localization.Error.lexerEndOfStream(),
-        ) {
-            super(message);
+        constructor() {
+            super(Localization.Error.lexerEndOfStream());
         }
     }
 
     export class ExpectedHexLiteralError extends Error {
         constructor(
             readonly graphemePosition: StringHelpers.GraphemePosition,
-            readonly message = Localization.Error.lexerExpectedHexLiteral(graphemePosition),
         ) {
-            super(message);
+            super(Localization.Error.lexerExpectedHexLiteral(graphemePosition));
         }
     }
 
     export class ExpectedKeywordOrIdentifierError extends Error {
         constructor(
             readonly graphemePosition: StringHelpers.GraphemePosition,
-            readonly message = Localization.Error.lexerExpectedKeywordOrIdentifier(graphemePosition),
         ) {
-            super(message);
+            super(Localization.Error.lexerExpectedKeywordOrIdentifier(graphemePosition));
         }
     }
 
     export class ExpectedNumericLiteralError extends Error {
         constructor(
             readonly graphemePosition: StringHelpers.GraphemePosition,
-            readonly message = Localization.Error.lexerExpectedNumericLiteral(graphemePosition),
         ) {
-            super(message);
+            super(Localization.Error.lexerExpectedNumericLiteral(graphemePosition));
         }
     }
 
     export class UnexpectedEofError extends Error {
         constructor(
             readonly graphemePosition: StringHelpers.GraphemePosition,
-            readonly message = Localization.Error.lexerUnexpectedEof(graphemePosition),
         ) {
-            super(message);
+            super(Localization.Error.lexerUnexpectedEof(graphemePosition));
         }
     }
 
     export class UnexpectedReadError extends Error {
         constructor(
             readonly graphemePosition: StringHelpers.GraphemePosition,
-            readonly message = Localization.Error.lexerUnexpectedRead(graphemePosition),
         ) {
-            super(message);
+            super(Localization.Error.lexerUnexpectedRead(graphemePosition));
         }
     }
 
     export class UnterminatedMultilineCommentError extends Error {
         constructor(
             readonly graphemePosition: StringHelpers.GraphemePosition,
-            readonly message = Localization.Error.lexerUnterminatedString(graphemePosition),
         ) {
-            super(message);
+            super(Localization.Error.lexerUnterminatedString(graphemePosition));
         }
     }
 
     export class UnterminatedStringError extends Error {
         constructor(
             readonly graphemePosition: StringHelpers.GraphemePosition,
-            readonly message = Localization.Error.lexerUnterminatedString(graphemePosition),
         ) {
-            super(message);
+            super(Localization.Error.lexerUnterminatedString(graphemePosition));
         }
     }
 

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -17,14 +17,15 @@ export namespace Lexer {
         | UntouchedLexer
     )
 
+    // most Lexer actions leave a TLexer in a touched state of some sort
     export type TLexerExceptUntouched = Exclude<TLexer, UntouchedLexer>;
 
     export interface ILexer {
         readonly kind: LexerKind,
         readonly document: string,
-        readonly tokens: ReadonlyArray<Token>,       // all tokens read up to this point
-        readonly comments: ReadonlyArray<TComment>,  // all comments read up to this point
-        readonly documentIndex: number, // where the lexer left off, can be EOF
+        readonly tokens: ReadonlyArray<Token>,      // all tokens read up to this point
+        readonly comments: ReadonlyArray<TComment>, // all comments read up to this point
+        readonly documentIndex: number,             // where the lexer left off, can be EOF
     }
 
     // the last read attempt didn't read any new tokens/comments (though possibly whitespace),
@@ -183,7 +184,11 @@ export namespace Lexer {
         }
     }
 
-    function updateState(originalState: TLexer, lexerReadPartialResult: PartialResult<LexerRead, LexerError.TLexerError>): TLexerExceptUntouched {
+    function updateState(
+        originalState: TLexer,
+        lexerReadPartialResult:
+        PartialResult<LexerRead, LexerError.TLexerError>,
+    ): TLexerExceptUntouched {
         switch (lexerReadPartialResult.kind) {
             case PartialResultKind.Ok: {
                 const lexerRead: LexerRead = lexerReadPartialResult.value;
@@ -231,7 +236,10 @@ export namespace Lexer {
         }
     }
 
-    function read(state: TLexer, behavior: LexerStrategy): PartialResult<LexerRead, LexerError.TLexerError> {
+    function read(
+        state: TLexer,
+        behavior: LexerStrategy,
+    ): PartialResult<LexerRead, LexerError.TLexerError> {
         const document = state.document;
         const documentLength = document.length;
         const documentStartIndex = state.documentIndex;
@@ -600,7 +608,7 @@ export namespace Lexer {
                 throw unexpectedReadError(document, documentIndex);
             }
         }
-        const substring = maybeSubstring;
+        const substring: string = maybeSubstring;
 
         switch (substring) {
             case Keyword.And:
@@ -676,7 +684,7 @@ export namespace Lexer {
             const graphemePosition = StringHelpers.graphemePositionAt(document, documentIndex);
             throw new LexerError.ExpectedKeywordOrIdentifierError(graphemePosition);
         }
-        const substring = maybeSubstring;
+        const substring: string = maybeSubstring;
 
         if (substring[0] === "#" || Keywords.indexOf(substring) !== -1) {
             return readKeyword(document, documentIndex, substring);
@@ -696,12 +704,18 @@ export namespace Lexer {
         }
     }
 
-    function maybeKeywordOrIdentifierSubstring(document: string, documentIndex: number): Option<string> {
+    function maybeKeywordOrIdentifierSubstring(
+        document: string,
+        documentIndex: number,
+    ): Option<string> {
         const chr = document[documentIndex];
+        let indexOfStart: number;
 
-        let indexOfStart = documentIndex;
         if (chr === "#") {
-            indexOfStart += 1;
+            indexOfStart = documentIndex + 1;
+        }
+        else {
+            indexOfStart = documentIndex;
         }
 
         const identifierEndIndex = indexOfRegexEnd(Pattern.RegExpIdentifier, document, indexOfStart);
@@ -713,7 +727,11 @@ export namespace Lexer {
         }
     }
 
-    function readConstantToken(documentStartIndex: number, tokenKind: TokenKind, data: string): Token {
+    function readConstantToken(
+        documentStartIndex: number,
+        tokenKind: TokenKind,
+        data: string,
+    ): Token {
         return {
             kind: tokenKind,
             documentStartIndex,

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -22,8 +22,8 @@ export namespace Lexer {
     export interface ILexer {
         readonly kind: LexerKind,
         readonly document: string,
-        readonly tokens: Token[],       // all tokens read up to this point
-        readonly comments: TComment[],  // all comments read up to this point
+        readonly tokens: ReadonlyArray<Token>,       // all tokens read up to this point
+        readonly comments: ReadonlyArray<TComment>,  // all comments read up to this point
         readonly documentIndex: number, // where the lexer left off, can be EOF
     }
 
@@ -63,8 +63,8 @@ export namespace Lexer {
 
     // what was read on a call to lex
     export interface LexerRead {
-        readonly tokens: Token[],
-        readonly comments: TComment[],
+        readonly tokens: ReadonlyArray<Token>,
+        readonly comments: ReadonlyArray<TComment>,
         readonly documentStartIndex: number,
         readonly documentEndIndex: number,
     }
@@ -187,8 +187,8 @@ export namespace Lexer {
         switch (lexerReadPartialResult.kind) {
             case PartialResultKind.Ok: {
                 const lexerRead: LexerRead = lexerReadPartialResult.value;
-                const newTokens: Token[] = originalState.tokens.concat(lexerRead.tokens);
-                const newComments: TComment[] = originalState.comments.concat(lexerRead.comments);
+                const newTokens: ReadonlyArray<Token> = originalState.tokens.concat(lexerRead.tokens);
+                const newComments: ReadonlyArray<TComment> = originalState.comments.concat(lexerRead.comments);
 
                 return {
                     kind: LexerKind.Touched,
@@ -202,8 +202,9 @@ export namespace Lexer {
 
             case PartialResultKind.Partial: {
                 const lexerRead: LexerRead = lexerReadPartialResult.value;
-                const newTokens: Token[] = originalState.tokens.concat(lexerRead.tokens);
-                const newComments: TComment[] = originalState.comments.concat(lexerRead.comments);
+                const newTokens: ReadonlyArray<Token> = originalState.tokens.concat(lexerRead.tokens);
+                const newComments: ReadonlyArray<TComment> = originalState.comments.concat(lexerRead.comments);
+                
                 return {
                     kind: LexerKind.TouchedWithError,
                     document: originalState.document,
@@ -461,7 +462,12 @@ export namespace Lexer {
         return readTokenFromSlice(document, documentIndex, TokenKind.NumericLiteral, numericEndIndex);
     }
 
-    function readComments(document: string, documentIndex: number, initial: CommentKind, phantomTokenIndex: number): TComment[] {
+    function readComments(
+        document: string,
+        documentIndex: number,
+        initial: CommentKind,
+        phantomTokenIndex: number
+    ): ReadonlyArray<TComment> {
         let maybeNextCommentKind: Option<CommentKind> = initial;
         let chr1 = document[documentIndex];
         let chr2 = document[documentIndex + 1];

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -385,7 +385,7 @@ export namespace Lexer {
                     error = new LexerError.LexerError(e);
                 }
                 else {
-                    error = CommonError.ensureWrappedError(e);
+                    error = CommonError.ensureCommonError(e);
                 }
                 continueLexing = false;
                 maybeError = error;

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -788,7 +788,7 @@ export namespace Lexer {
         let indexOfDoubleQuote = document.indexOf("\"", documentIndex)
 
         while (indexOfDoubleQuote !== -1) {
-            if (document[indexOfDoubleQuote + 1] == "\"") {
+            if (document[indexOfDoubleQuote + 1] === "\"") {
                 documentIndex = indexOfDoubleQuote + 2;
                 indexOfDoubleQuote = document.indexOf("\"", documentIndex);
             }

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -466,13 +466,13 @@ export namespace Lexer {
         document: string,
         documentIndex: number,
         initial: CommentKind,
-        phantomTokenIndex: number
+        phantomTokenIndex: number,
     ): ReadonlyArray<TComment> {
         let maybeNextCommentKind: Option<CommentKind> = initial;
         let chr1 = document[documentIndex];
         let chr2 = document[documentIndex + 1];
 
-        const comments = [];
+        const newComments = [];
         while (maybeNextCommentKind) {
             let comment: TComment;
             switch (maybeNextCommentKind) {
@@ -489,7 +489,7 @@ export namespace Lexer {
             }
 
             documentIndex = comment.documentEndIndex;
-            comments.push(comment);
+            newComments.push(comment);
 
             chr1 = document[documentIndex];
             chr2 = document[documentIndex + 1];
@@ -506,10 +506,14 @@ export namespace Lexer {
             }
         }
 
-        return comments;
+        return newComments;
     }
 
-    function readLineComment(document: string, documentIndex: number, phantomTokenIndex: number): LineComment {
+    function readLineComment(
+        document: string,
+        documentIndex: number,
+        phantomTokenIndex: number,
+    ): LineComment {
         const documentLength = document.length;
         const commentStart = documentIndex;
 
@@ -555,7 +559,11 @@ export namespace Lexer {
         }
     }
 
-    function readMultilineComment(document: string, documentIndex: number, phantomTokenIndex: number): MultilineComment {
+    function readMultilineComment(
+        document: string,
+        documentIndex: number,
+        phantomTokenIndex: number,
+    ): MultilineComment {
         const documentStartIndex = documentIndex;
         const indexOfCommentEnd = document.indexOf("*/", documentStartIndex + 2);
         if (indexOfCommentEnd === -1) {

--- a/src/lexer/lexerSnapshot.ts
+++ b/src/lexer/lexerSnapshot.ts
@@ -5,8 +5,8 @@ import { Token } from "./token";
 export class LexerSnapshot {
     constructor(
         public readonly document: string,
-        public readonly tokens: Token[],
-        public readonly comments: TComment[],
+        public readonly tokens: ReadonlyArray<Token>,
+        public readonly comments: ReadonlyArray<TComment>,
     ) { }
 
     public tokenPosition(token: Token): TokenPosition {

--- a/src/localization/error.ts
+++ b/src/localization/error.ts
@@ -91,7 +91,7 @@ export namespace Localization.Error {
     }
 
     export function parserExpectedAnyTokenKind(
-        expectedAnyTokenKind: TokenKind[],
+        expectedAnyTokenKind: ReadonlyArray<TokenKind>,
         maybeFoundTokenPosition: Option<TokenPosition>,
     ): string {
         if (maybeFoundTokenPosition) {

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -235,7 +235,7 @@ export namespace Ast {
         readonly sectionConstant: Constant,
         readonly maybeName: Option<Identifier>,
         readonly semicolonConstant: Constant,
-        readonly sectionMembers: SectionMember[],
+        readonly sectionMembers: ReadonlyArray<SectionMember>,
     }
 
     export interface SectionMember extends INode {
@@ -425,7 +425,7 @@ export namespace Ast {
     export interface UnaryExpression extends INode {
         readonly kind: NodeKind.UnaryExpression,
         readonly terminalNode: false,
-        readonly expressions: UnaryExpressionHelper<UnaryOperator, TUnaryExpression>[],
+        readonly expressions: ReadonlyArray<UnaryExpressionHelper<UnaryOperator, TUnaryExpression>>,
     }
 
     export const enum UnaryOperator {
@@ -510,19 +510,19 @@ export namespace Ast {
     // ---------- 12.2.3.16 Invoke expression ----------
     // -------------------------------------------------
 
-    export interface InvokeExpression extends IWrapped<NodeKind.InvokeExpression, ICsv<TExpression>[]> { }
+    export interface InvokeExpression extends IWrapped<NodeKind.InvokeExpression, ReadonlyArray<ICsv<TExpression>>> { }
 
     // -----------------------------------------------
     // ---------- 12.2.3.17 List expression ----------
     // -----------------------------------------------
 
-    export interface ListExpression extends IWrapped<NodeKind.ListExpression, ICsv<TExpression>[]> { }
+    export interface ListExpression extends IWrapped<NodeKind.ListExpression, ReadonlyArray<ICsv<TExpression>>> { }
 
     // -------------------------------------------------
     // ---------- 12.2.3.18 Record expression ----------
     // -------------------------------------------------
 
-    export interface RecordExpression extends IWrapped<NodeKind.RecordExpression, ICsv<GeneralizedIdentifierPairedExpression>[]> { }
+    export interface RecordExpression extends IWrapped<NodeKind.RecordExpression, ReadonlyArray<ICsv<GeneralizedIdentifierPairedExpression>>> { }
 
     // ------------------------------------------------------
     // ---------- 12.2.3.19 Item access expression ----------
@@ -549,7 +549,7 @@ export namespace Ast {
         readonly implicit: boolean,
     }
 
-    export interface FieldProjection extends IWrapped<NodeKind.FieldProjection, ICsv<FieldSelector>[]> {
+    export interface FieldProjection extends IWrapped<NodeKind.FieldProjection, ReadonlyArray<ICsv<FieldSelector>>> {
         // located after closeWrapperConstant
         readonly maybeOptionalConstant: Option<Constant>,
         // metadata marked for future use
@@ -582,7 +582,7 @@ export namespace Ast {
     export interface LetExpression extends INode {
         readonly kind: NodeKind.LetExpression,
         readonly letConstant: Constant,
-        readonly variableList: ICsv<IdentifierPairedExpression>[],
+        readonly variableList: ReadonlyArray<ICsv<IdentifierPairedExpression>>,
         readonly inConstant: Constant,
         readonly expression: TExpression,
     }
@@ -676,7 +676,7 @@ export namespace Ast {
         readonly kind: NodeKind.RecursivePrimaryExpression,
         readonly terminalNode: false,
         readonly head: TPrimaryExpression,
-        readonly recursiveExpressions: TRecursivePrimaryExpression[],
+        readonly recursiveExpressions: ReadonlyArray<TRecursivePrimaryExpression>,
     }
 
     export interface TypePrimaryType extends IPairedConstant<NodeKind.TypePrimaryType, TPrimaryType> { }
@@ -691,11 +691,11 @@ export namespace Ast {
         | RecordLiteral
     )
 
-    export interface ListLiteral extends IWrapped<NodeKind.ListLiteral, ICsv<TAnyLiteral>[]> {
+    export interface ListLiteral extends IWrapped<NodeKind.ListLiteral, ReadonlyArray<ICsv<TAnyLiteral>>> {
         readonly literalKind: LiteralKind.List,
     }
 
-    export interface RecordLiteral extends IWrapped<NodeKind.RecordLiteral, ICsv<GeneralizedIdentifierPairedAnyLiteral>[]> {
+    export interface RecordLiteral extends IWrapped<NodeKind.RecordLiteral, ReadonlyArray<ICsv<GeneralizedIdentifierPairedAnyLiteral>>> {
         readonly literalKind: LiteralKind.Record,
     }
 
@@ -708,7 +708,7 @@ export namespace Ast {
     export interface IBinOpExpression<NodeKindVariant, Operator, Operand> extends INode {
         readonly kind: NodeKindVariant & TBinOpExpressionNodeKind,
         readonly first: Operand,
-        readonly rest: UnaryExpressionHelper<Operator, Operand>[],
+        readonly rest: ReadonlyArray<UnaryExpressionHelper<Operator, Operand>>,
     }
 
     // BinOp expressions which uses a keyword as operators,
@@ -800,7 +800,7 @@ export namespace Ast {
         | Option<AsNullablePrimitiveType>
     )
 
-    export interface ParameterList<T> extends IWrapped<NodeKind.ParameterList, ICsv<Parameter<T>>[]> { }
+    export interface ParameterList<T> extends IWrapped<NodeKind.ParameterList, ReadonlyArray<ICsv<Parameter<T>>>> { }
 
     export interface Parameter<T> extends INode {
         readonly kind: NodeKind.Parameter,
@@ -831,7 +831,7 @@ export namespace Ast {
         readonly name: GeneralizedIdentifier,
         readonly maybeFieldTypeSpeification: Option<FieldTypeSpecification>,
     }
-    export interface FieldSpecificationList extends IWrapped<NodeKind.FieldSpecificationList, ICsv<FieldSpecification>[]> {
+    export interface FieldSpecificationList extends IWrapped<NodeKind.FieldSpecificationList, ReadonlyArray<ICsv<FieldSpecification>>> {
         // located between content and closeWrapperConstant
         readonly maybeOpenRecordMarkerConstant: Option<Constant>,
     }

--- a/src/parser/error.ts
+++ b/src/parser/error.ts
@@ -33,7 +33,7 @@ export namespace ParserError {
 
     export class ExpectedAnyTokenKindError extends Error {
         constructor(
-            readonly expectedAnyTokenKind: TokenKind[],
+            readonly expectedAnyTokenKind: ReadonlyArray<TokenKind>,
             readonly maybeFoundTokenPosition: Option<TokenPosition>,
             readonly message = Localization.Error.parserExpectedAnyTokenKind(expectedAnyTokenKind, maybeFoundTokenPosition),
         ) {

--- a/src/parser/error.ts
+++ b/src/parser/error.ts
@@ -35,9 +35,8 @@ export namespace ParserError {
         constructor(
             readonly expectedAnyTokenKind: ReadonlyArray<TokenKind>,
             readonly maybeFoundTokenPosition: Option<TokenPosition>,
-            readonly message = Localization.Error.parserExpectedAnyTokenKind(expectedAnyTokenKind, maybeFoundTokenPosition),
         ) {
-            super(message);
+            super(Localization.Error.parserExpectedAnyTokenKind(expectedAnyTokenKind, maybeFoundTokenPosition));
         }
     }
 
@@ -45,9 +44,8 @@ export namespace ParserError {
         constructor(
             readonly expectedTokenKind: TokenKind,
             readonly maybeFoundTokenPosition: Option<TokenPosition>,
-            readonly message = Localization.Error.parserExpectedTokenKind(expectedTokenKind, maybeFoundTokenPosition),
         ) {
-            super(message);
+            super(Localization.Error.parserExpectedTokenKind(expectedTokenKind, maybeFoundTokenPosition));
         }
     }
 
@@ -55,54 +53,48 @@ export namespace ParserError {
         constructor(
             readonly foundIdentifier: string,
             readonly tokenPosition: TokenPosition,
-            readonly message = Localization.Error.parserInvalidPrimitiveType(foundIdentifier, tokenPosition),
         ) {
-            super(message);
+            super(Localization.Error.parserInvalidPrimitiveType(foundIdentifier, tokenPosition));
         }
     }
 
     export class RequiredParameterAfterOptionalParameterError extends Error {
         constructor(
             readonly missingOptionalTokenPosition: TokenPosition,
-            readonly message = Localization.Error.parserRequiredParameterAfterOptionalParameter(missingOptionalTokenPosition),
         ) {
-            super(message);
+            super(Localization.Error.parserRequiredParameterAfterOptionalParameter(missingOptionalTokenPosition));
         }
     }
 
     export class UnexpectedEndOfTokensError extends Error {
         constructor(
             readonly topOfTokenRangeStack: Ast.NodeKind,
-            readonly message = Localization.Error.parserUnexpectedEndOfTokens(topOfTokenRangeStack),
         ) {
-            super(message);
+            super(Localization.Error.parserUnexpectedEndOfTokens(topOfTokenRangeStack));
         }
     }
 
     export class UnterminatedBracketError extends Error {
         constructor(
             readonly openBracketTokenPosition: TokenPosition,
-            readonly message = Localization.Error.parserUnterminatedBracket(openBracketTokenPosition),
         ) {
-            super(message);
+            super(Localization.Error.parserUnterminatedBracket(openBracketTokenPosition));
         }
     }
 
     export class UnterminatedParenthesesError extends Error {
         constructor(
             readonly openParenthesesTokenPosition: TokenPosition,
-            readonly message = Localization.Error.parserUnterminatedParentheses(openParenthesesTokenPosition),
         ) {
-            super(message);
+            super(Localization.Error.parserUnterminatedParentheses(openParenthesesTokenPosition));
         }
     }
 
     export class UnusedTokensRemainError extends Error {
         constructor(
             readonly firstUnusedTokenPosition: TokenPosition,
-            readonly message = Localization.Error.parserUnusedTokensRemain(firstUnusedTokenPosition),
         ) {
-            super(message);
+            super(Localization.Error.parserUnusedTokensRemain(firstUnusedTokenPosition));
         }
     }
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -40,7 +40,7 @@ export class Parser {
                 error = new ParserError.ParserError(e);
             }
             else {
-                error = CommonError.ensureWrappedError(e);
+                error = CommonError.ensureCommonError(e);
             }
             return {
                 kind: ResultKind.Err,
@@ -1896,7 +1896,7 @@ export class Parser {
 
     private isTokenKind(tokenKind: TokenKind, tokenIndex: number): boolean {
         const maybeToken: Option<Token> = this.lexerSnapshot.tokens[tokenIndex];
-        
+
         if (maybeToken) {
             return maybeToken.kind === tokenKind;
         }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1870,7 +1870,9 @@ export class Parser {
         };
     }
 
-    private singleTokenRange(tag: TokenKind | Keyword | Ast.IdentifierConstant | Ast.TUnaryExpressionHelperOperator): TokenRange {
+    private singleTokenRange(
+        tag: TokenKind | Keyword | Ast.IdentifierConstant | Ast.TUnaryExpressionHelperOperator,
+    ): TokenRange {
         const tokenIndex = this.tokenIndex;
         const token = this.lexerSnapshot.tokens[tokenIndex];
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1835,9 +1835,9 @@ export class Parser {
         });
     }
 
+    // faster version of popTokenRange, returns no value
     private popTokenRangeNoop() {
-        const element = this.tokenRangeStack.pop();
-        if (!element) {
+        if (!this.tokenRangeStack.pop()) {
             throw new CommonError.InvariantError("tried to pop from an empty stack");
         }
     }
@@ -1851,11 +1851,11 @@ export class Parser {
 
         const tokenStartIndex = element.tokenStartIndex;
         const tokenEndIndex = this.tokenIndex;
-        const lastInclusiveToken = lexerSnapshot.tokens[tokenEndIndex - 1];
+        const maybeLastInclusiveToken: Option<Token> = lexerSnapshot.tokens[tokenEndIndex - 1];
 
         let documentEndIndex;
-        if (lastInclusiveToken) {
-            documentEndIndex = lastInclusiveToken.documentEndIndex;
+        if (maybeLastInclusiveToken) {
+            documentEndIndex = maybeLastInclusiveToken.documentEndIndex;
         }
         else {
             documentEndIndex = lexerSnapshot.document.length;
@@ -1870,6 +1870,7 @@ export class Parser {
         };
     }
 
+    // create a TokenRange of length 1
     private singleTokenRange(
         tag: TokenKind | Keyword | Ast.IdentifierConstant | Ast.TUnaryExpressionHelperOperator,
     ): TokenRange {
@@ -1894,13 +1895,13 @@ export class Parser {
     }
 
     private isTokenKind(tokenKind: TokenKind, tokenIndex: number): boolean {
-        const tokens = this.lexerSnapshot.tokens;
-
-        if (tokenIndex < 0 || tokenIndex >= tokens.length) {
-            return false;
+        const maybeToken: Option<Token> = this.lexerSnapshot.tokens[tokenIndex];
+        
+        if (maybeToken) {
+            return maybeToken.kind === tokenKind;
         }
         else {
-            return tokens[tokenIndex].kind === tokenKind;
+            return false;
         }
     }
 
@@ -1923,6 +1924,7 @@ export class Parser {
     private currentTokenPosition(): Option<TokenPosition> {
         const lexerSnapshot = this.lexerSnapshot;
         const maybeToken: Option<Token> = lexerSnapshot.tokens[this.tokenIndex];
+
         if (maybeToken) {
             return lexerSnapshot.tokenPosition(maybeToken);
         }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -461,7 +461,7 @@ export class Parser {
     // 12.2.3.16 Invoke expression
     private readInvokeExpression(): Ast.InvokeExpression {
         const continueReadingValues = !this.isNextTokenKind(TokenKind.RightParenthesis);
-        return this.readWrapped<Ast.NodeKind.InvokeExpression, Ast.ICsv<Ast.TExpression>[]>(
+        return this.readWrapped<Ast.NodeKind.InvokeExpression, ReadonlyArray<Ast.ICsv<Ast.TExpression>>>(
             Ast.NodeKind.InvokeExpression,
             () => this.readTokenKindAsConstant(TokenKind.LeftParenthesis),
             () => this.readCsv(
@@ -475,7 +475,7 @@ export class Parser {
     // 12.2.3.17 List expression
     private readListExpression(): Ast.ListExpression {
         const continueReadingValues = !this.isNextTokenKind(TokenKind.RightBrace);
-        return this.readWrapped<Ast.NodeKind.ListExpression, Ast.ICsv<Ast.TExpression>[]>(
+        return this.readWrapped<Ast.NodeKind.ListExpression, ReadonlyArray<Ast.ICsv<Ast.TExpression>>>(
             Ast.NodeKind.ListExpression,
             () => this.readTokenKindAsConstant(TokenKind.LeftBrace),
             () => this.readCsv(
@@ -489,7 +489,7 @@ export class Parser {
     // 12.2.3.18 Record expression
     private readRecordExpression(): Ast.RecordExpression {
         const continueReadingValues = !this.isNextTokenKind(TokenKind.RightBracket);
-        return this.readWrapped<Ast.NodeKind.RecordExpression, Ast.ICsv<Ast.GeneralizedIdentifierPairedExpression>[]>(
+        return this.readWrapped<Ast.NodeKind.RecordExpression, ReadonlyArray<Ast.ICsv<Ast.GeneralizedIdentifierPairedExpression>>>(
             Ast.NodeKind.RecordExpression,
             () => this.readTokenKindAsConstant(TokenKind.LeftBracket),
             () => this.readGeneralizedIdentifierPairedExpressions(continueReadingValues),
@@ -534,7 +534,7 @@ export class Parser {
     // sub-item of 12.2.3.20 Field access expressions
     private readFieldProjection(isImplicit: boolean): Ast.FieldProjection {
         this.startTokenRange(Ast.NodeKind.FieldProjection);
-        const maybeReturn = this.readWrapped<Ast.NodeKind.FieldProjection, Ast.ICsv<Ast.FieldSelector>[]>(
+        const maybeReturn = this.readWrapped<Ast.NodeKind.FieldProjection, ReadonlyArray<Ast.ICsv<Ast.FieldSelector>>>(
             Ast.NodeKind.FieldProjection,
             () => this.readTokenKindAsConstant(TokenKind.LeftBracket),
             () => this.readCsv(
@@ -971,7 +971,7 @@ export class Parser {
 
     private readRecordLiteral(): Ast.RecordLiteral {
         const continueReadingValues = !this.isNextTokenKind(TokenKind.RightBracket);
-        const wrappedRead = this.readWrapped<Ast.NodeKind.RecordLiteral, Ast.ICsv<Ast.GeneralizedIdentifierPairedAnyLiteral>[]>(
+        const wrappedRead = this.readWrapped<Ast.NodeKind.RecordLiteral, ReadonlyArray<Ast.ICsv<Ast.GeneralizedIdentifierPairedAnyLiteral>>>(
             Ast.NodeKind.RecordLiteral,
             () => this.readTokenKindAsConstant(TokenKind.LeftBracket),
             () => this.readFieldNamePairedAnyLiterals(continueReadingValues),
@@ -983,7 +983,9 @@ export class Parser {
         }
     }
 
-    private readFieldNamePairedAnyLiterals(continueReadingValues: boolean): Ast.ICsv<Ast.GeneralizedIdentifierPairedAnyLiteral>[] {
+    private readFieldNamePairedAnyLiterals(
+        continueReadingValues: boolean
+    ): ReadonlyArray<Ast.ICsv<Ast.GeneralizedIdentifierPairedAnyLiteral>> {
         return this.readCsv(
             () => this.readKeyValuePair<Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral, Ast.GeneralizedIdentifier, Ast.TAnyLiteral>(
                 Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
@@ -996,7 +998,7 @@ export class Parser {
 
     private readListLiteral(): Ast.ListLiteral {
         const continueReadingValues = !this.isNextTokenKind(TokenKind.RightBrace);
-        const wrappedRead = this.readWrapped<Ast.NodeKind.ListLiteral, Ast.ICsv<Ast.TAnyLiteral>[]>(
+        const wrappedRead = this.readWrapped<Ast.NodeKind.ListLiteral, ReadonlyArray<Ast.ICsv<Ast.TAnyLiteral>>>(
             Ast.NodeKind.ListLiteral,
             () => this.readTokenKindAsConstant(TokenKind.LeftBrace),
             () => this.readCsv(
@@ -1303,14 +1305,18 @@ export class Parser {
         };
     }
 
-    private readIdentifierPairedExpressions(continueReadingValues: boolean): Ast.ICsv<Ast.IdentifierPairedExpression>[] {
+    private readIdentifierPairedExpressions(
+        continueReadingValues: boolean
+    ): ReadonlyArray<Ast.ICsv<Ast.IdentifierPairedExpression>> {
         return this.readCsv(
             () => this.readIdentifierPairedExpression(),
             continueReadingValues,
         );
     }
 
-    private readGeneralizedIdentifierPairedExpressions(continueReadingValues: boolean): Ast.ICsv<Ast.GeneralizedIdentifierPairedExpression>[] {
+    private readGeneralizedIdentifierPairedExpressions(
+        continueReadingValues: boolean
+    ): ReadonlyArray<Ast.ICsv<Ast.GeneralizedIdentifierPairedExpression>> {
         return this.readCsv(
             () => this.readGeneralizedIdentifierPairedExpression(),
             continueReadingValues,
@@ -1508,8 +1514,15 @@ export class Parser {
         }
     }
 
-    private expectAnyTokenKind(expectedAnyTokenKind: TokenKind[]): Option<ParserError.ExpectedAnyTokenKindError> {
-        if (this.currentTokenKind === undefined || expectedAnyTokenKind.indexOf(this.currentTokenKind) === -1) {
+    private expectAnyTokenKind(
+        expectedAnyTokenKind: ReadonlyArray<TokenKind>
+    ): Option<ParserError.ExpectedAnyTokenKindError> {
+        const isError = (
+            this.currentTokenKind === undefined
+            || expectedAnyTokenKind.indexOf(this.currentTokenKind) === -1
+        )
+
+        if (isError) {
             const maybeFoundTokenPosition = this.currentTokenPosition();
             return new ParserError.ExpectedAnyTokenKindError(
                 expectedAnyTokenKind,
@@ -1669,7 +1682,7 @@ export class Parser {
     private readCsv<T>(
         valueReader: () => T,
         continueReadingValues: boolean,
-    ): Ast.ICsv<T>[] {
+    ): ReadonlyArray<Ast.ICsv<T>> {
         const values: Ast.ICsv<T>[] = [];
 
         while (continueReadingValues) {

--- a/src/parser/tokenRange.ts
+++ b/src/parser/tokenRange.ts
@@ -12,7 +12,7 @@ export interface TokenRange {
 // used as a key in TokenRangeMap.
 // tag is needed as some TNodes can have the same range,
 // eg. an IdentifierExpression without the inclusive modifier '@'
-// have the same TokenRange as its Identifier child.
+// has the same TokenRange as its child, Identifier.
 export function tokenRangeHashFrom(
     tag: string,
     tokenStartIndex: number,

--- a/src/parser/tokenRange.ts
+++ b/src/parser/tokenRange.ts
@@ -11,8 +11,8 @@ export interface TokenRange {
 
 // used as a key in TokenRangeMap.
 // tag is needed as some TNodes can have the same range,
-// eg. IdentifierExpression without the inclusive modifier '@' has the same
-// TokenRange as its Identifier child.
+// eg. an IdentifierExpression without the inclusive modifier '@'
+// have the same TokenRange as its Identifier child.
 export function tokenRangeHashFrom(
     tag: string,
     tokenStartIndex: number,

--- a/src/test/lexer/simple.ts
+++ b/src/test/lexer/simple.ts
@@ -14,7 +14,7 @@ function expectLexSuccess(document: string): Lexer.TouchedLexer {
     return lexer;
 }
 
-function expectTokens(document: string, expected: [TokenKind, string][]): Lexer.TouchedLexer {
+function expectTokens(document: string, expected: ReadonlyArray<[TokenKind, string]>): Lexer.TouchedLexer {
     const touchedLexer = expectLexSuccess(document);
     const actual = touchedLexer.tokens.map(token => [token.kind, token.data]);
     const details = {
@@ -32,7 +32,7 @@ describe(`Lexer.Simple.TokenKinds`, () => {
         const document = `
 0x1
 0X1`;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.HexLiteral, `0x1`],
             [TokenKind.HexLiteral, `0X1`],
         ];
@@ -72,7 +72,7 @@ type
 #shared
 #table
 #time`;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.KeywordAnd, `and`],
             [TokenKind.KeywordAs, `as`],
             [TokenKind.KeywordEach, `each`],
@@ -111,7 +111,7 @@ type
 
     it(`NullLiteral`, () => {
         const document = `null`;
-        const expected: [TokenKind, string][] = [[TokenKind.NullLiteral, `null`]];
+        const expected: ReadonlyArray<[TokenKind, string]> = [[TokenKind.NullLiteral, `null`]];
         expectTokens(document, expected);
     });
 
@@ -129,7 +129,7 @@ type
 0.1e1
 0.1e-1
 0.1e+1`;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.NumericLiteral, `1`],
             [TokenKind.NumericLiteral, `1e1`],
             [TokenKind.NumericLiteral, `1e-1`],
@@ -172,7 +172,7 @@ type
 =>
 // TODO look into adding ..
 ...`;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.Comma, `,`],
             [TokenKind.Semicolon, `;`],
             [TokenKind.Equal, `=`],
@@ -205,7 +205,7 @@ type
 ""
 """"
 `;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.StringLiteral, `""`],
             [TokenKind.StringLiteral, `""""`],
         ];
@@ -216,7 +216,7 @@ type
 describe(`Lexer.Simple.Whitespace`, () => {
     it(`spaces`, () => {
         const document = ` a a `;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.Identifier, `a`],
             [TokenKind.Identifier, `a`],
         ];
@@ -225,7 +225,7 @@ describe(`Lexer.Simple.Whitespace`, () => {
 
     it(`tabs`, () => {
         const document = `\ta\ta\t`;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.Identifier, `a`],
             [TokenKind.Identifier, `a`],
         ];
@@ -234,7 +234,7 @@ describe(`Lexer.Simple.Whitespace`, () => {
 
     it(`trailing \\n`, () => {
         const document = `a\n`;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.Identifier, `a`],
         ];
         expectTokens(document, expected);
@@ -242,7 +242,7 @@ describe(`Lexer.Simple.Whitespace`, () => {
 
     it(`trailing \\r\\n`, () => {
         const document = `a\r\n`;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.Identifier, `a`],
         ];
         expectTokens(document, expected);
@@ -250,7 +250,7 @@ describe(`Lexer.Simple.Whitespace`, () => {
 
     it(`trailing space`, () => {
         const document = `a `;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.Identifier, `a`],
         ];
         expectTokens(document, expected);
@@ -258,7 +258,7 @@ describe(`Lexer.Simple.Whitespace`, () => {
 
     it(`leading \\n`, () => {
         const document = `\na`;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.Identifier, `a`],
         ];
         expectTokens(document, expected);
@@ -266,7 +266,7 @@ describe(`Lexer.Simple.Whitespace`, () => {
 
     it(`leading \\r\\n`, () => {
         const document = `\r\na`;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.Identifier, `a`],
         ];
         expectTokens(document, expected);
@@ -274,7 +274,7 @@ describe(`Lexer.Simple.Whitespace`, () => {
 
     it(`leading space`, () => {
         const document = ` a`;
-        const expected: [TokenKind, string][] = [
+        const expected: ReadonlyArray<[TokenKind, string]> = [
             [TokenKind.Identifier, `a`],
         ];
         expectTokens(document, expected);

--- a/src/test/parser/simple.ts
+++ b/src/test/parser/simple.ts
@@ -87,7 +87,7 @@ function nthNodeEarlyExit(_: Ast.TNode, state: NthNodeOfKindState) {
     return state.nthCounter === state.nthRequired;
 }
 
-function expectNodeKinds(document: string, expectedNodeKinds: Ast.NodeKind[]) {
+function expectNodeKinds(document: string, expectedNodeKinds: ReadonlyArray<Ast.NodeKind>) {
     const actualNodeKinds = collectNodeKindsFromAst(document);
     const details = {
         actualNodeKinds,

--- a/src/test/parser/simple.ts
+++ b/src/test/parser/simple.ts
@@ -23,7 +23,7 @@ function astFromDocument(document: string): Ast.TDocument {
     return parseResult.value.ast;
 }
 
-function collectNodeKindsFromAst(document: string): Ast.NodeKind[] {
+function collectNodeKindsFromAst(document: string): ReadonlyArray<Ast.NodeKind> {
     const ast = astFromDocument(document);
     const request: CollectAllNodeKindRequest = {
         ast,


### PR DESCRIPTION
* bumping up the version number
* renaming some functions
  * prefixing function names that return an Option with `maybe`
  * CommonError's ensureWrappedError -> ensureCommonError
* Lexer's drainWhitespace now also drains newlines
* inlining message parameter for error constructors
* changing array types (`[]`) to `ReadonlyArray<T>` where possible
* changing VisitNodeStrategy to be a string enum instead of numeric enum
* updating comments