### PR TITLE
Generalize Lexer errors

### DIFF
--- a/src/lexer/error.ts
+++ b/src/lexer/error.ts
@@ -44,6 +44,12 @@ export namespace LexerError {
         LineCodeUnitEnd_GreaterThan_LineLength = "LineCodeUnitEnd_GreaterThan_LineLength",
     }
 
+    export const enum ExpectedKind {
+        HexLiteral = "HexLiteral",
+        KeywordOrIdentifier = "KeywordOrIdentifier",
+        Numeric = "Numeric",
+    }
+
     export class LexerError extends Error {
         constructor(
             readonly innerError: TInnerLexerError,
@@ -90,6 +96,15 @@ export namespace LexerError {
     export class EndOfStreamError extends Error {
         constructor() {
             super(Localization.Error.lexerEndOfStream());
+        }
+    }
+
+    export class ExpectedError extends Error {
+        constructor(
+            readonly graphemePosition: StringHelpers.GraphemePosition,
+            readonly kind: ExpectedKind,
+        ) {
+            super(Localization.Error.lexerExpected(graphemePosition, kind))
         }
     }
 

--- a/src/lexer/error.ts
+++ b/src/lexer/error.ts
@@ -46,7 +46,7 @@ export namespace LexerError {
         Numeric = "Numeric",
     }
 
-    export const enum UnterminatedMultilineToken {
+    export const enum UnterminatedMultilineTokenKind {
         MultilineComment = "MultilineComment",
         QuotedIdentifier = "QuotedIdentifier",
         String = "String",
@@ -129,7 +129,7 @@ export namespace LexerError {
     export class UnterminatedMultilineTokenError extends Error {
         constructor(
             readonly graphemePosition: StringHelpers.GraphemePosition,
-            readonly kind: UnterminatedMultilineToken,
+            readonly kind: UnterminatedMultilineTokenKind,
         ) {
             super(Localization.Error.lexerUnterminatedMultilineToken(graphemePosition, kind));
         }

--- a/src/lexer/error.ts
+++ b/src/lexer/error.ts
@@ -20,9 +20,7 @@ export namespace LexerError {
         | ExpectedError
         | UnexpectedEofError
         | UnexpectedReadError
-        | UnterminatedMultilineCommentError
-        | UnterminatedQuotedIdentierError
-        | UnterminatedStringError
+        | UnterminatedMultilineTokenError
     )
 
     export const enum BadLineNumberKind {
@@ -48,7 +46,7 @@ export namespace LexerError {
         Numeric = "Numeric",
     }
 
-    export const enum UnterminatedKind {
+    export const enum UnterminatedMultilineToken {
         MultilineComment = "MultilineComment",
         QuotedIdentifier = "QuotedIdentifier",
         String = "String",
@@ -128,36 +126,12 @@ export namespace LexerError {
         }
     }
 
-    export class UnterminatedError extends Error {
+    export class UnterminatedMultilineTokenError extends Error {
         constructor(
             readonly graphemePosition: StringHelpers.GraphemePosition,
-            readonly kind: UnterminatedKind,
+            readonly kind: UnterminatedMultilineToken,
         ) {
-            super(Localization.Error.lexerUnterminated(graphemePosition, kind));
-        }
-    }
-
-    export class UnterminatedMultilineCommentError extends Error {
-        constructor(
-            readonly graphemePosition: StringHelpers.GraphemePosition,
-        ) {
-            super(Localization.Error.lexerUnterminatedMultilineComment(graphemePosition));
-        }
-    }
-
-    export class UnterminatedQuotedIdentierError extends Error {
-        constructor(
-            readonly graphemePosition: StringHelpers.GraphemePosition,
-        ) {
-            super(Localization.Error.lexerUnterminatedQuotedIdentifier(graphemePosition));
-        }
-    }
-
-    export class UnterminatedStringError extends Error {
-        constructor(
-            readonly graphemePosition: StringHelpers.GraphemePosition,
-        ) {
-            super(Localization.Error.lexerUnterminatedString(graphemePosition));
+            super(Localization.Error.lexerUnterminatedMultilineToken(graphemePosition, kind));
         }
     }
 
@@ -178,9 +152,7 @@ export namespace LexerError {
             || x instanceof ExpectedError
             || x instanceof UnexpectedEofError
             || x instanceof UnexpectedReadError
-            || x instanceof UnterminatedMultilineCommentError
-            || x instanceof UnterminatedQuotedIdentierError
-            || x instanceof UnterminatedStringError
+            || x instanceof UnterminatedMultilineTokenError
         );
     }
 }

--- a/src/lexer/error.ts
+++ b/src/lexer/error.ts
@@ -27,7 +27,12 @@ export namespace LexerError {
         | UnterminatedStringError
     )
 
-    // do not these sort variants,
+    export const enum BadLineNumberKind {
+        LessThanZero = "LessThanZero",
+        GreaterThanNumLines = "GreaterThanNumLines",
+    }
+
+        // do not these sort variants,
     // they are in order that logical checks are made, which in turn help create logical variants
     export const enum BadRangeKind {
         SameLine_LineCodeUnitStart_Higher = "SameLine_LineCodeUnitStart_Higher",
@@ -37,11 +42,6 @@ export namespace LexerError {
         LineNumberEnd_GreaterThan_NumLines = "LineNumberEnd_GreaterThan_NumLines",
         LineCodeUnitStart_GreaterThan_LineLength = "LineCodeUnitStart_GreaterThan_LineLength",
         LineCodeUnitEnd_GreaterThan_LineLength = "LineCodeUnitEnd_GreaterThan_LineLength",
-    }
-
-    export const enum BadLineNumberKind {
-        LessThanZero = "LessThanZero",
-        GreaterThanNumLines = "GreaterThanNumLines",
     }
 
     export class LexerError extends Error {

--- a/src/lexer/error.ts
+++ b/src/lexer/error.ts
@@ -12,7 +12,7 @@ export namespace LexerError {
     )
 
     export type TInnerLexerError = (
-        | BadLineNumber
+        | BadLineNumberError
         | BadRangeError
         | BadStateError
         | EndOfStreamError
@@ -60,7 +60,7 @@ export namespace LexerError {
         }
     }
 
-    export class BadLineNumber extends Error {
+    export class BadLineNumberError extends Error {
         constructor(
             readonly kind: BadLineNumberKind,
             readonly lineNumber: number,
@@ -144,7 +144,7 @@ export namespace LexerError {
 
     export function isTInnerLexerError(x: any): x is TInnerLexerError {
         return (
-            x instanceof BadLineNumber
+            x instanceof BadLineNumberError
             || x instanceof BadRangeError
             || x instanceof BadStateError
             || x instanceof EndOfStreamError

--- a/src/lexer/error.ts
+++ b/src/lexer/error.ts
@@ -17,9 +17,7 @@ export namespace LexerError {
         | BadStateError
         | EndOfStreamError
         | ErrorLineError
-        | ExpectedHexLiteralError
-        | ExpectedKeywordOrIdentifierError
-        | ExpectedNumericLiteralError
+        | ExpectedError
         | UnexpectedEofError
         | UnexpectedReadError
         | UnterminatedMultilineCommentError
@@ -108,30 +106,6 @@ export namespace LexerError {
         }
     }
 
-    export class ExpectedHexLiteralError extends Error {
-        constructor(
-            readonly graphemePosition: StringHelpers.GraphemePosition,
-        ) {
-            super(Localization.Error.lexerExpectedHexLiteral(graphemePosition));
-        }
-    }
-
-    export class ExpectedKeywordOrIdentifierError extends Error {
-        constructor(
-            readonly graphemePosition: StringHelpers.GraphemePosition,
-        ) {
-            super(Localization.Error.lexerExpectedKeywordOrIdentifier(graphemePosition));
-        }
-    }
-
-    export class ExpectedNumericLiteralError extends Error {
-        constructor(
-            readonly graphemePosition: StringHelpers.GraphemePosition,
-        ) {
-            super(Localization.Error.lexerExpectedNumericLiteral(graphemePosition));
-        }
-    }
-
     export class UnexpectedEofError extends Error {
         constructor(
             readonly graphemePosition: StringHelpers.GraphemePosition,
@@ -186,9 +160,7 @@ export namespace LexerError {
             || x instanceof BadStateError
             || x instanceof EndOfStreamError
             || x instanceof ErrorLineError
-            || x instanceof ExpectedHexLiteralError
-            || x instanceof ExpectedKeywordOrIdentifierError
-            || x instanceof ExpectedNumericLiteralError
+            || x instanceof ExpectedError
             || x instanceof UnexpectedEofError
             || x instanceof UnexpectedReadError
             || x instanceof UnterminatedMultilineCommentError

--- a/src/lexer/error.ts
+++ b/src/lexer/error.ts
@@ -48,6 +48,12 @@ export namespace LexerError {
         Numeric = "Numeric",
     }
 
+    export const enum UnterminatedKind {
+        MultilineComment = "MultilineComment",
+        QuotedIdentifier = "QuotedIdentifier",
+        String = "String",
+    }
+
     export class LexerError extends Error {
         constructor(
             readonly innerError: TInnerLexerError,
@@ -119,6 +125,15 @@ export namespace LexerError {
             readonly graphemePosition: StringHelpers.GraphemePosition,
         ) {
             super(Localization.Error.lexerUnexpectedRead(graphemePosition));
+        }
+    }
+
+    export class UnterminatedError extends Error {
+        constructor(
+            readonly graphemePosition: StringHelpers.GraphemePosition,
+            readonly kind: UnterminatedKind,
+        ) {
+            super(Localization.Error.lexerUnterminated(graphemePosition, kind));
         }
     }
 

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -134,7 +134,7 @@ export namespace Lexer {
     ): Result<State, LexerError.LexerError> {
         const lines: ReadonlyArray<TLine> = state.lines;
 
-        const maybeError: Option<LexerError.BadLineNumber> = maybeBadLineNumberError(
+        const maybeError: Option<LexerError.BadLineNumberError> = maybeBadLineNumberError(
             lineNumber,
             lines,
         );
@@ -208,7 +208,7 @@ export namespace Lexer {
     export function deleteLine(state: State, lineNumber: number): Result<State, LexerError.LexerError> {
         const lines: ReadonlyArray<TLine> = state.lines;
 
-        const maybeError: Option<LexerError.BadLineNumber> = maybeBadLineNumberError(
+        const maybeError: Option<LexerError.BadLineNumberError> = maybeBadLineNumberError(
             lineNumber,
             lines,
         );
@@ -1248,17 +1248,17 @@ export namespace Lexer {
     function maybeBadLineNumberError(
         lineNumber: number,
         lines: ReadonlyArray<TLine>,
-    ): Option<LexerError.BadLineNumber> {
+    ): Option<LexerError.BadLineNumberError> {
         const numLines: number = lines.length;
         if (lineNumber >= numLines) {
-            return new LexerError.BadLineNumber(
+            return new LexerError.BadLineNumberError(
                 LexerError.BadLineNumberKind.GreaterThanNumLines,
                 lineNumber,
                 numLines,
             );
         }
         else if (lineNumber < 0) {
-            return new LexerError.BadLineNumber(
+            return new LexerError.BadLineNumberError(
                 LexerError.BadLineNumberKind.LessThanZero,
                 lineNumber,
                 numLines,

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -941,7 +941,10 @@ export namespace Lexer {
     ): LineToken {
         const maybePositionEnd: Option<number> = maybeIndexOfRegexEnd(Pattern.RegExpHex, text, positionStart);
         if (maybePositionEnd === undefined) {
-            throw new LexerError.ExpectedHexLiteralError(graphemePositionFrom(text, lineNumber, positionStart));
+            throw new LexerError.ExpectedError(
+                graphemePositionFrom(text, lineNumber, positionStart),
+                LexerError.ExpectedKind.HexLiteral,
+            );
         }
         const positionEnd: number = maybePositionEnd;
 
@@ -955,7 +958,10 @@ export namespace Lexer {
     ): LineToken {
         const maybePositionEnd: Option<number> = maybeIndexOfRegexEnd(Pattern.RegExpNumeric, text, positionStart);
         if (maybePositionEnd === undefined) {
-            throw new LexerError.ExpectedNumericLiteralError(graphemePositionFrom(text, lineNumber, positionStart));
+            throw new LexerError.ExpectedError(
+                graphemePositionFrom(text, lineNumber, positionStart),
+                LexerError.ExpectedKind.Numeric,
+            );
         }
         const positionEnd: number = maybePositionEnd;
 
@@ -1068,7 +1074,10 @@ export namespace Lexer {
         else {
             const maybePositionEnd: Option<number> = maybeIndexOfRegexEnd(Pattern.RegExpIdentifier, text, positionStart);
             if (maybePositionEnd === undefined) {
-                throw unexpectedReadError(text, lineNumber, positionStart);
+                throw new LexerError.ExpectedError(
+                    graphemePositionFrom(text, lineNumber, positionStart),
+                    LexerError.ExpectedKind.KeywordOrIdentifier,
+                );
             }
             const positionEnd: number = maybePositionEnd;
             const data: string = text.substring(positionStart, positionEnd);

--- a/src/lexer/lexerSnapshot.ts
+++ b/src/lexer/lexerSnapshot.ts
@@ -140,7 +140,10 @@ function readMultilineComment(
     const maybeTokenEnd = collection.maybeTokenEnd;
     if (!maybeTokenEnd) {
         const positionStart = tokenStart.positionStart;
-        throw new LexerError.UnterminatedMultilineCommentError(positionStart)
+        throw new LexerError.UnterminatedMultilineTokenError(
+            positionStart,
+            LexerError.UnterminatedMultilineTokenKind.MultilineComment,
+        )
     }
     else if (maybeTokenEnd.kind !== LineTokenKind.MultilineCommentEnd) {
         const details = { foundTokenEnd: maybeTokenEnd };
@@ -173,7 +176,10 @@ function readQuotedIdentifier(
     const maybeTokenEnd = collection.maybeTokenEnd;
     if (!maybeTokenEnd) {
         const positionStart = tokenStart.positionStart;
-        throw new LexerError.UnterminatedQuotedIdentierError(positionStart)
+        throw new LexerError.UnterminatedMultilineTokenError(
+            positionStart,
+            LexerError.UnterminatedMultilineTokenKind.QuotedIdentifier,
+        );
     }
     else if (maybeTokenEnd.kind !== LineTokenKind.QuotedIdentifierEnd) {
         const details = { foundTokenEnd: maybeTokenEnd };
@@ -205,7 +211,10 @@ function readStringLiteral(
     const maybeTokenEnd = collection.maybeTokenEnd;
     if (!maybeTokenEnd) {
         const positionStart = tokenStart.positionStart;
-        throw new LexerError.UnterminatedStringError(positionStart)
+        throw new LexerError.UnterminatedMultilineTokenError(
+            positionStart,
+            LexerError.UnterminatedMultilineTokenKind.String,
+        );
     }
     else if (maybeTokenEnd.kind !== LineTokenKind.StringLiteralEnd) {
         const details = { foundTokenEnd: maybeTokenEnd };
@@ -334,6 +343,12 @@ interface ConcatenatedTokenRead {
     readonly flatIndexEnd: number,
 }
 
+interface FlatLineCollection {
+    readonly tokenStart: FlatLineToken,
+    readonly collectedTokens: ReadonlyArray<FlatLineToken>,
+    readonly maybeTokenEnd: Option<FlatLineToken>,
+}
+
 interface FlatLineToken {
     readonly kind: LineTokenKind,
     // range is [start, end)
@@ -341,10 +356,4 @@ interface FlatLineToken {
     readonly positionEnd: StringHelpers.ExtendedGraphemePosition,
     readonly data: string,
     readonly flatIndex: number,
-}
-
-interface FlatLineCollection {
-    readonly tokenStart: FlatLineToken,
-    readonly collectedTokens: ReadonlyArray<FlatLineToken>,
-    readonly maybeTokenEnd: Option<FlatLineToken>,
 }

--- a/src/localization/error.ts
+++ b/src/localization/error.ts
@@ -111,16 +111,16 @@ export namespace Localization.Error {
 
     export function lexerUnterminatedMultilineToken(
         graphemePosition: StringHelpers.GraphemePosition,
-        kind: LexerError.UnterminatedMultilineToken,
+        kind: LexerError.UnterminatedMultilineTokenKind,
     ): string {
         switch (kind) {
-            case LexerError.UnterminatedMultilineToken.MultilineComment:
+            case LexerError.UnterminatedMultilineTokenKind.MultilineComment:
                 return `Unterminated multiline comment starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
 
-            case LexerError.UnterminatedMultilineToken.QuotedIdentifier:
+            case LexerError.UnterminatedMultilineTokenKind.QuotedIdentifier:
                 return `Unterminated quoted identifier starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
 
-            case LexerError.UnterminatedMultilineToken.String:
+            case LexerError.UnterminatedMultilineTokenKind.String:
                 return `Unterminated multiline comment starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
                 
             default:

--- a/src/localization/error.ts
+++ b/src/localization/error.ts
@@ -88,10 +88,10 @@ export namespace Localization.Error {
 
             case LexerError.ExpectedKind.KeywordOrIdentifier:
                 return `Expected keyword or identifier on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
-                
+
             case LexerError.ExpectedKind.Numeric:
                 return `Expected numeric literal on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
-                
+
             default:
                 throw isNever(kind);
         }
@@ -109,16 +109,24 @@ export namespace Localization.Error {
         return `Unexpected read while attempting to lex on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
     }
 
-    export function lexerUnterminatedMultilineComment(graphemePosition: StringHelpers.GraphemePosition): string {
-        return `Unterminated multiline comment starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
-    }
+    export function lexerUnterminated(
+        graphemePosition: StringHelpers.GraphemePosition,
+        kind: LexerError.UnterminatedKind,
+    ): string {
+        switch (kind) {
+            case LexerError.UnterminatedKind.MultilineComment:
+                return `Unterminated multiline comment starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
 
-    export function lexerUnterminatedQuotedIdentifier(graphemePosition: StringHelpers.GraphemePosition): string {
-        return `Unterminated quoted identifier starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
-    }
+            case LexerError.UnterminatedKind.QuotedIdentifier:
+                return `Unterminated quoted identifier starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
+                
+            case LexerError.UnterminatedKind.String:
+                return `Unterminated multiline comment starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
+                
+            default:
+                throw isNever(kind);
+        }
 
-    export function lexerUnterminatedString(graphemePosition: StringHelpers.GraphemePosition): string {
-        return `Unterminated string starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
     }
 
     export function parserExpectedTokenKind(

--- a/src/localization/error.ts
+++ b/src/localization/error.ts
@@ -119,14 +119,13 @@ export namespace Localization.Error {
 
             case LexerError.UnterminatedKind.QuotedIdentifier:
                 return `Unterminated quoted identifier starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
-                
+
             case LexerError.UnterminatedKind.String:
                 return `Unterminated multiline comment starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
                 
             default:
                 throw isNever(kind);
         }
-
     }
 
     export function parserExpectedTokenKind(

--- a/src/localization/error.ts
+++ b/src/localization/error.ts
@@ -78,16 +78,23 @@ export namespace Localization.Error {
         return `The lexer reached end-of-stream.`;
     }
 
-    export function lexerExpectedHexLiteral(graphemePosition: StringHelpers.GraphemePosition): string {
-        return `Expected hex literal on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
-    }
+    export function lexerExpected(
+        graphemePosition: StringHelpers.GraphemePosition,
+        kind: LexerError.ExpectedKind,
+    ): string {
+        switch (kind) {
+            case LexerError.ExpectedKind.HexLiteral:
+                return `Expected hex literal on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
 
-    export function lexerExpectedKeywordOrIdentifier(graphemePosition: StringHelpers.GraphemePosition): string {
-        return `Expected keyword or identifier on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
-    }
-
-    export function lexerExpectedNumericLiteral(graphemePosition: StringHelpers.GraphemePosition): string {
-        return `Expected numeric literal on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
+            case LexerError.ExpectedKind.KeywordOrIdentifier:
+                return `Expected keyword or identifier on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
+                
+            case LexerError.ExpectedKind.Numeric:
+                return `Expected numeric literal on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
+                
+            default:
+                throw isNever(kind);
+        }
     }
 
     export function lexerLineError(errors: Lexer.TErrorLines): string {

--- a/src/localization/error.ts
+++ b/src/localization/error.ts
@@ -109,18 +109,18 @@ export namespace Localization.Error {
         return `Unexpected read while attempting to lex on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
     }
 
-    export function lexerUnterminated(
+    export function lexerUnterminatedMultilineToken(
         graphemePosition: StringHelpers.GraphemePosition,
-        kind: LexerError.UnterminatedKind,
+        kind: LexerError.UnterminatedMultilineToken,
     ): string {
         switch (kind) {
-            case LexerError.UnterminatedKind.MultilineComment:
+            case LexerError.UnterminatedMultilineToken.MultilineComment:
                 return `Unterminated multiline comment starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
 
-            case LexerError.UnterminatedKind.QuotedIdentifier:
+            case LexerError.UnterminatedMultilineToken.QuotedIdentifier:
                 return `Unterminated quoted identifier starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
 
-            case LexerError.UnterminatedKind.String:
+            case LexerError.UnterminatedMultilineToken.String:
                 return `Unterminated multiline comment starting on line ${graphemePosition.lineNumber}, column ${graphemePosition.columnNumber}.`;
                 
             default:

--- a/src/test/lexer/error.ts
+++ b/src/test/lexer/error.ts
@@ -14,11 +14,11 @@ function expectBadLineNumberKind(
     }
 
     const error: LexerError.LexerError = updateRangeResult.error;
-    if (!(error.innerError instanceof LexerError.BadLineNumber)) {
+    if (!(error.innerError instanceof LexerError.BadLineNumberError)) {
         throw new Error(`AssertFailed: error.innerError instanceof LexerError.BadLineNumber: ${JSON.stringify(error)}`);
     }
 
-    const innerError: LexerError.BadLineNumber = error.innerError;
+    const innerError: LexerError.BadLineNumberError = error.innerError;
     if (!(innerError.kind === expectedKind)) {
         throw new Error(`AssertFailed: innerError.kind === kind: ${JSON.stringify({ error, kind: expectedKind })}`);
     }
@@ -82,7 +82,7 @@ function expectUnterminatedMultilineTokenKind(
     const error: LexerError.TLexerError = snapshotResult.error;
     if (!(error.innerError instanceof LexerError.UnterminatedMultilineTokenError)) {
         throw new Error(`AssertFailed: error.innerError instanceof LexerError.UnterminatedMultilineTokenError: ${JSON.stringify(error)}`);
-    }
+}
 
     const innerError: LexerError.UnterminatedMultilineTokenError = error.innerError;
     if (!(innerError.kind === expectedKind)) {
@@ -92,7 +92,7 @@ function expectUnterminatedMultilineTokenKind(
 
 describe(`Lexer.Error`, () => {
 
-    describe(`${LexerError.BadLineNumber.name}`, () => {
+    describe(`${LexerError.BadLineNumberError.name}`, () => {
         it(`${LexerError.BadLineNumberKind.LessThanZero}`, () => {
             expectBadLineNumberKind(-1, LexerError.BadLineNumberKind.LessThanZero)
         });

--- a/src/test/lexer/error.ts
+++ b/src/test/lexer/error.ts
@@ -45,27 +45,6 @@ function expectSnapshotInnerError(text: string): LexerError.TInnerLexerError {
     }
 }
 
-function expectBadRangeKind(
-    range: Lexer.Range,
-    expectedKind: LexerError.BadRangeKind,
-) {
-    let state: Lexer.State = Lexer.stateFrom(`foo`);
-    const updateRangeResult: Result<Lexer.State, LexerError.LexerError> = Lexer.updateRange(state, range, `bar`);
-    if (!(updateRangeResult.kind === ResultKind.Err)) {
-        throw new Error(`AssertFailed: updateRangeResult.kind === ResultKind.Err: ${JSON.stringify(state)}`);
-    }
-
-    const error: LexerError.LexerError = updateRangeResult.error;
-    if (!(error.innerError instanceof LexerError.BadRangeError)) {
-        throw new Error(`AssertFailed: error.innerError instanceof LexerError.BadRangeError: ${JSON.stringify(error)}`);
-    }
-
-    const innerError: LexerError.BadRangeError = error.innerError;
-    if (!(innerError.kind === expectedKind)) {
-        throw new Error(`AssertFailed: innerError.kind === kind: ${JSON.stringify({ error, kind: expectedKind })}`);
-    }
-}
-
 function expectBadLineNumberKind(
     lineNumber: number,
     expectedKind: LexerError.BadLineNumberKind,
@@ -82,6 +61,27 @@ function expectBadLineNumberKind(
     }
 
     const innerError: LexerError.BadLineNumber = error.innerError;
+    if (!(innerError.kind === expectedKind)) {
+        throw new Error(`AssertFailed: innerError.kind === kind: ${JSON.stringify({ error, kind: expectedKind })}`);
+    }
+}
+
+function expectBadRangeKind(
+    range: Lexer.Range,
+    expectedKind: LexerError.BadRangeKind,
+) {
+    let state: Lexer.State = Lexer.stateFrom(`foo`);
+    const updateRangeResult: Result<Lexer.State, LexerError.LexerError> = Lexer.updateRange(state, range, `bar`);
+    if (!(updateRangeResult.kind === ResultKind.Err)) {
+        throw new Error(`AssertFailed: updateRangeResult.kind === ResultKind.Err: ${JSON.stringify(state)}`);
+    }
+
+    const error: LexerError.LexerError = updateRangeResult.error;
+    if (!(error.innerError instanceof LexerError.BadRangeError)) {
+        throw new Error(`AssertFailed: error.innerError instanceof LexerError.BadRangeError: ${JSON.stringify(error)}`);
+    }
+
+    const innerError: LexerError.BadRangeError = error.innerError;
     if (!(innerError.kind === expectedKind)) {
         throw new Error(`AssertFailed: innerError.kind === kind: ${JSON.stringify({ error, kind: expectedKind })}`);
     }
@@ -111,6 +111,16 @@ describe(`Lexer.Error`, () => {
     it(`UnterminatedStringError: "`, () => {
         const innerError = expectSnapshotInnerError(`"`);
         expect(innerError instanceof LexerError.UnterminatedStringError).to.equal(true, innerError.message);
+    });
+
+    describe(`${LexerError.BadLineNumber.name}`, () => {
+        it(`${LexerError.BadLineNumberKind.LessThanZero}`, () => {
+            expectBadLineNumberKind(-1, LexerError.BadLineNumberKind.LessThanZero)
+        });
+
+        it(`${LexerError.BadLineNumberKind.GreaterThanNumLines}`, () => {
+            expectBadLineNumberKind(1, LexerError.BadLineNumberKind.GreaterThanNumLines)
+        });
     });
 
     describe(`${LexerError.BadRangeError.name}`, () => {
@@ -210,16 +220,6 @@ describe(`Lexer.Error`, () => {
                 },
             };
             expectBadRangeKind(range, LexerError.BadRangeKind.LineCodeUnitEnd_GreaterThan_LineLength);
-        });
-    });
-
-    describe(`${LexerError.BadLineNumber.name}`, () => {
-        it(`${LexerError.BadLineNumberKind.LessThanZero}`, () => {
-            expectBadLineNumberKind(-1, LexerError.BadLineNumberKind.LessThanZero)
-        });
-
-        it(`${LexerError.BadLineNumberKind.GreaterThanNumLines}`, () => {
-            expectBadLineNumberKind(1, LexerError.BadLineNumberKind.GreaterThanNumLines)
         });
     });
 });

--- a/src/test/lexer/error.ts
+++ b/src/test/lexer/error.ts
@@ -111,20 +111,6 @@ function expectBadRangeKind(
 }
 
 describe(`Lexer.Error`, () => {
-    // it(`ExpectedHexLiteralError: 0x`, () => {
-    //     const stateErrorLinesPair = expectStateErrorLines(`0x`, 1);
-    //     const innerError = stateErrorLinesPair.errorLines[0].error.innerError;
-    //     expect(innerError instanceof LexerError.ExpectedHexLiteralError).to.equal(true, innerError.message);
-    // });
-
-    // it(`lexerLineError: 0x \\n 0x`, () => {
-    //     const stateErrorLinesPair = expectStateErrorLines(`0x \n 0x`, 2);
-    //     const firstInnerError = stateErrorLinesPair.errorLines[0].error.innerError;
-    //     expect(firstInnerError instanceof LexerError.ExpectedHexLiteralError).to.equal(true, firstInnerError.message);
-
-    //     const secondInnerError = stateErrorLinesPair.errorLines[1].error.innerError;
-    //     expect(secondInnerError instanceof LexerError.ExpectedHexLiteralError).to.equal(true, secondInnerError.message);
-    // });
 
     it(`UnterminatedMultilineCommentError: /*`, () => {
         const innerError = expectSnapshotInnerError(`/*`);
@@ -138,18 +124,26 @@ describe(`Lexer.Error`, () => {
 
     describe(`${LexerError.BadLineNumber.name}`, () => {
         it(`${LexerError.BadLineNumberKind.LessThanZero}`, () => {
-            expectExpectedKind("0x", LexerError.ExpectedKind.HexLiteral)
-        });
-    });
-
-    describe(`${LexerError.ExpectedError.name}`, () => {
-        it(`${LexerError.ExpectedKind.HexLiteral}`, () => {
             expectBadLineNumberKind(-1, LexerError.BadLineNumberKind.LessThanZero)
         });
 
         it(`${LexerError.BadLineNumberKind.GreaterThanNumLines}`, () => {
             expectBadLineNumberKind(1, LexerError.BadLineNumberKind.GreaterThanNumLines)
         });
+    });
+
+    describe(`${LexerError.ExpectedError.name}`, () => {
+        it(`${LexerError.ExpectedKind.HexLiteral}`, () => {
+            expectExpectedKind(`0x`, LexerError.ExpectedKind.HexLiteral)
+        });
+
+        it(`${LexerError.ExpectedKind.KeywordOrIdentifier}`, () => {
+            expectExpectedKind(`^`, LexerError.ExpectedKind.KeywordOrIdentifier)
+        });
+
+        // LexerError.ExpectedKind.Numeric only throws if the regex is incorrect,
+        // meaning there's no good way to test it.
+
     });
 
     describe(`${LexerError.BadRangeError.name}`, () => {

--- a/src/test/lexer/error.ts
+++ b/src/test/lexer/error.ts
@@ -3,36 +3,6 @@ import "mocha";
 import { Result, ResultKind } from "../../common";
 import { Lexer, LexerError, LexerSnapshot } from "../../lexer";
 
-// interface StateErrorLinesPair {
-//     readonly state: Lexer.State,
-//     readonly errorLines: Lexer.TErrorLines,
-// }
-
-// function expectStateErrorLines(text: string, numErrorLines: number): StateErrorLinesPair {
-//     const state: Lexer.State = Lexer.stateFrom(text);
-
-//     const maybeErrorLines = Lexer.maybeErrorLines(state);
-//     if (!(maybeErrorLines !== undefined)) {
-//         throw new Error(`AssertFailed: Lexer.maybeFirstErrorLine(state) !== undefined: ${JSON.stringify(state)}`);
-//     }
-//     else if (!(maybeErrorLines !== undefined)) {
-//         throw new Error(`AssertFailed: maybeErrorLines !== undefined: ${JSON.stringify(state)}`);
-//     }
-//     else if (!(numErrorLines === Object.keys(maybeErrorLines).length)) {
-//         const details = {
-//             "Object.keys(maybeErrorLines).length": Object.keys(maybeErrorLines).length,
-//             numErrorLines,
-//         };
-//         throw new Error(`AssertFailed: numErrorLines === Object.keys(maybeErrorLines).length): ${JSON.stringify(details)}`);
-//     }
-//     else {
-//         return {
-//             state,
-//             errorLines: maybeErrorLines,
-//         };
-//     }
-// }
-
 function expectSnapshotInnerError(text: string): LexerError.TInnerLexerError {
     const state: Lexer.State = Lexer.stateFrom(text);
     const snapshotResult: Result<LexerSnapshot, LexerError.TLexerError> = LexerSnapshot.tryFrom(state);

--- a/src/test/lexer/error.ts
+++ b/src/test/lexer/error.ts
@@ -42,7 +42,7 @@ function expectExpectedKind(
 ) {
     const state: Lexer.State = Lexer.stateFrom(text);
     expect(state.lines.length).to.equal(1);
-    
+
     const line: Lexer.TLine = state.lines[0];
     if (!(Lexer.isErrorLine(line))) {
         throw new Error(`AssertFailed: Lexer.isErrorLine(line): ${JSON.stringify(line)}`);


### PR DESCRIPTION
Several Lexer errors were essentially overlapping one another. Like errors have been combined into a new generalized error, and have added a `kind` attribute to know which case it is.

The following were combined into ExpectedError: ExpectedHexLiteralError, ExpectedKeywordOrIdentifierError, ExpectedNumericLiteralError.

The following were combined into UnterminatedMultilineTokenError: UnterminatedMultilineCommentError, UnterminatedQuotedIdentierError, UnterminatedStringError.