### PR TITLE
Parser Context

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -8,7 +8,6 @@ parseText(`if true then 1 else 2`);
 
 // @ts-ignore
 function parseText(text: string): Lexer.State {
-    console.log(JSON.stringify(lexAndParse(text), null, 4));
     const parseResult = lexAndParse(text);
     if (parseResult.kind === ResultKind.Ok) {
         console.log(JSON.stringify(parseResult.value, null, 4));

--- a/src/example.ts
+++ b/src/example.ts
@@ -36,8 +36,7 @@ function lexText(text: string) {
         //       considered an error at this stage.
         const errorLines: Lexer.TErrorLines = maybeErrorLines;
 
-        for (let lineNumber of Object.keys(errorLines)) {
-            const errorLine = errorLines[Number.parseInt(lineNumber)];
+        for (const errorLine of errorLines.values()) {
             console.log(errorLine);
         }
     }

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 import { Option, Result, ResultKind } from "./common";
 import { Lexer, LexerError, LexerSnapshot, TComment } from "./lexer";
-import { Ast, Parser, ParserError } from "./parser";
+import { Ast, ParseOk, Parser, ParserError } from "./parser";
 
 export type LexAndParseErr = (
     | LexerError.TLexerError
@@ -36,11 +36,12 @@ export function lexAndParse(text: string): Result<LexAndParseOk, LexAndParseErr>
     if (parseResult.kind === ResultKind.Err) {
         return parseResult;
     }
+    const parseOk: ParseOk = parseResult.value;
 
     return {
         kind: ResultKind.Ok,
         value: {
-            ast: parseResult.value,
+            ast: parseOk.document,
             comments: snapshot.comments,
         }
     }

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -155,14 +155,7 @@ export namespace Lexer {
             };
         }
 
-        // unsafe action:
-        //      casting ReadonlyArray<SplitLine> to SplitLine[]
-        // what I'm trying to avoid:
-        //      the cost of properly casting, aka deep cloning the object
-        // why it's safe:
-        //      the array is generated for this function block,
-        //      and it never leaves this function block.
-        const splitLines: SplitLine[] = splitOnLineTerminators(text) as SplitLine[];
+        const splitLines: SplitLine[] = splitOnLineTerminators(text);
 
         const rangeStart: RangePosition = range.start;
         const lineStart: TLine = state.lines[rangeStart.lineNumber];
@@ -337,7 +330,7 @@ export namespace Lexer {
         lineTerminator: string,
     }
 
-    function splitOnLineTerminators(text: string): ReadonlyArray<SplitLine> {
+    function splitOnLineTerminators(text: string): SplitLine[] {
         let lines: SplitLine[] = text
             .split("\r\n")
             .map((text: string) => {

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -17,7 +17,7 @@ import { LineToken, LineTokenKind } from "./token";
 
 export namespace Lexer {
 
-    export type TErrorLines = { [lineNumber: number]: TErrorLine; }
+    export type TErrorLines = Map<number, TErrorLine>;
 
     export type TLine = (
         | TouchedLine
@@ -294,7 +294,7 @@ export namespace Lexer {
     }
 
     export function maybeErrorLines(state: State): Option<TErrorLines> {
-        const errorLines: TErrorLines = {};
+        const errorLines: TErrorLines = new Map();
 
         const lines: ReadonlyArray<TLine> = state.lines;
         const numLines = lines.length;
@@ -302,7 +302,7 @@ export namespace Lexer {
         for (let index = 0; index < numLines; index++) {
             const line: TLine = lines[index];
             if (isErrorLine(line)) {
-                errorLines[index] = line;
+                errorLines.set(index, line);
                 errorsExist = true;
             }
         }

--- a/src/lexer/lexerSnapshot.ts
+++ b/src/lexer/lexerSnapshot.ts
@@ -76,14 +76,18 @@ export class LexerSnapshot {
                 }
 
                 default:
-                    // unsafe action:
-                    //      casting TokenLineKind to TokenKind
-                    // what I'm trying to avoid:
-                    //      the cost of properly casting, aka one switch statement per LineTokenKind
-                    // why it's safe:
-                    //      the above TokenLineKinds are taken care of, along with their Content and End variants,
-                    //      leaving the rest to be a 1-to-1 match with TokenKind.
-                    //      eg. set(LineTokenKind) & set(remaining variants) === set(LineKind)
+                    // UNSAFE MARKER
+                    //
+                    // Purpose of code block:
+                    //      Translate LineTokenKind to LineToken.
+                    //
+                    // Why are you trying to avoid a safer approach?
+                    //      A proper mapping would require a switch statement, one case per kind in LineNodeKind
+                    //
+                    // Why is it safe?
+                    //      Almost all of LineTokenKind and TokenKind have a 1-to-1 mapping.
+                    //      The edge cases (multiline tokens) have already been taken care of above.
+                    //      set(remaining variants of LineTokenKind) === set(LineKind)
                     const positionStart: StringHelpers.ExtendedGraphemePosition = flatToken.positionStart;
                     const positionEnd: StringHelpers.ExtendedGraphemePosition = flatToken.positionEnd;
                     tokens.push({
@@ -107,7 +111,7 @@ function readLineComment(
 ): LineComment {
     const positionStart: StringHelpers.ExtendedGraphemePosition = flatToken.positionStart;
     const positionEnd: StringHelpers.ExtendedGraphemePosition = flatToken.positionEnd;
-    
+
     return {
         kind: CommentKind.Line,
         data: flatToken.data,

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -62,17 +62,18 @@ export namespace ParserContext {
         oldNode: Node,
         astNode: Ast.TNode,
     ): Node {
-        const parentId: number = oldNode.parentId;
-        if (parentId < 0) {
-            throw new CommonError.InvariantError(`parentId < 0: ${parentId}.`);
-        }
-
         if (astNode.terminalNode) {
             state.terminalNodeIds.push(oldNode.nodeId);
         }
 
         oldNode.maybeAstNode = astNode;
-        return expectNode(state.nodesById, parentId);
+        const parentId: number = oldNode.parentId;
+        if (parentId !== -1) {
+            return expectNode(state.nodesById, parentId);
+        }
+        else {
+            return oldNode;
+        }
     }
 
     export function deleteContext(

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 import { Option, CommonError } from "../common";
 import { Ast } from "./ast";
 

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -11,7 +11,6 @@ export namespace ParserContext {
     export interface Node {
         readonly nodeId: number,
         readonly codeUnitStart: number,
-        codeUnitEnd: number,
         parentId: number,
         childrenIds: number[],
         maybeAstNode: Option<Ast.TNode>,
@@ -21,7 +20,6 @@ export namespace ParserContext {
         const root: Node = {
             nodeId: 0,
             codeUnitStart: 0,
-            codeUnitEnd: -1,
             parentId: -1,
             childrenIds: [],
             maybeAstNode: undefined,
@@ -41,7 +39,6 @@ export namespace ParserContext {
         const child: Node = {
             nodeId: state.nodeIdCounter,
             codeUnitStart,
-            codeUnitEnd: -1,
             parentId: parent.nodeId,
             childrenIds: [],
             maybeAstNode: undefined,

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -2,12 +2,53 @@ import { Option } from "../common";
 import { Ast } from "./ast";
 
 export namespace ParserContext {
-    export interface ContextNode {
-        readonly id: number,
+    export interface State {
+        readonly root: Node,
+        readonly nodesById: { [nodeId: number]: Node; },
+        nodeIdCounter: number,
+    }
+
+    export interface Node {
+        readonly nodeId: number,
         readonly codeUnitStart: number,
         maybeCodeUnitEnd: Option<number>,
-        maybeParent: Option<ContextNode>,
-        children: ContextNode[],
+        maybeParentId: Option<number>,
+        childrenIds: number[],
         maybeAstNode: Option<Ast.TNode>,
+    }
+
+    export function empty(): State {
+        const root: Node = {
+            nodeId: 0,
+            codeUnitStart: 0,
+            maybeCodeUnitEnd: undefined,
+            maybeParentId: undefined,
+            childrenIds: [],
+            maybeAstNode: undefined,
+        };
+
+        return {
+            root,
+            nodesById: {0: root},
+            nodeIdCounter: 0,
+        }
+    }
+
+    // assumes parent is in state
+    export function addNode(state: State, parent: Node, codeUnitStart: number): Node {
+        state.nodeIdCounter += 1;
+
+        const child: Node = {
+            nodeId: state.nodeIdCounter,
+            codeUnitStart,
+            maybeCodeUnitEnd: undefined,
+            maybeParentId: parent.nodeId,
+            childrenIds: [],
+            maybeAstNode: undefined,
+        }
+
+        state.nodesById[child.nodeId] = child;
+
+        return child;
     }
 }

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -52,6 +52,7 @@ export namespace ParserContext {
         }
 
         state.nodesById.set(child.nodeId, child);
+        parent.childNodeIds.push(child.nodeId);
 
         return child;
     }

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -11,8 +11,8 @@ export namespace ParserContext {
     export interface Node {
         readonly nodeId: number,
         readonly codeUnitStart: number,
-        maybeCodeUnitEnd: Option<number>,
-        maybeParentId: Option<number>,
+        codeUnitEnd: number,
+        parentId: number,
         childrenIds: number[],
         maybeAstNode: Option<Ast.TNode>,
     }
@@ -21,8 +21,8 @@ export namespace ParserContext {
         const root: Node = {
             nodeId: 0,
             codeUnitStart: 0,
-            maybeCodeUnitEnd: undefined,
-            maybeParentId: undefined,
+            codeUnitEnd: -1,
+            parentId: -1,
             childrenIds: [],
             maybeAstNode: undefined,
         };
@@ -35,14 +35,14 @@ export namespace ParserContext {
     }
 
     // assumes parent is in state
-    export function addNode(state: State, parent: Node, codeUnitStart: number): Node {
+    export function addChild(state: State, parent: Node, codeUnitStart: number): Node {
         state.nodeIdCounter += 1;
 
         const child: Node = {
             nodeId: state.nodeIdCounter,
             codeUnitStart,
-            maybeCodeUnitEnd: undefined,
-            maybeParentId: parent.nodeId,
+            codeUnitEnd: -1,
+            parentId: parent.nodeId,
             childrenIds: [],
             maybeAstNode: undefined,
         }

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 import { Option, CommonError } from "../common";
 import { Ast } from "./ast";
+import { Token } from "../lexer";
 
 export namespace ParserContext {
 
@@ -21,7 +22,7 @@ export namespace ParserContext {
     export interface Node {
         readonly nodeId: number,
         readonly nodeKind: Ast.NodeKind,
-        readonly tokenIndex: number,
+        readonly maybeTokenStart: Option<Token>,
         readonly maybeParentId: Option<number>,
         childNodeIds: number[],
         maybeAstNode: Option<Ast.TNode>,
@@ -50,7 +51,7 @@ export namespace ParserContext {
         state: State,
         maybeParent: Option<Node>,
         nodeKind: Ast.NodeKind,
-        tokenIndex: number,
+        tokenStart: Option<Token>,
     ): Node {
         state.nodeIdCounter += 1;
         const newNodeId = state.nodeIdCounter;
@@ -68,7 +69,7 @@ export namespace ParserContext {
         const child: Node = {
             nodeId: state.nodeIdCounter,
             nodeKind,
-            tokenIndex,
+            maybeTokenStart: tokenStart,
             maybeParentId,
             childNodeIds: [],
             maybeAstNode: undefined,

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -1,0 +1,13 @@
+import { Option } from "../common";
+import { Ast } from "./ast";
+
+export namespace ParserContext {
+    export interface ContextNode {
+        readonly id: number,
+        readonly codeUnitStart: number,
+        maybeCodeUnitEnd: Option<number>,
+        maybeParent: Option<ContextNode>,
+        children: ContextNode[],
+        maybeAstNode: Option<Ast.TNode>,
+    }
+}

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -91,12 +91,12 @@ export namespace ParserContext {
         nodesById.delete(nodeId);
 
         const maybeTerminalIndex = terminalNodeIds.indexOf(nodeId);
-        if (maybeTerminalIndex) {
+        if (maybeTerminalIndex !== -1) {
             const terminalIndex: number = maybeTerminalIndex;
             state.terminalNodeIds = [
                 ...terminalNodeIds.slice(0, terminalIndex),
                 ...terminalNodeIds.slice(terminalIndex + 1),
-            ]
+            ];
         }
 
         if (parentId === -1) {

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -4,7 +4,7 @@ import { Ast } from "./ast";
 export namespace ParserContext {
     export interface State {
         readonly root: Node,
-        readonly nodesById: { [nodeId: number]: Node; },
+        readonly nodesById: Node[],
         nodeIdCounter: number,
     }
 
@@ -29,7 +29,7 @@ export namespace ParserContext {
 
         return {
             root,
-            nodesById: {0: root},
+            nodesById: [root],
             nodeIdCounter: 0,
         }
     }
@@ -50,5 +50,24 @@ export namespace ParserContext {
         state.nodesById[child.nodeId] = child;
 
         return child;
+    }
+
+    export function deepCopy(state: State): State {
+        const nodesById: Node[] = state.nodesById.map(deepCopyNode);
+
+        return {
+            root: nodesById[0],
+            nodesById,
+            nodeIdCounter: state.nodeIdCounter,
+        }
+    }
+
+    function deepCopyNode(node: Node): Node {
+        return {
+            ...node,
+            maybeAstNode: node.maybeAstNode !== undefined
+                ? { ...node.maybeAstNode }
+                : undefined
+        }
     }
 }

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -20,6 +20,7 @@ export namespace ParserContext {
 
     export interface Node {
         readonly nodeId: number,
+        readonly nodeKind: Ast.NodeKind,
         readonly tokenIndex: number,
         readonly maybeParentId: Option<number>,
         childNodeIds: number[],
@@ -45,7 +46,12 @@ export namespace ParserContext {
         return maybeNode;
     }
 
-    export function addChild(state: State, maybeParent: Option<Node>, tokenIndex: number): Node {
+    export function addChild(
+        state: State,
+        maybeParent: Option<Node>,
+        nodeKind: Ast.NodeKind,
+        tokenIndex: number,
+    ): Node {
         state.nodeIdCounter += 1;
         const newNodeId = state.nodeIdCounter;
 
@@ -61,6 +67,7 @@ export namespace ParserContext {
 
         const child: Node = {
             nodeId: state.nodeIdCounter,
+            nodeKind,
             tokenIndex,
             maybeParentId,
             childNodeIds: [],

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -14,7 +14,7 @@ export namespace ParserContext {
     export interface Node {
         readonly nodeId: number,
         readonly codeUnitStart: number,
-        parentId: number,
+        readonly parentId: number,
         readonly childNodeIds: number[],
         maybeAstNode: Option<Ast.TNode>,
     }

--- a/src/parser/error.ts
+++ b/src/parser/error.ts
@@ -2,9 +2,10 @@
 // Licensed under the MIT license.
 import { CommonError } from "../common";
 import { Option } from "../common/option";
-import { TokenKind, Token } from "../lexer/token";
+import { Token, TokenKind } from "../lexer/token";
 import { Localization } from "../localization/error";
 import { Ast } from "./ast";
+import { ParserContext } from "./context";
 
 export namespace ParserError {
 
@@ -27,6 +28,7 @@ export namespace ParserError {
     export class ParserError extends Error {
         constructor(
             readonly innerError: TInnerParserError,
+            readonly context: ParserContext.State,
         ) {
             super(innerError.message);
         }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -97,8 +97,9 @@ export class Parser {
     }
 
     private readSection(): Ast.Section {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.Section);
+        const nodeKind: Ast.NodeKind.Section = Ast.NodeKind.Section;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const maybeLiteralAttributes = this.maybeReadLiteralAttributes();
         const sectionConstant = this.readTokenKindAsConstant(TokenKind.KeywordSection);
@@ -117,7 +118,7 @@ export class Parser {
         }
 
         const astNode: Ast.Section = {
-            kind: Ast.NodeKind.Section,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             maybeLiteralAttributes,
@@ -132,8 +133,9 @@ export class Parser {
 
     // sub-item of 12.2.2 Section Documents
     private readSectionMember(): Ast.SectionMember {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.SectionMember);
+        const nodeKind: Ast.NodeKind.SectionMember = Ast.NodeKind.SectionMember;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const maybeLiteralAttributes = this.maybeReadLiteralAttributes();
         const maybeSharedConstant = this.maybeReadTokenKindAsConstant(TokenKind.KeywordShared);
@@ -141,7 +143,7 @@ export class Parser {
         const semicolonConstant = this.readTokenKindAsConstant(TokenKind.Semicolon);
 
         const astNode: Ast.SectionMember = {
-            kind: Ast.NodeKind.SectionMember,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             maybeLiteralAttributes,
@@ -415,8 +417,9 @@ export class Parser {
 
     // 12.2.3.11 Literal expression
     private readLiteralExpression(): Ast.LiteralExpression {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.LiteralExpression);
+        const nodeKind: Ast.NodeKind.LiteralExpression = Ast.NodeKind.LiteralExpression;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const expectedTokenKinds = [
             TokenKind.HexLiteral,
@@ -438,7 +441,7 @@ export class Parser {
 
         const literal = this.readToken();
         const astNode: Ast.LiteralExpression = {
-            kind: Ast.NodeKind.LiteralExpression,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: true,
             literal: literal,
@@ -450,14 +453,15 @@ export class Parser {
 
     // 12.2.3.12 Identifier expression
     private readIdentifierExpression(): Ast.IdentifierExpression {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.IdentifierExpression);
+        const nodeKind: Ast.NodeKind.IdentifierExpression = Ast.NodeKind.IdentifierExpression;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const maybeInclusiveConstant = this.maybeReadTokenKindAsConstant(TokenKind.AtSign);
         const identifier = this.readIdentifier();
 
         const astNode: Ast.IdentifierExpression = {
-            kind: Ast.NodeKind.IdentifierExpression,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             maybeInclusiveConstant,
@@ -479,13 +483,14 @@ export class Parser {
 
     // 12.2.3.15 Not-implemented expression
     private readNotImplementedExpression(): Ast.NotImplementedExpression {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.NotImplementedExpression);
+        const nodeKind: Ast.NodeKind.NotImplementedExpression = Ast.NodeKind.NotImplementedExpression;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const ellipsisConstant = this.readTokenKindAsConstant(TokenKind.Ellipsis);
 
         const astNode: Ast.NotImplementedExpression = {
-            kind: Ast.NodeKind.NotImplementedExpression,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             ellipsisConstant,
@@ -535,11 +540,12 @@ export class Parser {
 
     // 12.2.3.19 Item access expression
     private readItemAccessExpression(): Ast.ItemAccessExpression {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.ItemAccessExpression);
+        const nodeKind: Ast.NodeKind.ItemAccessExpression = Ast.NodeKind.ItemAccessExpression;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const maybeReturn = this.readWrapped<Ast.NodeKind.ItemAccessExpression, Ast.TExpression>(
-            Ast.NodeKind.ItemAccessExpression,
+            nodeKind,
             () => this.readTokenKindAsConstant(TokenKind.LeftBrace),
             () => this.readExpression(),
             () => this.readTokenKindAsConstant(TokenKind.RightBrace),
@@ -575,11 +581,12 @@ export class Parser {
 
     // sub-item of 12.2.3.20 Field access expressions
     private readFieldProjection(): Ast.FieldProjection {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.FieldProjection);
+        const nodeKind: Ast.NodeKind.FieldProjection = Ast.NodeKind.FieldProjection;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const maybeReturn = this.readWrapped<Ast.NodeKind.FieldProjection, ReadonlyArray<Ast.ICsv<Ast.FieldSelector>>>(
-            Ast.NodeKind.FieldProjection,
+            nodeKind,
             () => this.readTokenKindAsConstant(TokenKind.LeftBracket),
             () => this.readCsv(
                 () => this.readFieldSelector(false),
@@ -613,11 +620,12 @@ export class Parser {
 
     // sub-item of 12.2.3.20 Field access expressions
     private readFieldSelector(allowOptional: boolean): Ast.FieldSelector {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.FieldSelector);
+        const nodeKind: Ast.NodeKind.FieldSelector = Ast.NodeKind.FieldSelector;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const maybeReturn = this.readWrapped<Ast.NodeKind.FieldSelector, Ast.GeneralizedIdentifier>(
-            Ast.NodeKind.FieldSelector,
+            nodeKind,
             () => this.readTokenKindAsConstant(TokenKind.LeftBracket),
             () => this.readGeneralizedIdentifier(),
             () => this.readTokenKindAsConstant(TokenKind.RightBracket),
@@ -648,8 +656,9 @@ export class Parser {
 
     // 12.2.3.21 Function expression
     private readFunctionExpression(): Ast.FunctionExpression {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.FunctionExpression);
+        const nodeKind: Ast.NodeKind.FunctionExpression = Ast.NodeKind.FunctionExpression;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const parameters = this.readParameterList(() => this.maybeReadAsNullablePrimitiveType());
         const maybeFunctionReturnType = this.maybeReadAsNullablePrimitiveType();
@@ -657,7 +666,7 @@ export class Parser {
         const expression = this.readExpression();
 
         const astNode: Ast.FunctionExpression = {
-            kind: Ast.NodeKind.FunctionExpression,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             parameters,
@@ -680,8 +689,9 @@ export class Parser {
 
     // 12.2.3.23 Let expression
     private readLetExpression(): Ast.LetExpression {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.LetExpression);
+        const nodeKind: Ast.NodeKind.LetExpression = Ast.NodeKind.LetExpression;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const letConstant = this.readTokenKindAsConstant(TokenKind.KeywordLet);
         const identifierExpressionPairedExpressions = this.readIdentifierPairedExpressions(true);
@@ -824,13 +834,14 @@ export class Parser {
 
     // sub-item of 12.2.3.25 Type expression
     private readRecordType(): Ast.RecordType {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.RecordType)
+        const nodeKind: Ast.NodeKind.RecordType = Ast.NodeKind.RecordType;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind)
 
         const fields = this.readFieldSpecificationList(true);
 
         const astNode: Ast.RecordType = {
-            kind: Ast.NodeKind.RecordType,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             fields,
@@ -841,8 +852,9 @@ export class Parser {
 
     // sub-item of 12.2.3.25 Type expression
     private readTableType(): Ast.TableType {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.TableType)
+        const nodeKind: Ast.NodeKind.TableType = Ast.NodeKind.TableType
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind)
 
         const tableConstant = this.readIdentifierConstantAsConstant(Ast.IdentifierConstant.Table);
         const currentTokenKind = this.currentTokenKind;
@@ -861,7 +873,7 @@ export class Parser {
         }
 
         const astNode: Ast.TableType = {
-            kind: Ast.NodeKind.TableType,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             tableConstant,
@@ -873,8 +885,9 @@ export class Parser {
 
     // sub-item of 12.2.3.25 Type expression
     private readFieldSpecificationList(allowOpenMarker: boolean): Ast.FieldSpecificationList {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.FieldSpecificationList);
+        const nodeKind: Ast.NodeKind.FieldSpecificationList = Ast.NodeKind.FieldSpecificationList;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const leftBracketConstant = this.readTokenKindAsConstant(TokenKind.LeftBracket);
         const fields: Ast.ICsv<Ast.FieldSpecification>[] = [];
@@ -938,7 +951,7 @@ export class Parser {
         const rightBracketConstant = this.readTokenKindAsConstant(TokenKind.RightBracket);
 
         const astNode: Ast.FieldSpecificationList = {
-            kind: Ast.NodeKind.FieldSpecificationList,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             openWrapperConstant: leftBracketConstant,
@@ -952,8 +965,9 @@ export class Parser {
 
     // sub-item of 12.2.3.25 Type expression
     private maybeReadFieldTypeSpecification(): Option<Ast.FieldTypeSpecification> {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.FieldTypeSpecification);
+        const nodeKind: Ast.NodeKind.FieldTypeSpecification = Ast.NodeKind.FieldTypeSpecification;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const maybeEqualConstant: Option<Ast.Constant> = this.maybeReadTokenKindAsConstant(TokenKind.Equal);
         if (maybeEqualConstant) {
@@ -978,20 +992,24 @@ export class Parser {
 
     // sub-item of 12.2.3.25 Type expression
     private readFunctionType(): Ast.FunctionType {
-        this.startTokenRange(Ast.NodeKind.FunctionType)
+        const nodeKind: Ast.NodeKind.FunctionType = Ast.NodeKind.FunctionType;
+        this.startContext(nodeKind)
+        this.startTokenRange(nodeKind);
 
         const functionConstant = this.readIdentifierConstantAsConstant(Ast.IdentifierConstant.Function);
         const parameters = this.readParameterList(() => this.readAsType());
         const functionReturnType = this.readAsType();
 
-        return {
-            kind: Ast.NodeKind.FunctionType,
+        const astNode: Ast.FunctionType = {
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             functionConstant,
             parameters,
             functionReturnType,
         };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // sub-item of 12.2.3.25 Type expression
@@ -1014,8 +1032,9 @@ export class Parser {
 
     // 12.2.3.27 Error handling expression
     private readErrorHandlingExpression(): Ast.ErrorHandlingExpression {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.ErrorHandlingExpression);
+        const nodeKind: Ast.NodeKind.ErrorHandlingExpression = Ast.NodeKind.ErrorHandlingExpression;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const tryConstant = this.readTokenKindAsConstant(TokenKind.KeywordTry);
         const protectedExpression = this.readExpression();
@@ -1029,7 +1048,7 @@ export class Parser {
         );
 
         const astNode: Ast.ErrorHandlingExpression = {
-            kind: Ast.NodeKind.ErrorHandlingExpression,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             tryConstant,
@@ -1107,7 +1126,9 @@ export class Parser {
     }
 
     private readParameterList<T>(typeReader: () => T): Ast.ParameterList<T> {
-        this.startTokenRange(Ast.NodeKind.ParameterList);
+        const nodeKind: Ast.NodeKind.ParameterList = Ast.NodeKind.ParameterList;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const leftParenthesisConstant = this.readTokenKindAsConstant(TokenKind.LeftParenthesis);
         let continueReadingValues = !this.isOnTokenKind(TokenKind.RightParenthesis);
@@ -1153,14 +1174,33 @@ export class Parser {
 
         const rightParenthesisConstant = this.readTokenKindAsConstant(TokenKind.RightParenthesis);
 
-        return {
-            kind: Ast.NodeKind.ParameterList,
+        const astNode: Ast.ParameterList<T> = {
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             openWrapperConstant: leftParenthesisConstant,
             content: parameters,
             closeWrapperConstant: rightParenthesisConstant,
         };
+
+        // UNSAFE MARKER
+        //
+        // Purpose of code block:
+        //      End the context started within the same function.
+        //
+        // Why are you trying to avoid a safer approach?
+        //      endContext takes an Ast.TNode, but due to generics the parser
+        //      can't prove for all types A that Ast.ParameterList<A>
+        //      results in an Ast.TNode.
+        //
+        //      The alternative approach is let the callers of readParameterList
+        //      take the return and end the context themselves, which is messy.
+        //
+        // Why is it safe?
+        //      All Ast.ParameterList used by the parser are of Ast.TParameterList,
+        //      a sub type of Ast.TNode.
+        this.endContext(astNode as unknown as Ast.TParameterList);
+        return astNode;
     }
 
     private maybeReadAsNullablePrimitiveType(): Option<Ast.AsNullablePrimitiveType> {
@@ -1239,13 +1279,14 @@ export class Parser {
     }
 
     private readIdentifier(): Ast.Identifier {
-        this.startContext();
+        const nodeKind: Ast.NodeKind.Identifier = Ast.NodeKind.Identifier;
+        this.startContext(nodeKind);
 
         const tokenRange = this.singleTokenRange(TokenKind.Identifier);
         const literal = this.readTokenKind(TokenKind.Identifier);
 
         const astNode: Ast.Identifier = {
-            kind: Ast.NodeKind.Identifier,
+            kind: nodeKind,
             tokenRange,
             terminalNode: true,
             literal,
@@ -1255,8 +1296,9 @@ export class Parser {
     }
 
     private readGeneralizedIdentifier(): Ast.GeneralizedIdentifier {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.GeneralizedIdentifier);
+        const nodeKind: Ast.NodeKind.GeneralizedIdentifier = Ast.NodeKind.GeneralizedIdentifier;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         let literal;
 
@@ -1302,7 +1344,7 @@ export class Parser {
         }
 
         const astNode: Ast.GeneralizedIdentifier = {
-            kind: Ast.NodeKind.GeneralizedIdentifier,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: true,
             literal,
@@ -1322,8 +1364,9 @@ export class Parser {
     }
 
     private tryReadPrimitiveType(): Result<Ast.PrimitiveType, ParserError.InvalidPrimitiveTypeError | CommonError.InvariantError> {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.PrimitiveType);
+        const nodeKind: Ast.NodeKind.PrimitiveType = Ast.NodeKind.PrimitiveType;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const state: ParserState = this.backupParserState();
         const expectedTokenKinds = [
@@ -1386,7 +1429,7 @@ export class Parser {
         }
 
         const astNode: Ast.PrimitiveType = {
-            kind: Ast.NodeKind.PrimitiveType,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             primitiveType,
@@ -1490,7 +1533,8 @@ export class Parser {
 
     private maybeReadTokenKindAsConstant(tokenKind: TokenKind): Option<Ast.Constant> {
         if (this.isOnTokenKind(tokenKind)) {
-            this.startContext();
+            const nodeKind: Ast.NodeKind.Constant = Ast.NodeKind.Constant;
+            this.startContext(nodeKind);
             const tokenRange = this.singleTokenRange(tokenKind);
 
             const maybeConstantKind = Ast.constantKindFromTokenKind(tokenKind);
@@ -1500,7 +1544,7 @@ export class Parser {
 
             this.readToken();
             const astNode: Ast.Constant = {
-                kind: Ast.NodeKind.Constant,
+                kind: nodeKind,
                 tokenRange,
                 terminalNode: true,
                 literal: maybeConstantKind,
@@ -1524,7 +1568,8 @@ export class Parser {
 
     private maybeReadIdentifierConstantAsConstant(identifierConstant: Ast.IdentifierConstant): Option<Ast.Constant> {
         if (this.isOnIdentifierConstant(identifierConstant)) {
-            this.startContext();
+            const nodeKind: Ast.NodeKind.Constant = Ast.NodeKind.Constant;
+            this.startContext(nodeKind);
             const tokenRange = this.singleTokenRange(identifierConstant);
 
             const maybeConstantKind = Ast.constantKindFromIdentifieConstant(identifierConstant);
@@ -1534,7 +1579,7 @@ export class Parser {
 
             this.readToken();
             const astNode: Ast.Constant = {
-                kind: Ast.NodeKind.Constant,
+                kind: nodeKind,
                 tokenRange,
                 terminalNode: true,
                 literal: maybeConstantKind,
@@ -1548,13 +1593,14 @@ export class Parser {
     }
 
     private readUnaryOperatorAsConstant(operator: Ast.TUnaryExpressionHelperOperator): Ast.Constant {
-        this.startContext();
+        const nodeKind: Ast.NodeKind.Constant = Ast.NodeKind.Constant;
+        this.startContext(nodeKind);
         const tokenRange = this.singleTokenRange(operator);
 
         this.readToken();
 
         const astNode: Ast.Constant = {
-            kind: Ast.NodeKind.Constant,
+            kind: nodeKind,
             tokenRange,
             terminalNode: true,
             literal: operator,
@@ -1640,7 +1686,7 @@ export class Parser {
         keywordTokenKind: KeywordTokenKindVariant & TokenKind,
         rightExpressionReader: () => R,
     ): L | Ast.IBinOpKeyword<NodeKindVariant, L, R> {
-        this.startContext();
+        this.startContext(nodeKind);
         this.startTokenRange(nodeKind);
 
         const left = leftExpressionReader()
@@ -1730,7 +1776,7 @@ export class Parser {
         constantReader: () => Ast.Constant,
         pairedReader: () => Paired,
     ): Ast.IPairedConstant<NodeKindVariant, Paired> {
-        this.startContext();
+        this.startContext(nodeKind);
         this.startTokenRange(nodeKind);
 
         const constant: Ast.Constant = constantReader();
@@ -1789,7 +1835,7 @@ export class Parser {
         contentReader: () => Content,
         closeConstantReader: () => Ast.Constant,
     ): Ast.IWrapped<NodeKindVariant, Content> {
-        this.startContext();
+        this.startContext(nodeKind);
         this.startTokenRange(nodeKind);
 
         const openWrapperConstant: Ast.Constant = openConstantReader();
@@ -1830,7 +1876,7 @@ export class Parser {
         keyReader: () => Key,
         valueReader: () => Value,
     ): Ast.IKeyValuePair<NodeKindVariant, Key, Value> {
-        this.startContext();
+        this.startContext(nodeKind);
         this.startTokenRange(nodeKind);
 
         const key: Key = keyReader();
@@ -1872,15 +1918,16 @@ export class Parser {
         const values: Ast.ICsv<T>[] = [];
 
         while (continueReadingValues) {
-            this.startContext();
-            this.startTokenRange(Ast.NodeKind.Csv);
+            const nodeKind: Ast.NodeKind.Csv = Ast.NodeKind.Csv;
+            this.startContext(nodeKind);
+            this.startTokenRange(nodeKind);
 
             const node: T = valueReader();
             const maybeCommaConstant: Option<Ast.Constant> = this.maybeReadTokenKindAsConstant(TokenKind.Comma);
             continueReadingValues = maybeCommaConstant !== undefined;
 
             const value: Ast.ICsv<T> = {
-                kind: Ast.NodeKind.Csv,
+                kind: nodeKind,
                 tokenRange: this.popTokenRange(),
                 terminalNode: false,
                 node,
@@ -2086,10 +2133,11 @@ export class Parser {
         }
     }
 
-    private startContext() {
+    private startContext(nodeKind: Ast.NodeKind) {
         this.maybeContextNode = ParserContext.addChild(
             this.contextState,
             this.maybeContextNode,
+            nodeKind,
             this.tokenIndex,
         );
     }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -275,17 +275,20 @@ export class Parser {
         let maybeOperator = Ast.unaryOperatorFrom(this.currentTokenKind);
 
         if (maybeOperator) {
-            this.startContext();
-            this.startTokenRange(Ast.NodeKind.UnaryExpression);
+            const nodeKind: Ast.NodeKind.UnaryExpression = Ast.NodeKind.UnaryExpression;
+            this.startContext(nodeKind);
+            this.startTokenRange(nodeKind);
+
             const expressions: Ast.UnaryExpressionHelper<Ast.UnaryOperator, Ast.TUnaryExpression>[] = [];
 
             while (maybeOperator) {
-                this.startContext();
-                this.startTokenRange(Ast.NodeKind.UnaryExpressionHelper);
+                const nodeKind: Ast.NodeKind.UnaryExpressionHelper = Ast.NodeKind.UnaryExpressionHelper;
+                this.startContext(nodeKind);
+                this.startTokenRange(nodeKind);
 
                 const operatorConstant = this.readUnaryOperatorAsConstant(maybeOperator);
                 const expression: Ast.UnaryExpressionHelper<Ast.UnaryOperator, Ast.TUnaryExpression> = {
-                    kind: Ast.NodeKind.UnaryExpressionHelper,
+                    kind: nodeKind,
                     tokenRange: this.popTokenRange(),
                     terminalNode: false,
                     inBinaryExpression: false,
@@ -300,7 +303,7 @@ export class Parser {
             };
 
             const astNode: Ast.UnaryExpression = {
-                kind: Ast.NodeKind.UnaryExpression,
+                kind: nodeKind,
                 tokenRange: this.popTokenRange(),
                 terminalNode: false,
                 expressions,
@@ -713,8 +716,9 @@ export class Parser {
 
     // 12.2.3.24 If expression
     private readIfExpression(): Ast.IfExpression {
-        this.startContext();
-        this.startTokenRange(Ast.NodeKind.IfExpression);
+        const nodeKind: Ast.NodeKind.IfExpression = Ast.NodeKind.IfExpression;
+        this.startContext(nodeKind);
+        this.startTokenRange(nodeKind);
 
         const ifConstant = this.readTokenKindAsConstant(TokenKind.KeywordIf);
         const condition = this.readExpression();
@@ -726,7 +730,7 @@ export class Parser {
         const falseExpression = this.readExpression();
 
         const astNode: Ast.IfExpression = {
-            kind: Ast.NodeKind.IfExpression,
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             ifConstant,
@@ -911,10 +915,13 @@ export class Parser {
             }
 
             else if (this.isOnTokenKind(TokenKind.Identifier)) {
-                this.startContext();
-                this.startTokenRange(Ast.NodeKind.Csv);
-                this.startContext();
-                this.startTokenRange(Ast.NodeKind.FieldSpecification);
+                const csvNodeKind: Ast.NodeKind.Csv = Ast.NodeKind.Csv;;
+                this.startContext(csvNodeKind);
+                this.startTokenRange(csvNodeKind);
+
+                const fieldSpecificationNodeKind: Ast.NodeKind.FieldSpecification = Ast.NodeKind.FieldSpecification;;
+                this.startContext(fieldSpecificationNodeKind);
+                this.startTokenRange(fieldSpecificationNodeKind);
 
                 const maybeOptionalConstant = this.maybeReadIdentifierConstantAsConstant(Ast.IdentifierConstant.Optional);
                 const name = this.readGeneralizedIdentifier();
@@ -923,7 +930,7 @@ export class Parser {
                 continueReadingValues = maybeCommaConstant !== undefined;
 
                 const field: Ast.FieldSpecification = {
-                    kind: Ast.NodeKind.FieldSpecification,
+                    kind: fieldSpecificationNodeKind,
                     tokenRange: this.popTokenRange(),
                     terminalNode: false,
                     maybeOptionalConstant,
@@ -933,7 +940,7 @@ export class Parser {
                 this.endContext(field);
 
                 const csv: Ast.ICsv<Ast.FieldSpecification> = {
-                    kind: Ast.NodeKind.Csv,
+                    kind: csvNodeKind,
                     tokenRange: this.popTokenRange(),
                     terminalNode: false,
                     node: field,
@@ -1231,7 +1238,9 @@ export class Parser {
 
     private readRecursivePrimaryExpression(head: Ast.TPrimaryExpression): Ast.RecursivePrimaryExpression {
         const tokenRangeStart = head.tokenRange.startTokenIndex;
-        this.startTokenRangeAt(Ast.NodeKind.RecursivePrimaryExpression, tokenRangeStart);
+        const nodeKind: Ast.NodeKind.RecursivePrimaryExpression =Ast.NodeKind.RecursivePrimaryExpression;
+        this.startContext(nodeKind);
+        this.startTokenRangeAt(nodeKind, tokenRangeStart);
 
         const recursiveExpressions = [];
         let continueReadingValues = true;
@@ -1269,13 +1278,15 @@ export class Parser {
             }
         }
 
-        return {
-            kind: Ast.NodeKind.RecursivePrimaryExpression,
+        const astNode: Ast.RecursivePrimaryExpression = {
+            kind: nodeKind,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             head,
             recursiveExpressions,
         };
+        this.endContext(astNode);
+        return astNode;
     }
 
     private readIdentifier(): Ast.Identifier {
@@ -1610,26 +1621,32 @@ export class Parser {
     }
 
     private readKeyword(): Ast.IdentifierExpression {
-        this.startContext();
-        const tokenRange = this.singleTokenRange(TokenKind.Identifier);
+        const identifierExpressionNodeKind: Ast.NodeKind.IdentifierExpression = Ast.NodeKind.IdentifierExpression;
+        this.startContext(identifierExpressionNodeKind);
+        const identifierExpressionTokenRange = this.singleTokenRange(TokenKind.Identifier);
+
+        const identifierNodeKind: Ast.NodeKind.Identifier = Ast.NodeKind.Identifier;
+        this.startContext(identifierNodeKind);
+        const identifierTokenRange = this.singleTokenRange(TokenKind.Identifier);
 
         const literal = this.readToken();
         const identifier: Ast.Identifier = {
-            kind: Ast.NodeKind.Identifier,
-            tokenRange,
+            kind: identifierNodeKind,
+            tokenRange: identifierTokenRange,
             terminalNode: true,
             literal,
-        }
+        };
+        this.endContext(identifier);
 
-        const astNode: Ast.IdentifierExpression = {
-            kind: Ast.NodeKind.IdentifierExpression,
-            tokenRange,
+        const identifierExpression: Ast.IdentifierExpression = {
+            kind: identifierExpressionNodeKind,
+            tokenRange: identifierExpressionTokenRange,
             terminalNode: false,
             maybeInclusiveConstant: undefined,
             identifier,
         };
-        this.endContext(astNode);
-        return astNode;
+        this.endContext(identifierExpression);
+        return identifierExpression;
     }
 
     private fieldSpecificationListReadError(allowOpenMarker: boolean): Option<Error> {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -91,6 +91,7 @@ export class Parser {
     }
 
     private readSection(): Ast.Section {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.Section);
 
         const maybeLiteralAttributes = this.maybeReadLiteralAttributes();
@@ -109,7 +110,7 @@ export class Parser {
             sectionMembers.push(this.readSectionMember());
         }
 
-        return {
+        const astNode: Ast.Section = {
             kind: Ast.NodeKind.Section,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
@@ -118,11 +119,14 @@ export class Parser {
             maybeName,
             semicolonConstant,
             sectionMembers
-        }
+        };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // sub-item of 12.2.2 Section Documents
     private readSectionMember(): Ast.SectionMember {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.SectionMember);
 
         const maybeLiteralAttributes = this.maybeReadLiteralAttributes();
@@ -130,7 +134,7 @@ export class Parser {
         const namePairedExpression = this.readIdentifierPairedExpression();
         const semicolonConstant = this.readTokenKindAsConstant(TokenKind.Semicolon);
 
-        return {
+        const astNode: Ast.SectionMember = {
             kind: Ast.NodeKind.SectionMember,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
@@ -138,7 +142,9 @@ export class Parser {
             maybeSharedConstant,
             namePairedExpression,
             semicolonConstant,
-        }
+        };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // 12.2.3.1 Expressions
@@ -261,13 +267,17 @@ export class Parser {
         let maybeOperator = Ast.unaryOperatorFrom(this.currentTokenKind);
 
         if (maybeOperator) {
+            this.startContext();
             this.startTokenRange(Ast.NodeKind.UnaryExpression);
             const expressions: Ast.UnaryExpressionHelper<Ast.UnaryOperator, Ast.TUnaryExpression>[] = [];
 
             while (maybeOperator) {
+                // TODO figure this mess
+                // this.startContext();
                 this.startTokenRange(Ast.NodeKind.UnaryExpressionHelper);
+
                 const operatorConstant = this.readUnaryOperatorAsConstant(maybeOperator);
-                expressions.push({
+                const astNode: Ast.UnaryExpressionHelper<Ast.UnaryOperator, Ast.TUnaryExpression> = {
                     kind: Ast.NodeKind.UnaryExpressionHelper,
                     tokenRange: this.popTokenRange(),
                     terminalNode: false,
@@ -275,17 +285,21 @@ export class Parser {
                     operator: maybeOperator,
                     operatorConstant,
                     node: this.readUnaryExpression(),
-                });
+                };
+
+                expressions.push(astNode);
+                // this.endContext(astNode);
                 maybeOperator = Ast.unaryOperatorFrom(this.currentTokenKind);
             };
 
-            const result: Ast.UnaryExpression = {
+            const astNode: Ast.UnaryExpression = {
                 kind: Ast.NodeKind.UnaryExpression,
                 tokenRange: this.popTokenRange(),
                 terminalNode: false,
                 expressions,
             };
-            return result;
+            this.endContext(astNode);
+            return astNode;
         }
         else {
             return this.readTypeExpression();
@@ -396,6 +410,7 @@ export class Parser {
 
     // 12.2.3.11 Literal expression
     private readLiteralExpression(): Ast.LiteralExpression {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.LiteralExpression);
 
         const expectedTokenKinds = [
@@ -417,13 +432,15 @@ export class Parser {
         }
 
         const literal = this.readToken();
-        return {
+        const astNode: Ast.LiteralExpression = {
             kind: Ast.NodeKind.LiteralExpression,
             tokenRange: this.popTokenRange(),
             terminalNode: true,
             literal: literal,
             literalKind: maybeLiteralKind,
         };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // 12.2.3.12 Identifier expression
@@ -457,16 +474,19 @@ export class Parser {
 
     // 12.2.3.15 Not-implemented expression
     private readNotImplementedExpression(): Ast.NotImplementedExpression {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.NotImplementedExpression);
 
         const ellipsisConstant = this.readTokenKindAsConstant(TokenKind.Ellipsis);
 
-        return {
+        const astNode: Ast.NotImplementedExpression = {
             kind: Ast.NodeKind.NotImplementedExpression,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             ellipsisConstant,
         };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // 12.2.3.16 Invoke expression

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -277,7 +277,7 @@ export class Parser {
                 this.startTokenRange(Ast.NodeKind.UnaryExpressionHelper);
 
                 const operatorConstant = this.readUnaryOperatorAsConstant(maybeOperator);
-                const astNode: Ast.UnaryExpressionHelper<Ast.UnaryOperator, Ast.TUnaryExpression> = {
+                const expression: Ast.UnaryExpressionHelper<Ast.UnaryOperator, Ast.TUnaryExpression> = {
                     kind: Ast.NodeKind.UnaryExpressionHelper,
                     tokenRange: this.popTokenRange(),
                     terminalNode: false,
@@ -286,8 +286,7 @@ export class Parser {
                     operatorConstant,
                     node: this.readUnaryExpression(),
                 };
-
-                expressions.push(astNode);
+                expressions.push(expression);
                 // this.endContext(astNode);
                 maybeOperator = Ast.unaryOperatorFrom(this.currentTokenKind);
             };
@@ -929,6 +928,7 @@ export class Parser {
 
     // sub-item of 12.2.3.25 Type expression
     private maybeReadFieldTypeSpecification(): Option<Ast.FieldTypeSpecification> {
+        // TODO figure out context
         this.startTokenRange(Ast.NodeKind.FieldTypeSpecification);
         const maybeEqualConstant = this.maybeReadTokenKindAsConstant(TokenKind.Equal);
         if (maybeEqualConstant) {
@@ -986,6 +986,7 @@ export class Parser {
 
     // 12.2.3.27 Error handling expression
     private readErrorHandlingExpression(): Ast.ErrorHandlingExpression {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.ErrorHandlingExpression);
 
         const tryConstant = this.readTokenKindAsConstant(TokenKind.KeywordTry);
@@ -999,7 +1000,7 @@ export class Parser {
             () => this.readExpression(),
         );
 
-        return {
+        const astNode: Ast.ErrorHandlingExpression = {
             kind: Ast.NodeKind.ErrorHandlingExpression,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
@@ -1007,6 +1008,8 @@ export class Parser {
             protectedExpression,
             maybeOtherwiseExpression,
         };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // 12.2.4 Literal Attributes
@@ -1283,7 +1286,9 @@ export class Parser {
     }
 
     private tryReadPrimitiveType(): Result<Ast.PrimitiveType, ParserError.InvalidPrimitiveTypeError | CommonError.InvariantError> {
+        // TODO figure out context
         this.startTokenRange(Ast.NodeKind.PrimitiveType);
+
         const state: ParserState = this.backupParserState();
         const expectedTokenKinds = [
             TokenKind.Identifier,
@@ -1507,6 +1512,7 @@ export class Parser {
     private readUnaryOperatorAsConstant(operator: Ast.TUnaryExpressionHelperOperator): Ast.Constant {
         this.startContext();
         const tokenRange = this.singleTokenRange(operator);
+
         this.readToken();
 
         const astNode: Ast.Constant = {
@@ -1522,6 +1528,7 @@ export class Parser {
     private readKeyword(): Ast.IdentifierExpression {
         this.startContext();
         const tokenRange = this.singleTokenRange(TokenKind.Identifier);
+
         const literal = this.readToken();
         const identifier: Ast.Identifier = {
             kind: Ast.NodeKind.Identifier,
@@ -1595,6 +1602,7 @@ export class Parser {
         keywordTokenKind: KeywordTokenKindVariant & TokenKind,
         rightExpressionReader: () => R,
     ): L | Ast.IBinOpKeyword<NodeKindVariant, L, R> {
+        // TODO figure out context
         this.startTokenRange(nodeKind);
         const left = leftExpressionReader()
         const maybeConstant = this.maybeReadTokenKindAsConstant(keywordTokenKind);
@@ -1621,6 +1629,7 @@ export class Parser {
         operatorFrom: (tokenKind: Option<TokenKind>) => Option<(Operator & Ast.TUnaryExpressionHelperOperator)>,
         operandReader: () => Operand,
     ): Operand | Ast.IBinOpExpression<NodeKindVariant, Operator, Operand> {
+        // TODO figure out context
         this.startTokenRange(nodeKind);
         const first = operandReader();
 
@@ -1663,6 +1672,7 @@ export class Parser {
         pairedReader: () => Paired,
     ): Ast.IPairedConstant<NodeKindVariant, Paired> {
         this.startTokenRange(nodeKind);
+
         const constant = constantReader();
         const paired = pairedReader();
         return {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -2066,14 +2066,11 @@ export class Parser {
     }
 
     private endContext(astNode: Ast.TNode) {
-        const oldContextNode: ParserContext.Node = this.contextNode;
-        const parentId: number = oldContextNode.parentId;
-        if (parentId < 0) {
-            throw new CommonError.InvariantError("AssertFailed: parentId >= 0");
-        }
-
-        oldContextNode.maybeAstNode = astNode;
-        this.contextNode = this.contextState.nodesById[parentId];
+        this.contextNode = ParserContext.endContext(
+            this.contextState,
+            this.contextNode,
+            astNode,
+        );
     }
 
     private isNextTokenKind(tokenKind: TokenKind): boolean {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -21,7 +21,7 @@ export class Parser {
         private tokenIndex: number = 0,
         private readonly tokenRangeStack: TokenRangeStackElement[] = [],
         private contextState: ParserContext.State = ParserContext.empty(),
-        private maybeContextNode: Option<ParserContext.Node> = undefined,
+        private maybeCurrentContextNode: Option<ParserContext.Node> = undefined,
     ) {
         if (this.lexerSnapshot.tokens.length) {
             this.maybeCurrentToken = this.lexerSnapshot.tokens[0];
@@ -37,8 +37,8 @@ export class Parser {
         const parser = new Parser(lexerSnapshot);
         try {
             const document: Ast.TDocument = parser.readDocument();
-            if (parser.maybeContextNode !== undefined) {
-                const details = { maybeContextNode: parser.maybeContextNode }
+            if (parser.maybeCurrentContextNode !== undefined) {
+                const details = { maybeContextNode: parser.maybeCurrentContextNode }
                 throw new CommonError.InvariantError("maybeContextNode should be falsey, there shouldn't be an open context", details);
             }
 
@@ -2156,34 +2156,34 @@ export class Parser {
     }
 
     private startContext(nodeKind: Ast.NodeKind) {
-        this.maybeContextNode = ParserContext.addChild(
+        this.maybeCurrentContextNode = ParserContext.addChild(
             this.contextState,
-            this.maybeContextNode,
+            this.maybeCurrentContextNode,
             nodeKind,
             this.maybeCurrentToken,
         );
     }
 
     private endContext(astNode: Ast.TNode) {
-        if (this.maybeContextNode === undefined) {
+        if (this.maybeCurrentContextNode === undefined) {
             throw new CommonError.InvariantError("maybeContextNode should be truthy, can't end context if it doesn't exist.");
         }
 
-        this.maybeContextNode = ParserContext.endContext(
+        this.maybeCurrentContextNode = ParserContext.endContext(
             this.contextState,
-            this.maybeContextNode,
+            this.maybeCurrentContextNode,
             astNode,
         );
     }
 
     private deleteContext() {
-        if (this.maybeContextNode === undefined) {
+        if (this.maybeCurrentContextNode === undefined) {
             throw new CommonError.InvariantError("maybeContextNode should be truthy, can't end context if it doesn't exist.");
         }
 
-        this.maybeContextNode = ParserContext.deleteContext(
+        this.maybeCurrentContextNode = ParserContext.deleteContext(
             this.contextState,
-            this.maybeContextNode,
+            this.maybeCurrentContextNode,
         );
     }
 
@@ -2256,8 +2256,8 @@ export class Parser {
             tokenIndex: this.tokenIndex,
             tokenRangeStackLength: this.tokenRangeStack.length,
             contextState: ParserContext.deepCopy(this.contextState),
-            maybeContextNodeId: this.maybeContextNode !== undefined
-                ? this.maybeContextNode.nodeId
+            maybeContextNodeId: this.maybeCurrentContextNode !== undefined
+                ? this.maybeCurrentContextNode.nodeId
                 : undefined,
         };
     }
@@ -2273,10 +2273,10 @@ export class Parser {
         this.contextState = backup.contextState;
 
         if (backup.maybeContextNodeId) {
-            this.maybeContextNode = ParserContext.expectNode(this.contextState.nodesById, backup.maybeContextNodeId);
+            this.maybeCurrentContextNode = ParserContext.expectNode(this.contextState.nodesById, backup.maybeContextNodeId);
         }
         else {
-            this.maybeContextNode = undefined;
+            this.maybeCurrentContextNode = undefined;
         }
     }
 }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -530,6 +530,7 @@ export class Parser {
 
     // 12.2.3.19 Item access expression
     private readItemAccessExpression(): Ast.ItemAccessExpression {
+        // TODO figure out context
         this.startTokenRange(Ast.NodeKind.ItemAccessExpression);
         const maybeReturn = this.readWrapped<Ast.NodeKind.ItemAccessExpression, Ast.TExpression>(
             Ast.NodeKind.ItemAccessExpression,
@@ -564,6 +565,7 @@ export class Parser {
 
     // sub-item of 12.2.3.20 Field access expressions
     private readFieldProjection(): Ast.FieldProjection {
+        // TODO figure out context
         this.startTokenRange(Ast.NodeKind.FieldProjection);
         const maybeReturn = this.readWrapped<Ast.NodeKind.FieldProjection, ReadonlyArray<Ast.ICsv<Ast.FieldSelector>>>(
             Ast.NodeKind.FieldProjection,
@@ -597,6 +599,7 @@ export class Parser {
 
     // sub-item of 12.2.3.20 Field access expressions
     private readFieldSelector(allowOptional: boolean): Ast.FieldSelector {
+        // TODO figure out context
         this.startTokenRange(Ast.NodeKind.FieldSelector);
         const maybeReturn = this.readWrapped<Ast.NodeKind.FieldSelector, Ast.GeneralizedIdentifier>(
             Ast.NodeKind.FieldSelector,
@@ -627,6 +630,7 @@ export class Parser {
 
     // 12.2.3.21 Function expression
     private readFunctionExpression(): Ast.FunctionExpression {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.FunctionExpression);
 
         const parameters = this.readParameterList(() => this.maybeReadAsNullablePrimitiveType());
@@ -634,7 +638,7 @@ export class Parser {
         const fatArrowConstant = this.readTokenKindAsConstant(TokenKind.FatArrow);
         const expression = this.readExpression();
 
-        return {
+        const astNode: Ast.FunctionExpression = {
             kind: Ast.NodeKind.FunctionExpression,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
@@ -642,7 +646,9 @@ export class Parser {
             maybeFunctionReturnType,
             fatArrowConstant,
             expression,
-        }
+        };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // 12.2.3.22 Each expression
@@ -656,6 +662,7 @@ export class Parser {
 
     // 12.2.3.23 Let expression
     private readLetExpression(): Ast.LetExpression {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.LetExpression);
 
         const letConstant = this.readTokenKindAsConstant(TokenKind.KeywordLet);
@@ -663,7 +670,7 @@ export class Parser {
         const inConstant = this.readTokenKindAsConstant(TokenKind.KeywordIn);
         const expression = this.readExpression();
 
-        return {
+        const astNode: Ast.LetExpression = {
             kind: Ast.NodeKind.LetExpression,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
@@ -672,10 +679,13 @@ export class Parser {
             inConstant,
             expression,
         };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // 12.2.3.24 If expression
     private readIfExpression(): Ast.IfExpression {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.IfExpression);
 
         const ifConstant = this.readTokenKindAsConstant(TokenKind.KeywordIf);
@@ -687,7 +697,7 @@ export class Parser {
         const elseConstant = this.readTokenKindAsConstant(TokenKind.KeywordElse);
         const falseExpression = this.readExpression();
 
-        return {
+        const astNode: Ast.IfExpression = {
             kind: Ast.NodeKind.IfExpression,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
@@ -698,6 +708,8 @@ export class Parser {
             elseConstant,
             falseExpression,
         };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // 12.2.3.25 Type expression
@@ -794,20 +806,24 @@ export class Parser {
 
     // sub-item of 12.2.3.25 Type expression
     private readRecordType(): Ast.RecordType {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.RecordType)
 
         const fields = this.readFieldSpecificationList(true);
 
-        return {
+        const astNode: Ast.RecordType = {
             kind: Ast.NodeKind.RecordType,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             fields,
         };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // sub-item of 12.2.3.25 Type expression
     private readTableType(): Ast.TableType {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.TableType)
 
         const tableConstant = this.readIdentifierConstantAsConstant(Ast.IdentifierConstant.Table);
@@ -826,17 +842,20 @@ export class Parser {
             rowType = this.readFieldSpecificationList(false);
         }
 
-        return {
+        const astNode: Ast.TableType = {
             kind: Ast.NodeKind.TableType,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             tableConstant,
             rowType,
         };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // sub-item of 12.2.3.25 Type expression
     private readFieldSpecificationList(allowOpenMarker: boolean): Ast.FieldSpecificationList {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.FieldSpecificationList);
 
         const leftBracketConstant = this.readTokenKindAsConstant(TokenKind.LeftBracket);
@@ -861,6 +880,7 @@ export class Parser {
             }
 
             else if (this.isOnTokenKind(TokenKind.Identifier)) {
+                // TODO figure out context
                 this.startTokenRange(Ast.NodeKind.Csv);
                 this.startTokenRange(Ast.NodeKind.FieldSpecification);
 
@@ -894,7 +914,7 @@ export class Parser {
 
         const rightBracketConstant = this.readTokenKindAsConstant(TokenKind.RightBracket);
 
-        return {
+        const astNode: Ast.FieldSpecificationList = {
             kind: Ast.NodeKind.FieldSpecificationList,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
@@ -903,6 +923,8 @@ export class Parser {
             maybeOpenRecordMarkerConstant,
             closeWrapperConstant: rightBracketConstant,
         };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // sub-item of 12.2.3.25 Type expression

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -428,18 +428,21 @@ export class Parser {
 
     // 12.2.3.12 Identifier expression
     private readIdentifierExpression(): Ast.IdentifierExpression {
+        this.startContext();
         this.startTokenRange(Ast.NodeKind.IdentifierExpression);
 
         const maybeInclusiveConstant = this.maybeReadTokenKindAsConstant(TokenKind.AtSign);
         const identifier = this.readIdentifier();
 
-        return {
+        const astNode: Ast.IdentifierExpression = {
             kind: Ast.NodeKind.IdentifierExpression,
             tokenRange: this.popTokenRange(),
             terminalNode: false,
             maybeInclusiveConstant,
             identifier,
-        }
+        };
+        this.endContext(astNode);
+        return astNode;
     }
 
     // 12.2.3.14 Parenthesized expression
@@ -1402,6 +1405,7 @@ export class Parser {
 
     private maybeReadTokenKindAsConstant(tokenKind: TokenKind): Option<Ast.Constant> {
         if (this.isOnTokenKind(tokenKind)) {
+            this.startContext();
             const tokenRange = this.singleTokenRange(tokenKind);
 
             const maybeConstantKind = Ast.constantKindFromTokenKind(tokenKind);
@@ -1410,12 +1414,14 @@ export class Parser {
             }
 
             this.readToken();
-            return {
+            const astNode: Ast.Constant = {
                 kind: Ast.NodeKind.Constant,
                 tokenRange,
                 terminalNode: true,
                 literal: maybeConstantKind,
-            }
+            };
+            this.endContext(astNode);
+            return astNode;
         }
         else {
             return undefined;
@@ -1433,6 +1439,7 @@ export class Parser {
 
     private maybeReadIdentifierConstantAsConstant(identifierConstant: Ast.IdentifierConstant): Option<Ast.Constant> {
         if (this.isOnIdentifierConstant(identifierConstant)) {
+            this.startContext();
             const tokenRange = this.singleTokenRange(identifierConstant);
 
             const maybeConstantKind = Ast.constantKindFromIdentifieConstant(identifierConstant);
@@ -1441,12 +1448,14 @@ export class Parser {
             }
 
             this.readToken();
-            return {
+            const astNode: Ast.Constant = {
                 kind: Ast.NodeKind.Constant,
                 tokenRange,
                 terminalNode: true,
                 literal: maybeConstantKind,
-            }
+            };
+            this.endContext(astNode);
+            return astNode;
         }
         else {
             return undefined;
@@ -1454,18 +1463,22 @@ export class Parser {
     }
 
     private readUnaryOperatorAsConstant(operator: Ast.TUnaryExpressionHelperOperator): Ast.Constant {
+        this.startContext();
         const tokenRange = this.singleTokenRange(operator);
         this.readToken();
 
-        return {
+        const astNode: Ast.Constant = {
             kind: Ast.NodeKind.Constant,
             tokenRange,
             terminalNode: true,
             literal: operator,
-        }
+        };
+        this.endContext(astNode);
+        return astNode;
     }
 
     private readKeyword(): Ast.IdentifierExpression {
+        this.startContext();
         const tokenRange = this.singleTokenRange(TokenKind.Identifier);
         const literal = this.readToken();
         const identifier: Ast.Identifier = {
@@ -1475,13 +1488,15 @@ export class Parser {
             literal,
         }
 
-        return {
+        const astNode: Ast.IdentifierExpression = {
             kind: Ast.NodeKind.IdentifierExpression,
             tokenRange,
             terminalNode: false,
             maybeInclusiveConstant: undefined,
             identifier,
-        }
+        };
+        this.endContext(astNode);
+        return astNode;
     }
 
     private fieldSpecificationListReadError(allowOpenMarker: boolean): Option<Error> {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -89,7 +89,8 @@ export class Parser {
                     throw maybeErr;
                 }
             }
-            catch (firstErr) {
+            catch (expressionError) {
+                const expressionContextState = ParserContext.deepCopy(this.contextState);
                 this.restoreParserState(state);
                 try {
                     document = this.readSection();
@@ -99,11 +100,13 @@ export class Parser {
                     }
                 }
                 catch {
-                    throw firstErr;
+                    this.contextState = expressionContextState;
+                    throw expressionError;
                 }
             }
         }
 
+        this.endContext(document);
         return document;
     }
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -37,6 +37,11 @@ export class Parser {
         const parser = new Parser(lexerSnapshot);
         try {
             const document: Ast.TDocument = parser.readDocument();
+            if (parser.maybeContextNode !== undefined) {
+                const details = { maybeContextNode: parser.maybeContextNode }
+                throw new CommonError.InvariantError("maybeContextNode should be falsey, there shouldn't be an open context", details);
+            }
+
             return {
                 kind: ResultKind.Ok,
                 value: {
@@ -1238,7 +1243,7 @@ export class Parser {
 
     private readRecursivePrimaryExpression(head: Ast.TPrimaryExpression): Ast.RecursivePrimaryExpression {
         const tokenRangeStart = head.tokenRange.startTokenIndex;
-        const nodeKind: Ast.NodeKind.RecursivePrimaryExpression =Ast.NodeKind.RecursivePrimaryExpression;
+        const nodeKind: Ast.NodeKind.RecursivePrimaryExpression = Ast.NodeKind.RecursivePrimaryExpression;
         this.startContext(nodeKind);
         this.startTokenRangeAt(nodeKind, tokenRangeStart);
 

--- a/src/parser/tokenRange.ts
+++ b/src/parser/tokenRange.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 import { StringHelpers } from "../common";
 
-export type TokenRangeMap<T> = { [key: string]: T; }
+export type TokenRangeMap<T> = Map<string, T>
 
 // keep track of how many tokens and code units make up a TNode in the range of [start, end).
 export interface TokenRange {

--- a/src/test/tokenizer/common.ts
+++ b/src/test/tokenizer/common.ts
@@ -22,12 +22,16 @@ export class Tokenizer implements TokensProvider {
     }
 
     static ITokenFrom(lineToken: LineToken): IToken {
-        // unsafe action:
-        //      cast LineTokenKind into string
-        // what I'm trying to avoid:
-        //      the cost of properly casting, aka one switch statement per LineTokenKind
-        // why it's safe:
-        //      all variants for LineTokenKind are strings
+        // UNSAFE MARKER
+        //
+        // Purpose of code block:
+        //      Translate LineTokenKind to LineToken.
+        //
+        // Why are you trying to avoid a safer approach?
+        //      A proper mapping would require a switch statement, one case per kind in LineNodeKind.
+        //
+        // Why is it safe?
+        //      All variants of LineNodeKind are strings.
         return {
             startIndex: lineToken.positionStart,
             scopes: lineToken.kind as unknown as string,
@@ -43,7 +47,7 @@ export class TokenizerState implements IState {
     }
 
     // For tokenizer state comparison, all we really care about is the line mode end value.
-    // i.e. we need to know if we're ending on an unterminated comment/string as it 
+    // i.e. we need to know if we're ending on an unterminated comment/string as it
     // would impact tokenization for the following line.
     public equals(other: IState): boolean {
         if (!other) {


### PR DESCRIPTION
The existing behavior for the parser is to either completely parse the AST (ensuring no leftover tokens), otherwise error out. It does not retain any metadata as to what or how much was parsed. This won't work with Intellisense as documents aren't valid as they're being typed. 

This stores created nodes (along with some metadata) while parsing. If a `ParserError` is thrown then the context can be accessed as a new attribute on the error class.

Currently the program does nothing with the context object. Implementation, such as scope analysis, will be added later.

Other minor changes:
* replaced indexable types with Map
* updated the style for unsafe disclaimer comment blocks