### PR TITLE
Bugfix for InvokeExpression inspection

### DIFF
--- a/src/inspection/visitNode.ts
+++ b/src/inspection/visitNode.ts
@@ -308,7 +308,7 @@ function inspectInvokeExpression(state: State, invokeExprXorNode: NodeIdMap.TXor
     );
 
     const position: Position = state.position;
-    let positionArgumentIndex: Option<number>;
+    let maybePositionArgumentIndex: Option<number>;
 
     const numArguments: number = argXorNodes.length;
     for (let index: number = 0; index < numArguments; index += 1) {
@@ -318,14 +318,10 @@ function inspectInvokeExpression(state: State, invokeExprXorNode: NodeIdMap.TXor
         }
 
         if (isPositionOnXorNode(position, argXorNode, true)) {
-            positionArgumentIndex = index;
+            maybePositionArgumentIndex = index;
         }
     }
-
-    if (positionArgumentIndex === undefined) {
-        const details: {} = { invokeExprId: invokeExprXorNode.node.id };
-        throw new CommonError.InvariantError(`couldn't find the argument index that position is on`, details);
-    }
+    const positionArgumentIndex: number = maybePositionArgumentIndex !== undefined ? maybePositionArgumentIndex : 0;
 
     state.result.nodes.push({
         kind: NodeKind.InvokeExpression,
@@ -333,12 +329,7 @@ function inspectInvokeExpression(state: State, invokeExprXorNode: NodeIdMap.TXor
         maybePositionStart,
         maybeName,
         maybeArguments: {
-            // Handles off-by-one errors due to trailing ParserContext.Node, eg. `foo(|`.
-            // Assumes only the last XorNode might be a ParserContext.Node
-            numArguments:
-                argXorNodes[argXorNodes.length - 1].kind === NodeIdMap.XorNodeKind.Context
-                    ? numArguments - 1
-                    : numArguments,
+            numArguments,
             positionArgumentIndex,
         },
     });

--- a/src/test/inspection.ts
+++ b/src/test/inspection.ts
@@ -547,6 +547,39 @@ describe(`Inspection`, () => {
             };
             expectParseOkAbridgedInspectionEqual(text, position, expected);
         });
+
+        it(`foo(|)`, () => {
+            const text: string = `foo()`;
+            const position: Inspection.Position = {
+                lineNumber: 0,
+                lineCodeUnit: 4,
+            };
+            const expected: AbridgedInspection = {
+                nodes: [
+                    {
+                        kind: NodeKind.InvokeExpression,
+
+                        maybePositionStart: {
+                            codeUnit: 3,
+                            lineCodeUnit: 3,
+                            lineNumber: 0,
+                        },
+                        maybePositionEnd: {
+                            codeUnit: 5,
+                            lineCodeUnit: 5,
+                            lineNumber: 0,
+                        },
+                        maybeName: `foo`,
+                        maybeArguments: {
+                            numArguments: 0,
+                            positionArgumentIndex: 0,
+                        },
+                    },
+                ],
+                scope: [`foo`],
+            };
+            expectParseOkAbridgedInspectionEqual(text, position, expected);
+        });
     });
 
     describe(`${Ast.NodeKind.InvokeExpression} (ParserContext)`, () => {
@@ -609,7 +642,7 @@ describe(`Inspection`, () => {
                         maybeName: "foo",
                         maybePositionEnd: undefined,
                         maybeArguments: {
-                            numArguments: 0,
+                            numArguments: 1,
                             positionArgumentIndex: 0,
                         },
                     },
@@ -619,7 +652,7 @@ describe(`Inspection`, () => {
             expectParseErrAbridgedInspectionEqual(text, position, expected);
         });
 
-        it(`abc123 [x](y|`, () => {
+        it(`[x](y|`, () => {
             const text: string = `[x](y`;
             const position: Inspection.Position = {
                 lineNumber: 0,


### PR DESCRIPTION
There was an error with InvokeExpression inspection's when it was an Ast with 0 arguments.