### PR TITLE
Add PositionIdentifier to Inspection

### DIFF
--- a/src/inspection/index.ts
+++ b/src/inspection/index.ts
@@ -3,3 +3,4 @@
 
 export * from "./node";
 export * from "./inspection";
+export * from "./positionIdentifier";

--- a/src/inspection/inspection.ts
+++ b/src/inspection/inspection.ts
@@ -19,7 +19,7 @@ import { visitNode } from "./visitNode";
 export type TriedInspect = Traverse.TriedTraverse<Inspected>;
 
 export interface State extends Traverse.IState<UnfrozenInspected> {
-    readonly maybePositionIdentifier: Option<Ast.Identifier>;
+    readonly maybePositionIdentifier: Option<Ast.Identifier | Ast.GeneralizedIdentifier>;
     readonly position: Position;
     readonly nodeIdMapCollection: NodeIdMap.Collection;
     readonly leafNodeIds: ReadonlyArray<number>;
@@ -87,7 +87,7 @@ const DefaultInspection: Inspected = {
 function maybePositionIdentifier(
     nodeIdMapCollection: NodeIdMap.Collection,
     closestLeaf: Ast.TNode,
-): Option<Ast.Identifier> {
+): Option<Ast.Identifier | Ast.GeneralizedIdentifier> {
     // If closestLeaf is '@', then check if it's part of an IdentifierExpression.
     if (closestLeaf.kind === Ast.NodeKind.Constant && closestLeaf.literal === `@`) {
         const maybeParentId: Option<number> = nodeIdMapCollection.parentIdById.get(closestLeaf.id);
@@ -98,7 +98,10 @@ function maybePositionIdentifier(
 
         const parent: Ast.TNode = NodeIdMap.expectAstNode(nodeIdMapCollection.astNodeById, parentId);
         return parent.kind === Ast.NodeKind.IdentifierExpression ? parent.identifier : undefined;
-    } else if (closestLeaf.kind === Ast.NodeKind.Identifier) {
+    } else if (
+        closestLeaf.kind === Ast.NodeKind.Identifier ||
+        closestLeaf.kind === Ast.NodeKind.GeneralizedIdentifier
+    ) {
         return closestLeaf;
     } else {
         return undefined;

--- a/src/inspection/inspection.ts
+++ b/src/inspection/inspection.ts
@@ -140,9 +140,9 @@ function addParentXorNode(
     return maybeParent !== undefined ? [maybeParent] : [];
 }
 
-// Either returns a XorNode used as the root for a traverse, or returns undefined. The options are:
-//  * the XorNode at the given position
-//  * the closest XorNode to the left of the given position
+// Either returns a Ast.TNode used as the root for a traverse, or returns undefined. The options are:
+//  * the Ast.TNode at the given position
+//  * the closest Ast.TNode to the left of the given position
 //  * undefined
 function maybeClosestAstNode(
     position: Position,
@@ -185,12 +185,12 @@ function closerAstNode(position: Position, maybeCurrentNode: Option<Ast.TNode>, 
         return currentNode;
     } else if (
         newNodePositionStart.lineNumber === position.lineNumber &&
-        newNodePositionStart.lineCodeUnit > position.lineCodeUnit
+        newNodePositionStart.lineCodeUnit >= position.lineCodeUnit
     ) {
         return currentNode;
     }
 
-    // Both currentTokenPositionStart and newTokenPositionStart are <= position,
-    // so a quick comparison can be done by examining TokenPosition.codeUnit
-    return currentNodePositionStart.codeUnit < newNodePositionStart.codeUnit ? newNode : currentNode;
+    // Already checked (currentTokenPositionStart <= Position && newTokenPositionStart <= Position),
+    // so grab the right most Node by checking TokenPosition.codeUnit
+    return newNodePositionStart.codeUnit > currentNodePositionStart.codeUnit ? newNode : currentNode;
 }

--- a/src/inspection/positionIdentifier.ts
+++ b/src/inspection/positionIdentifier.ts
@@ -9,7 +9,7 @@ export const enum PositionIdentifierKind {
 
 export interface IPositionIdentifier {
     readonly kind: PositionIdentifierKind;
-    readonly identifier: Ast.Identifier;
+    readonly identifier: Ast.Identifier | Ast.GeneralizedIdentifier;
 }
 
 export interface LocalIdentifier extends IPositionIdentifier {

--- a/src/inspection/positionIdentifier.ts
+++ b/src/inspection/positionIdentifier.ts
@@ -1,0 +1,22 @@
+import { Ast, NodeIdMap } from "../parser";
+
+export type TPositionIdentifier = LocalIdentifier | UndefinedIdentifier;
+
+export const enum PositionIdentifierKind {
+    Local = "Local",
+    Undefined = "Undefined",
+}
+
+export interface IPositionIdentifier {
+    readonly kind: PositionIdentifierKind;
+    readonly identifier: Ast.Identifier;
+}
+
+export interface LocalIdentifier extends IPositionIdentifier {
+    readonly kind: PositionIdentifierKind.Local;
+    readonly defiinition: NodeIdMap.TXorNode;
+}
+
+export interface UndefinedIdentifier extends IPositionIdentifier {
+    readonly kind: PositionIdentifierKind.Undefined;
+}

--- a/src/inspection/positionIdentifier.ts
+++ b/src/inspection/positionIdentifier.ts
@@ -14,7 +14,7 @@ export interface IPositionIdentifier {
 
 export interface LocalIdentifier extends IPositionIdentifier {
     readonly kind: PositionIdentifierKind.Local;
-    readonly defiinition: NodeIdMap.TXorNode;
+    readonly definition: NodeIdMap.TXorNode;
 }
 
 export interface UndefinedIdentifier extends IPositionIdentifier {

--- a/src/inspection/visitNode.ts
+++ b/src/inspection/visitNode.ts
@@ -551,27 +551,41 @@ function inspectSection(state: State, sectionXorNode: NodeIdMap.TXorNode): void 
     );
 
     for (const sectionMember of sectionMemberXorNodes) {
-        const request: NodeIdMap.MultipleChildByAttributeIndexRequest = {
+        const maybeIdentifierPairedExprXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
             nodeIdMapCollection,
-            firstDrilldown: {
-                rootNodeId: sectionMember.node.id,
-                attributeIndex: 2,
-                maybeAllowedNodeKinds: [Ast.NodeKind.IdentifierPairedExpression],
-            },
-            drilldowns: [
-                {
-                    attributeIndex: 0,
-                    maybeAllowedNodeKinds: [Ast.NodeKind.Identifier],
-                },
-            ],
-        };
+            sectionMember.node.id,
+            2,
+            [Ast.NodeKind.IdentifierPairedExpression],
+        );
+        if (maybeIdentifierPairedExprXorNode === undefined) {
+            continue;
+        }
+        const identifierPairedExprXorNode: NodeIdMap.TXorNode = maybeIdentifierPairedExprXorNode;
+        const identifierPairedExprId: number = identifierPairedExprXorNode.node.id;
 
-        const maybeNameXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeMultipleChildByAttributeRequest(request);
+        const maybeNameXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+            nodeIdMapCollection,
+            identifierPairedExprId,
+            0,
+            [Ast.NodeKind.Identifier],
+        );
         if (maybeNameXorNode === undefined) {
-            break;
+            continue;
         }
         const nameXorNode: NodeIdMap.TXorNode = maybeNameXorNode;
         inspectIdentifier(state, nameXorNode);
+
+        const maybeValueXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+            nodeIdMapCollection,
+            identifierPairedExprId,
+            2,
+            undefined,
+        );
+
+        if (maybeValueXorNode) {
+            const valueXorNode: NodeIdMap.TXorNode = maybeValueXorNode;
+            maybeSetPositionIdentifier(state, nameXorNode, valueXorNode);
+        }
     }
 }
 

--- a/src/parser/nodeIdMap.ts
+++ b/src/parser/nodeIdMap.ts
@@ -80,7 +80,7 @@ export function maybeParentXorNode(nodeIdMapCollection: Collection, childId: num
     return maybeXorNode(nodeIdMapCollection, parentNodeId);
 }
 
-// Helper function for Repeatedly calling maybeChildByAttributeIndex.
+// Helper function for repeatedly calling maybeChildByAttributeIndex.
 export function maybeMultipleChildByAttributeRequest(request: MultipleChildByAttributeIndexRequest): Option<TXorNode> {
     const nodeIdMapCollection: Collection = request.nodeIdMapCollection;
     const firstDrilldown: FirstDrilldown = request.firstDrilldown;

--- a/src/test/inspection.ts
+++ b/src/test/inspection.ts
@@ -4,10 +4,10 @@
 import { expect } from "chai";
 import "mocha";
 import { Inspection } from "..";
-import { Option, ResultKind } from "../common";
-import { NodeKind, TNode } from "../inspection";
-import { Lexer, LexerSnapshot, TriedLexerSnapshot } from "../lexer";
-import { Ast, Parser, ParserError } from "../parser";
+import { isNever, Option, ResultKind } from "../common";
+import { NodeKind, PositionIdentifierKind, TNode, TPositionIdentifier } from "../inspection";
+import { Lexer, LexerSnapshot, Token, TokenPosition, TriedLexerSnapshot } from "../lexer";
+import { Ast, NodeIdMap, Parser, ParserError } from "../parser";
 
 type AbridgedScope = ReadonlyArray<string>;
 
@@ -16,11 +16,77 @@ interface AbridgedInspection {
     readonly scope: AbridgedScope;
 }
 
+type TAbridgedPositionIdentifier = AbridgedLocalIdentifier | AbridgedUndefinedIdentifier;
+
+interface IAbridgedPositionIdentifier {
+    readonly kind: PositionIdentifierKind;
+    readonly identifierLiteral: string;
+}
+
+interface AbridgedLocalIdentifier extends IAbridgedPositionIdentifier {
+    readonly kind: PositionIdentifierKind.Local;
+    readonly maybeDefinitionPositionStart: Option<TokenPosition>;
+}
+
+interface AbridgedUndefinedIdentifier extends IAbridgedPositionIdentifier {
+    readonly kind: PositionIdentifierKind.Undefined;
+}
+
 function abridgedInspectionFrom(inspection: Inspection.Inspected): AbridgedInspection {
     return {
         nodes: inspection.nodes,
         scope: [...inspection.scope.keys()],
     };
+}
+
+function abridgedMaybePositionIdentifierFrom(
+    maybePositionIdentifier: Option<TPositionIdentifier>,
+): Option<TAbridgedPositionIdentifier> {
+    if (maybePositionIdentifier === undefined) {
+        return undefined;
+    }
+    const positionIdentifier: TPositionIdentifier = maybePositionIdentifier;
+
+    switch (positionIdentifier.kind) {
+        case PositionIdentifierKind.Local: {
+            const definition: NodeIdMap.TXorNode = positionIdentifier.definition;
+
+            let maybeDefinitionPositionStart: Option<TokenPosition>;
+            switch (definition.kind) {
+                case NodeIdMap.XorNodeKind.Ast:
+                    maybeDefinitionPositionStart = definition.node.tokenRange.positionStart;
+                    break;
+
+                case NodeIdMap.XorNodeKind.Context: {
+                    const maybeTokenStart: Option<Token> = definition.node.maybeTokenStart;
+                    if (maybeTokenStart !== undefined) {
+                        const tokenStart: Token = maybeTokenStart;
+                        maybeDefinitionPositionStart = tokenStart.positionStart;
+                    }
+
+                    break;
+                }
+
+                default:
+                    throw isNever(definition);
+            }
+
+            return {
+                kind: positionIdentifier.kind,
+                identifierLiteral: positionIdentifier.identifier.literal,
+                maybeDefinitionPositionStart,
+            };
+        }
+
+        case PositionIdentifierKind.Undefined:
+            return {
+                kind: positionIdentifier.kind,
+                identifierLiteral: positionIdentifier.identifier.literal,
+            };
+
+        default:
+            throw isNever(positionIdentifier);
+    }
 }
 
 function expectTriedParse(text: string): Parser.TriedParse {
@@ -96,6 +162,49 @@ function expectAbridgedInspectionEqual(triedInspect: Inspection.TriedInspect, ex
     const actual: AbridgedInspection = abridgedInspectionFrom(inspection);
 
     expect(actual).deep.equal(expected);
+}
+
+function expectParseOkPositionIdentifierEqual(
+    text: string,
+    position: Inspection.Position,
+    expected: Option<TAbridgedPositionIdentifier>,
+): void {
+    const parseOk: Parser.ParseOk = expectParseOk(text);
+    const triedInspect: Inspection.TriedInspect = Inspection.tryFrom(
+        position,
+        parseOk.nodeIdMapCollection,
+        parseOk.leafNodeIds,
+    );
+    expectPositionIdentifierEqual(triedInspect, expected);
+}
+
+// function expectParseErrPositionIdentifierEqual(
+//     text: string,
+//     position: Inspection.Position,
+//     expected: Option<TAbridgedPositionIdentifier>,
+// ): void {
+//     const parserError: ParserError.ParserError = expectParseErr(text);
+//     const triedInspect: Inspection.TriedInspect = Inspection.tryFrom(
+//         position,
+//         parserError.context.nodeIdMapCollection,
+//         parserError.context.leafNodeIds,
+//     );
+//     expectPositionIdentifierEqual(triedInspect, expected);
+// }
+
+function expectPositionIdentifierEqual(
+    triedInspect: Inspection.TriedInspect,
+    expected: Option<TAbridgedPositionIdentifier>,
+): void {
+    if (!(triedInspect.kind === ResultKind.Ok)) {
+        throw new Error(`AssertFailed: triedInspect.kind === ResultKind.Ok: ${triedInspect.error.message}`);
+    }
+    const inspection: Inspection.Inspected = triedInspect.value;
+    const actual: Option<TAbridgedPositionIdentifier> = abridgedMaybePositionIdentifierFrom(
+        inspection.maybePositionIdentifier,
+    );
+
+    expect(actual).deep.equal(expected, JSON.stringify(actual));
 }
 
 describe(`Inspection`, () => {
@@ -1114,6 +1223,18 @@ describe(`Inspection`, () => {
                 };
                 expectParseErrAbridgedInspectionEqual(text, position, expected);
             });
+        });
+    });
+
+    describe(`Inspected.maybePositionIdentifier`, () => {
+        it(`let x = 1, y = 2 in x * y|`, () => {
+            const text: string = `let x = 1, y = 2 in x * y`;
+            const position: Inspection.Position = {
+                lineNumber: 0,
+                lineCodeUnit: 24,
+            };
+            const expected: TAbridgedPositionIdentifier = (0 as unknown) as TAbridgedPositionIdentifier;
+            expectParseOkPositionIdentifierEqual(text, position, expected);
         });
     });
 });

--- a/src/test/inspection.ts
+++ b/src/test/inspection.ts
@@ -16,14 +16,10 @@ interface AbridgedInspection {
     readonly scope: AbridgedScope;
 }
 
-function abridgedScopeFrom(inspection: Inspection.Inspected): AbridgedScope {
-    return [...inspection.scope.keys()];
-}
-
 function abridgedInspectionFrom(inspection: Inspection.Inspected): AbridgedInspection {
     return {
         nodes: inspection.nodes,
-        scope: abridgedScopeFrom(inspection),
+        scope: [...inspection.scope.keys()],
     };
 }
 
@@ -103,1019 +99,1021 @@ function expectAbridgedInspectionEqual(triedInspect: Inspection.TriedInspect, ex
 }
 
 describe(`Inspection`, () => {
-    describe(`${Ast.NodeKind.EachExpression} (Ast)`, () => {
-        it(`|each 1`, () => {
-            const text: string = `each 1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 0,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
+    describe(`AbridgedInspected`, () => {
+        describe(`${Ast.NodeKind.EachExpression} (Ast)`, () => {
+            it(`|each 1`, () => {
+                const text: string = `each 1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 0,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
 
-        it(`|each 1`, () => {
-            const text: string = `each 1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 4,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.EachExpression,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
+            it(`|each 1`, () => {
+                const text: string = `each 1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 4,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.EachExpression,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: {
+                                codeUnit: 6,
+                                lineCodeUnit: 6,
+                                lineNumber: 0,
+                            },
                         },
-                        maybePositionEnd: {
-                            codeUnit: 6,
-                            lineCodeUnit: 6,
-                            lineNumber: 0,
+                    ],
+                    scope: [`_`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`each each|`, () => {
+                const text: string = `each each`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 9,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.EachExpression,
+                            maybePositionStart: {
+                                codeUnit: 5,
+                                lineCodeUnit: 5,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
                         },
-                    },
-                ],
-                scope: [`_`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`each each|`, () => {
-            const text: string = `each each`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 9,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.EachExpression,
-                        maybePositionStart: {
-                            codeUnit: 5,
-                            lineCodeUnit: 5,
-                            lineNumber: 0,
+                        {
+                            kind: NodeKind.EachExpression,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
                         },
-                        maybePositionEnd: undefined,
-                    },
-                    {
-                        kind: NodeKind.EachExpression,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
+                    ],
+                    scope: [`_`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+        });
+
+        describe(`${Ast.NodeKind.EachExpression} (ParserContext)`, () => {
+            it(`|each`, () => {
+                const text: string = `each`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 0,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`each|`, () => {
+                const text: string = `each`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 4,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.EachExpression,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
                         },
-                        maybePositionEnd: undefined,
-                    },
-                ],
-                scope: [`_`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-    });
+                    ],
+                    scope: [`_`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
 
-    describe(`${Ast.NodeKind.EachExpression} (ParserContext)`, () => {
-        it(`|each`, () => {
-            const text: string = `each`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 0,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`each|`, () => {
-            const text: string = `each`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 4,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.EachExpression,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
+            it(`each each 1|`, () => {
+                const text: string = `each each 1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 11,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.EachExpression,
+                            maybePositionStart: {
+                                codeUnit: 5,
+                                lineCodeUnit: 5,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: {
+                                codeUnit: 11,
+                                lineCodeUnit: 11,
+                                lineNumber: 0,
+                            },
                         },
-                        maybePositionEnd: undefined,
-                    },
-                ],
-                scope: [`_`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`each each 1|`, () => {
-            const text: string = `each each 1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 11,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.EachExpression,
-                        maybePositionStart: {
-                            codeUnit: 5,
-                            lineCodeUnit: 5,
-                            lineNumber: 0,
+                        {
+                            kind: NodeKind.EachExpression,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: {
+                                codeUnit: 11,
+                                lineCodeUnit: 11,
+                                lineNumber: 0,
+                            },
                         },
-                        maybePositionEnd: {
-                            codeUnit: 11,
-                            lineCodeUnit: 11,
-                            lineNumber: 0,
+                    ],
+                    scope: [`_`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+        });
+
+        describe(`${Ast.NodeKind.FunctionExpression} (Ast)`, () => {
+            it(`|(x) => z`, () => {
+                const text: string = `(x) => z`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 0,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`(x|, y) => z`, () => {
+                const text: string = `(x, y) => z`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 2,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`x`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`(x, y)| => z`, () => {
+                const text: string = `(x, y) => z`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 6,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`x`, `y`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`(x, y) => z|`, () => {
+                const text: string = `(x, y) => z`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 11,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`z`, `x`, `y`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+        });
+
+        describe(`${Ast.NodeKind.FunctionExpression} (ParserContext)`, () => {
+            it(`|(x) =>`, () => {
+                const text: string = `(x) =>`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 0,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`(x|, y) =>`, () => {
+                const text: string = `(x, y) =>`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 2,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`x`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`(x, y)| =>`, () => {
+                const text: string = `(x, y) =>`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 6,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`x`, `y`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`(x, y) =>|`, () => {
+                const text: string = `(x, y) =>`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 9,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`x`, `y`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+        });
+
+        describe(`${Ast.NodeKind.IdentifierExpression} (Ast)`, () => {
+            it(`|foo`, () => {
+                const text: string = `foo`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 0,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`f|oo`, () => {
+                const text: string = `foo`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 1,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`foo`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`foo|`, () => {
+                const text: string = `foo`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 3,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`foo`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`|@foo`, () => {
+                const text: string = `@foo`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 0,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`@|foo`, () => {
+                const text: string = `@foo`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 1,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`@foo`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`@f|oo`, () => {
+                const text: string = `@foo`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 2,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`@foo`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`@foo|`, () => {
+                const text: string = `@foo`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 4,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`@foo`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+        });
+
+        describe(`${Ast.NodeKind.InvokeExpression} (Ast)`, () => {
+            it(`|foo(x)`, () => {
+                const text: string = `foo(x)`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 0,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`foo(x, y|)`, () => {
+                const text: string = `foo(x, y)`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 8,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.InvokeExpression,
+                            maybePositionStart: {
+                                codeUnit: 3,
+                                lineCodeUnit: 3,
+                                lineNumber: 0,
+                            },
+                            maybeName: "foo",
+                            maybePositionEnd: {
+                                codeUnit: 9,
+                                lineCodeUnit: 9,
+                                lineNumber: 0,
+                            },
+                            maybeArguments: {
+                                numArguments: 2,
+                                positionArgumentIndex: 1,
+                            },
                         },
-                    },
-                    {
-                        kind: NodeKind.EachExpression,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
+                    ],
+                    scope: [`x`, `y`, `foo`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`foo(x, y)|`, () => {
+                const text: string = `foo(x, y)`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 9,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`foo`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`[x](y|)`, () => {
+                const text: string = `[x](y)`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 5,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.InvokeExpression,
+
+                            maybePositionStart: {
+                                codeUnit: 3,
+                                lineCodeUnit: 3,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: {
+                                codeUnit: 6,
+                                lineCodeUnit: 6,
+                                lineNumber: 0,
+                            },
+                            maybeName: undefined,
+                            maybeArguments: {
+                                numArguments: 1,
+                                positionArgumentIndex: 0,
+                            },
                         },
-                        maybePositionEnd: {
-                            codeUnit: 11,
-                            lineCodeUnit: 11,
-                            lineNumber: 0,
+                    ],
+                    scope: [`y`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`foo(|)`, () => {
+                const text: string = `foo()`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 4,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.InvokeExpression,
+
+                            maybePositionStart: {
+                                codeUnit: 3,
+                                lineCodeUnit: 3,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: {
+                                codeUnit: 5,
+                                lineCodeUnit: 5,
+                                lineNumber: 0,
+                            },
+                            maybeName: `foo`,
+                            maybeArguments: {
+                                numArguments: 0,
+                                positionArgumentIndex: 0,
+                            },
                         },
-                    },
-                ],
-                scope: [`_`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-    });
-
-    describe(`${Ast.NodeKind.FunctionExpression} (Ast)`, () => {
-        it(`|(x) => z`, () => {
-            const text: string = `(x) => z`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 0,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
+                    ],
+                    scope: [`foo`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
         });
 
-        it(`(x|, y) => z`, () => {
-            const text: string = `(x, y) => z`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 2,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`x`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
+        describe(`${Ast.NodeKind.InvokeExpression} (ParserContext)`, () => {
+            it(`|foo(x`, () => {
+                const text: string = `foo(x`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 0,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
 
-        it(`(x, y)| => z`, () => {
-            const text: string = `(x, y) => z`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 6,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`x`, `y`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`(x, y) => z|`, () => {
-            const text: string = `(x, y) => z`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 11,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`z`, `x`, `y`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-    });
-
-    describe(`${Ast.NodeKind.FunctionExpression} (ParserContext)`, () => {
-        it(`|(x) =>`, () => {
-            const text: string = `(x) =>`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 0,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`(x|, y) =>`, () => {
-            const text: string = `(x, y) =>`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 2,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`x`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`(x, y)| =>`, () => {
-            const text: string = `(x, y) =>`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 6,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`x`, `y`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`(x, y) =>|`, () => {
-            const text: string = `(x, y) =>`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 9,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`x`, `y`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-    });
-
-    describe(`${Ast.NodeKind.IdentifierExpression} (Ast)`, () => {
-        it(`|foo`, () => {
-            const text: string = `foo`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 0,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`f|oo`, () => {
-            const text: string = `foo`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 1,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`foo`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`foo|`, () => {
-            const text: string = `foo`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 3,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`foo`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`|@foo`, () => {
-            const text: string = `@foo`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 0,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`@|foo`, () => {
-            const text: string = `@foo`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 1,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`@foo`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`@f|oo`, () => {
-            const text: string = `@foo`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 2,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`@foo`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`@foo|`, () => {
-            const text: string = `@foo`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 4,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`@foo`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-    });
-
-    describe(`${Ast.NodeKind.InvokeExpression} (Ast)`, () => {
-        it(`|foo(x)`, () => {
-            const text: string = `foo(x)`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 0,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`foo(x, y|)`, () => {
-            const text: string = `foo(x, y)`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 8,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.InvokeExpression,
-                        maybePositionStart: {
-                            codeUnit: 3,
-                            lineCodeUnit: 3,
-                            lineNumber: 0,
+            it(`foo(x, y|`, () => {
+                const text: string = `foo(x, y`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 8,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.InvokeExpression,
+                            maybePositionStart: {
+                                codeUnit: 3,
+                                lineCodeUnit: 3,
+                                lineNumber: 0,
+                            },
+                            maybeName: "foo",
+                            maybePositionEnd: undefined,
+                            maybeArguments: {
+                                numArguments: 2,
+                                positionArgumentIndex: 1,
+                            },
                         },
-                        maybeName: "foo",
-                        maybePositionEnd: {
-                            codeUnit: 9,
-                            lineCodeUnit: 9,
-                            lineNumber: 0,
+                    ],
+                    scope: [`y`, `x`, `foo`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`foo(|`, () => {
+                const text: string = `foo(`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 4,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.InvokeExpression,
+                            maybePositionStart: {
+                                codeUnit: 3,
+                                lineCodeUnit: 3,
+                                lineNumber: 0,
+                            },
+                            maybeName: "foo",
+                            maybePositionEnd: undefined,
+                            maybeArguments: {
+                                numArguments: 1,
+                                positionArgumentIndex: 0,
+                            },
                         },
-                        maybeArguments: {
-                            numArguments: 2,
-                            positionArgumentIndex: 1,
+                    ],
+                    scope: [`foo`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`[x](y|`, () => {
+                const text: string = `[x](y`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 5,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.InvokeExpression,
+
+                            maybePositionStart: {
+                                codeUnit: 3,
+                                lineCodeUnit: 3,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
+                            maybeName: undefined,
+                            maybeArguments: {
+                                numArguments: 1,
+                                positionArgumentIndex: 0,
+                            },
                         },
-                    },
-                ],
-                scope: [`x`, `y`, `foo`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
+                    ],
+                    scope: [`y`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
         });
 
-        it(`foo(x, y)|`, () => {
-            const text: string = `foo(x, y)`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 9,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`foo`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
+        describe(`${Ast.NodeKind.ListExpression} (ParserContext)`, () => {
+            it(`|{1`, () => {
+                const text: string = `{1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 0,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`{|1`, () => {
+                const text: string = `{1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 1,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.List,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
+                        },
+                    ],
+                    scope: [],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`{|1`, () => {
+                const text: string = `{1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 1,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.List,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
+                        },
+                    ],
+                    scope: [],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`{1|`, () => {
+                const text: string = `{1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 2,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.List,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
+                        },
+                    ],
+                    scope: [],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`{{|1`, () => {
+                const text: string = `{{1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 2,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.List,
+                            maybePositionStart: {
+                                codeUnit: 1,
+                                lineCodeUnit: 1,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
+                        },
+                        {
+                            kind: NodeKind.List,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
+                        },
+                    ],
+                    scope: [],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
         });
 
-        it(`[x](y|)`, () => {
-            const text: string = `[x](y)`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 5,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.InvokeExpression,
+        describe(`${Ast.NodeKind.RecordExpression} (Ast)`, () => {
+            it(`|[a=1]`, () => {
+                const text: string = `[a=1]`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 0,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
 
-                        maybePositionStart: {
-                            codeUnit: 3,
-                            lineCodeUnit: 3,
-                            lineNumber: 0,
+            it(`[|a=1]`, () => {
+                const text: string = `[a=1]`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 1,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.Record,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: {
+                                codeUnit: 5,
+                                lineCodeUnit: 5,
+                                lineNumber: 0,
+                            },
                         },
-                        maybePositionEnd: {
-                            codeUnit: 6,
-                            lineCodeUnit: 6,
-                            lineNumber: 0,
+                    ],
+                    scope: [],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`[a=1|]`, () => {
+                const text: string = `[a=1]`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 4,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.Record,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: {
+                                codeUnit: 5,
+                                lineCodeUnit: 5,
+                                lineNumber: 0,
+                            },
                         },
-                        maybeName: undefined,
-                        maybeArguments: {
-                            numArguments: 1,
-                            positionArgumentIndex: 0,
+                    ],
+                    scope: [`a`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`[a=1]|`, () => {
+                const text: string = `[a=1]`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 5,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`[a=[|b=1]]`, () => {
+                const text: string = `[a=[|b=1]]`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 4,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.Record,
+                            maybePositionStart: {
+                                codeUnit: 3,
+                                lineCodeUnit: 3,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: {
+                                codeUnit: 9,
+                                lineCodeUnit: 9,
+                                lineNumber: 0,
+                            },
                         },
-                    },
-                ],
-                scope: [`y`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
+                        {
+                            kind: NodeKind.Record,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: {
+                                codeUnit: 10,
+                                lineCodeUnit: 10,
+                                lineNumber: 0,
+                            },
+                        },
+                    ],
+                    scope: [`a`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
         });
 
-        it(`foo(|)`, () => {
-            const text: string = `foo()`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 4,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.InvokeExpression,
+        describe(`${Ast.NodeKind.RecordExpression} (ParserContext)`, () => {
+            it(`|[a=1`, () => {
+                const text: string = `[a=1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 0,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
 
-                        maybePositionStart: {
-                            codeUnit: 3,
-                            lineCodeUnit: 3,
-                            lineNumber: 0,
+            it(`[|a=1`, () => {
+                const text: string = `[a=1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 1,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.Record,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
                         },
-                        maybePositionEnd: {
-                            codeUnit: 5,
-                            lineCodeUnit: 5,
-                            lineNumber: 0,
-                        },
-                        maybeName: `foo`,
-                        maybeArguments: {
-                            numArguments: 0,
-                            positionArgumentIndex: 0,
-                        },
-                    },
-                ],
-                scope: [`foo`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-    });
+                    ],
+                    scope: [],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
 
-    describe(`${Ast.NodeKind.InvokeExpression} (ParserContext)`, () => {
-        it(`|foo(x`, () => {
-            const text: string = `foo(x`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 0,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
+            it(`[a=|1`, () => {
+                const text: string = `[a=1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 3,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.Record,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
+                        },
+                    ],
+                    scope: [`a`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
 
-        it(`foo(x, y|`, () => {
-            const text: string = `foo(x, y`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 8,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.InvokeExpression,
-                        maybePositionStart: {
-                            codeUnit: 3,
-                            lineCodeUnit: 3,
-                            lineNumber: 0,
+            it(`[a=1|`, () => {
+                const text: string = `[a=1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 4,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.Record,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
                         },
-                        maybeName: "foo",
-                        maybePositionEnd: undefined,
-                        maybeArguments: {
-                            numArguments: 2,
-                            positionArgumentIndex: 1,
-                        },
-                    },
-                ],
-                scope: [`y`, `x`, `foo`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
+                    ],
+                    scope: [`a`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
 
-        it(`foo(|`, () => {
-            const text: string = `foo(`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 4,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.InvokeExpression,
-                        maybePositionStart: {
-                            codeUnit: 3,
-                            lineCodeUnit: 3,
-                            lineNumber: 0,
+            it(`[a=[|b=1`, () => {
+                const text: string = `[a=[b=1`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 4,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.Record,
+                            maybePositionStart: {
+                                codeUnit: 3,
+                                lineCodeUnit: 3,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
                         },
-                        maybeName: "foo",
-                        maybePositionEnd: undefined,
-                        maybeArguments: {
-                            numArguments: 1,
-                            positionArgumentIndex: 0,
+                        {
+                            kind: NodeKind.Record,
+                            maybePositionStart: {
+                                codeUnit: 0,
+                                lineCodeUnit: 0,
+                                lineNumber: 0,
+                            },
+                            maybePositionEnd: undefined,
                         },
-                    },
-                ],
-                scope: [`foo`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`[x](y|`, () => {
-            const text: string = `[x](y`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 5,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.InvokeExpression,
-
-                        maybePositionStart: {
-                            codeUnit: 3,
-                            lineCodeUnit: 3,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: undefined,
-                        maybeName: undefined,
-                        maybeArguments: {
-                            numArguments: 1,
-                            positionArgumentIndex: 0,
-                        },
-                    },
-                ],
-                scope: [`y`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-    });
-
-    describe(`${Ast.NodeKind.ListExpression} (ParserContext)`, () => {
-        it(`|{1`, () => {
-            const text: string = `{1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 0,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
+                    ],
+                    scope: [`a`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
         });
 
-        it(`{|1`, () => {
-            const text: string = `{1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 1,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.List,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: undefined,
-                    },
-                ],
-                scope: [],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
+        describe(`${Ast.NodeKind.SectionMember} (Ast)`, () => {
+            it(`s|ection foo; x = 1; y = 2;`, () => {
+                const text: string = `section foo; x = 1; y = 2;`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 1,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`section foo; x = 1|; y = 2;`, () => {
+                const text: string = `section foo; x = 1; y = 2;`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 18,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`x`],
+                };
+
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`section foo; x = 1; y = 2;|`, () => {
+                const text: string = `section foo; x = 1; y = 2;|`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 26,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`x`, `y`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
         });
 
-        it(`{|1`, () => {
-            const text: string = `{1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 1,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.List,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: undefined,
-                    },
-                ],
-                scope: [],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
+        describe(`${Ast.NodeKind.SectionMember} (ParserContext)`, () => {
+            it(`s|ection foo; x = 1; y = 2`, () => {
+                const text: string = `section foo; x = 1; y = 2`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 1,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
 
-        it(`{1|`, () => {
-            const text: string = `{1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 2,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.List,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: undefined,
-                    },
-                ],
-                scope: [],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
+            it(`section foo; x = 1|; y = 2`, () => {
+                const text: string = `section foo; x = 1; y = 2`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 18,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`x`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
 
-        it(`{{|1`, () => {
-            const text: string = `{{1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 2,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.List,
-                        maybePositionStart: {
-                            codeUnit: 1,
-                            lineCodeUnit: 1,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: undefined,
-                    },
-                    {
-                        kind: NodeKind.List,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: undefined,
-                    },
-                ],
-                scope: [],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-    });
-
-    describe(`${Ast.NodeKind.RecordExpression} (Ast)`, () => {
-        it(`|[a=1]`, () => {
-            const text: string = `[a=1]`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 0,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`[|a=1]`, () => {
-            const text: string = `[a=1]`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 1,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.Record,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: {
-                            codeUnit: 5,
-                            lineCodeUnit: 5,
-                            lineNumber: 0,
-                        },
-                    },
-                ],
-                scope: [],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`[a=1|]`, () => {
-            const text: string = `[a=1]`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 4,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.Record,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: {
-                            codeUnit: 5,
-                            lineCodeUnit: 5,
-                            lineNumber: 0,
-                        },
-                    },
-                ],
-                scope: [`a`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`[a=1]|`, () => {
-            const text: string = `[a=1]`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 5,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`[a=[|b=1]]`, () => {
-            const text: string = `[a=[|b=1]]`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 4,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.Record,
-                        maybePositionStart: {
-                            codeUnit: 3,
-                            lineCodeUnit: 3,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: {
-                            codeUnit: 9,
-                            lineCodeUnit: 9,
-                            lineNumber: 0,
-                        },
-                    },
-                    {
-                        kind: NodeKind.Record,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: {
-                            codeUnit: 10,
-                            lineCodeUnit: 10,
-                            lineNumber: 0,
-                        },
-                    },
-                ],
-                scope: [`a`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-    });
-
-    describe(`${Ast.NodeKind.RecordExpression} (ParserContext)`, () => {
-        it(`|[a=1`, () => {
-            const text: string = `[a=1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 0,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`[|a=1`, () => {
-            const text: string = `[a=1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 1,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.Record,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: undefined,
-                    },
-                ],
-                scope: [],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`[a=|1`, () => {
-            const text: string = `[a=1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 3,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.Record,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: undefined,
-                    },
-                ],
-                scope: [`a`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`[a=1|`, () => {
-            const text: string = `[a=1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 4,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.Record,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: undefined,
-                    },
-                ],
-                scope: [`a`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`[a=[|b=1`, () => {
-            const text: string = `[a=[b=1`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 4,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [
-                    {
-                        kind: NodeKind.Record,
-                        maybePositionStart: {
-                            codeUnit: 3,
-                            lineCodeUnit: 3,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: undefined,
-                    },
-                    {
-                        kind: NodeKind.Record,
-                        maybePositionStart: {
-                            codeUnit: 0,
-                            lineCodeUnit: 0,
-                            lineNumber: 0,
-                        },
-                        maybePositionEnd: undefined,
-                    },
-                ],
-                scope: [`a`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-    });
-
-    describe(`${Ast.NodeKind.SectionMember} (Ast)`, () => {
-        it(`s|ection foo; x = 1; y = 2;`, () => {
-            const text: string = `section foo; x = 1; y = 2;`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 1,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`section foo; x = 1|; y = 2;`, () => {
-            const text: string = `section foo; x = 1; y = 2;`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 18,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`x`],
-            };
-
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`section foo; x = 1; y = 2;|`, () => {
-            const text: string = `section foo; x = 1; y = 2;|`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 26,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`x`, `y`],
-            };
-            expectParseOkAbridgedInspectionEqual(text, position, expected);
-        });
-    });
-
-    describe(`${Ast.NodeKind.SectionMember} (ParserContext)`, () => {
-        it(`s|ection foo; x = 1; y = 2`, () => {
-            const text: string = `section foo; x = 1; y = 2`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 1,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`section foo; x = 1|; y = 2`, () => {
-            const text: string = `section foo; x = 1; y = 2`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 18,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`x`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
-        });
-
-        it(`section foo; x = 1; y = 2|`, () => {
-            const text: string = `section foo; x = 1; y = 2|`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 25,
-            };
-            const expected: AbridgedInspection = {
-                nodes: [],
-                scope: [`x`, `y`],
-            };
-            expectParseErrAbridgedInspectionEqual(text, position, expected);
+            it(`section foo; x = 1; y = 2|`, () => {
+                const text: string = `section foo; x = 1; y = 2|`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 25,
+                };
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`x`, `y`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
         });
     });
 });

--- a/src/test/inspection/abridgedInspected.ts
+++ b/src/test/inspection/abridgedInspected.ts
@@ -457,7 +457,7 @@ describe(`Inspection`, () => {
                             },
                         },
                     ],
-                    scope: [`x`, `y`, `foo`],
+                    scope: [`y`, `x`, `foo`],
                 };
                 expectParseOkAbridgedInspectionEqual(text, position, expected);
             });

--- a/src/test/inspection/abridgedPositionIdentifier.ts
+++ b/src/test/inspection/abridgedPositionIdentifier.ts
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect } from "chai";
+import "mocha";
+import { Inspection } from "../..";
+import { isNever, Option, ResultKind } from "../../common";
+import { PositionIdentifierKind, TPositionIdentifier } from "../../inspection";
+import { Token, TokenPosition } from "../../lexer";
+import { NodeIdMap, Parser } from "../../parser";
+import { expectParseOk } from "./common";
+
+type TAbridgedPositionIdentifier = AbridgedLocalIdentifier | AbridgedUndefinedIdentifier;
+
+interface IAbridgedPositionIdentifier {
+    readonly kind: PositionIdentifierKind;
+    readonly identifierLiteral: string;
+}
+
+interface AbridgedLocalIdentifier extends IAbridgedPositionIdentifier {
+    readonly kind: PositionIdentifierKind.Local;
+    readonly maybeDefinitionPositionStart: Option<TokenPosition>;
+}
+
+interface AbridgedUndefinedIdentifier extends IAbridgedPositionIdentifier {
+    readonly kind: PositionIdentifierKind.Undefined;
+}
+
+function abridgedMaybePositionIdentifierFrom(
+    maybePositionIdentifier: Option<TPositionIdentifier>,
+): Option<TAbridgedPositionIdentifier> {
+    if (maybePositionIdentifier === undefined) {
+        return undefined;
+    }
+    const positionIdentifier: TPositionIdentifier = maybePositionIdentifier;
+
+    switch (positionIdentifier.kind) {
+        case PositionIdentifierKind.Local: {
+            const definition: NodeIdMap.TXorNode = positionIdentifier.definition;
+
+            let maybeDefinitionPositionStart: Option<TokenPosition>;
+            switch (definition.kind) {
+                case NodeIdMap.XorNodeKind.Ast:
+                    maybeDefinitionPositionStart = definition.node.tokenRange.positionStart;
+                    break;
+
+                case NodeIdMap.XorNodeKind.Context: {
+                    const maybeTokenStart: Option<Token> = definition.node.maybeTokenStart;
+                    if (maybeTokenStart !== undefined) {
+                        const tokenStart: Token = maybeTokenStart;
+                        maybeDefinitionPositionStart = tokenStart.positionStart;
+                    }
+
+                    break;
+                }
+
+                default:
+                    throw isNever(definition);
+            }
+
+            return {
+                kind: positionIdentifier.kind,
+                identifierLiteral: positionIdentifier.identifier.literal,
+                maybeDefinitionPositionStart,
+            };
+        }
+
+        case PositionIdentifierKind.Undefined:
+            return {
+                kind: positionIdentifier.kind,
+                identifierLiteral: positionIdentifier.identifier.literal,
+            };
+
+        default:
+            throw isNever(positionIdentifier);
+    }
+}
+
+function expectParseOkPositionIdentifierEqual(
+    text: string,
+    position: Inspection.Position,
+    expected: Option<TAbridgedPositionIdentifier>,
+): void {
+    const parseOk: Parser.ParseOk = expectParseOk(text);
+    const triedInspect: Inspection.TriedInspect = Inspection.tryFrom(
+        position,
+        parseOk.nodeIdMapCollection,
+        parseOk.leafNodeIds,
+    );
+    expectPositionIdentifierEqual(triedInspect, expected);
+}
+
+// function expectParseErrPositionIdentifierEqual(
+//     text: string,
+//     position: Inspection.Position,
+//     expected: Option<TAbridgedPositionIdentifier>,
+// ): void {
+//     const parserError: ParserError.ParserError = expectParseErr(text);
+//     const triedInspect: Inspection.TriedInspect = Inspection.tryFrom(
+//         position,
+//         parserError.context.nodeIdMapCollection,
+//         parserError.context.leafNodeIds,
+//     );
+//     expectPositionIdentifierEqual(triedInspect, expected);
+// }
+
+function expectPositionIdentifierEqual(
+    triedInspect: Inspection.TriedInspect,
+    expected: Option<TAbridgedPositionIdentifier>,
+): void {
+    if (!(triedInspect.kind === ResultKind.Ok)) {
+        throw new Error(`AssertFailed: triedInspect.kind === ResultKind.Ok: ${triedInspect.error.message}`);
+    }
+    const inspection: Inspection.Inspected = triedInspect.value;
+    const actual: Option<TAbridgedPositionIdentifier> = abridgedMaybePositionIdentifierFrom(
+        inspection.maybePositionIdentifier,
+    );
+
+    expect(actual).deep.equal(expected, JSON.stringify(actual));
+}
+
+describe(`Inspection`, () => {
+    describe(`AbridgedPositionIdentifier`, () => {
+        it(`let x = 1, y = 2 in x * y|`, () => {
+            const text: string = `let x = 1, y = 2 in x * y`;
+            const position: Inspection.Position = {
+                lineNumber: 0,
+                lineCodeUnit: 24,
+            };
+            const expected: TAbridgedPositionIdentifier = (0 as unknown) as TAbridgedPositionIdentifier;
+            expectParseOkPositionIdentifierEqual(text, position, expected);
+        });
+    });
+});

--- a/src/test/inspection/abridgedPositionIdentifier.ts
+++ b/src/test/inspection/abridgedPositionIdentifier.ts
@@ -116,18 +116,44 @@ function expectPositionIdentifierEqual(
         inspection.maybePositionIdentifier,
     );
 
-    expect(actual).deep.equal(expected, JSON.stringify(actual));
+    expect(actual).deep.equal(expected);
 }
 
 describe(`Inspection`, () => {
     describe(`AbridgedPositionIdentifier`, () => {
+        it(`let x = 1, y = 2 in x| * y`, () => {
+            const text: string = `let x = 1, y = 2 in x * y`;
+            const position: Inspection.Position = {
+                lineNumber: 0,
+                lineCodeUnit: 21,
+            };
+            const expected: TAbridgedPositionIdentifier = {
+                kind: PositionIdentifierKind.Local,
+                identifierLiteral: `x`,
+                maybeDefinitionPositionStart: {
+                    lineNumber: 0,
+                    lineCodeUnit: 8,
+                    codeUnit: 8,
+                },
+            };
+            expectParseOkPositionIdentifierEqual(text, position, expected);
+        });
+
         it(`let x = 1, y = 2 in x * y|`, () => {
             const text: string = `let x = 1, y = 2 in x * y`;
             const position: Inspection.Position = {
                 lineNumber: 0,
                 lineCodeUnit: 24,
             };
-            const expected: TAbridgedPositionIdentifier = (0 as unknown) as TAbridgedPositionIdentifier;
+            const expected: TAbridgedPositionIdentifier = {
+                kind: PositionIdentifierKind.Local,
+                identifierLiteral: `y`,
+                maybeDefinitionPositionStart: {
+                    lineNumber: 0,
+                    lineCodeUnit: 15,
+                    codeUnit: 15,
+                },
+            };
             expectParseOkPositionIdentifierEqual(text, position, expected);
         });
     });

--- a/src/test/inspection/abridgedPositionIdentifier.ts
+++ b/src/test/inspection/abridgedPositionIdentifier.ts
@@ -188,6 +188,24 @@ describe(`Inspection`, () => {
                 };
                 expectParseOkPositionIdentifierEqual(text, position, expected);
             });
+
+            it(`section; foo = 1; bar = foo|;`, () => {
+                const text: string = `section; foo = 1; bar = foo;`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 27,
+                };
+                const expected: TAbridgedPositionIdentifier = {
+                    kind: PositionIdentifierKind.Local,
+                    identifierLiteral: `foo`,
+                    maybeDefinitionPositionStart: {
+                        lineNumber: 0,
+                        lineCodeUnit: 15,
+                        codeUnit: 15,
+                    },
+                };
+                expectParseOkPositionIdentifierEqual(text, position, expected);
+            });
         });
 
         describe("ParserContext", () => {

--- a/src/test/inspection/abridgedPositionIdentifier.ts
+++ b/src/test/inspection/abridgedPositionIdentifier.ts
@@ -7,8 +7,8 @@ import { Inspection } from "../..";
 import { isNever, Option, ResultKind } from "../../common";
 import { PositionIdentifierKind, TPositionIdentifier } from "../../inspection";
 import { Token, TokenPosition } from "../../lexer";
-import { NodeIdMap, Parser } from "../../parser";
-import { expectParseOk } from "./common";
+import { NodeIdMap, Parser, ParserError } from "../../parser";
+import { expectParseErr, expectParseOk } from "./common";
 
 type TAbridgedPositionIdentifier = AbridgedLocalIdentifier | AbridgedUndefinedIdentifier;
 
@@ -90,19 +90,19 @@ function expectParseOkPositionIdentifierEqual(
     expectPositionIdentifierEqual(triedInspect, expected);
 }
 
-// function expectParseErrPositionIdentifierEqual(
-//     text: string,
-//     position: Inspection.Position,
-//     expected: Option<TAbridgedPositionIdentifier>,
-// ): void {
-//     const parserError: ParserError.ParserError = expectParseErr(text);
-//     const triedInspect: Inspection.TriedInspect = Inspection.tryFrom(
-//         position,
-//         parserError.context.nodeIdMapCollection,
-//         parserError.context.leafNodeIds,
-//     );
-//     expectPositionIdentifierEqual(triedInspect, expected);
-// }
+function expectParseErrPositionIdentifierEqual(
+    text: string,
+    position: Inspection.Position,
+    expected: Option<TAbridgedPositionIdentifier>,
+): void {
+    const parserError: ParserError.ParserError = expectParseErr(text);
+    const triedInspect: Inspection.TriedInspect = Inspection.tryFrom(
+        position,
+        parserError.context.nodeIdMapCollection,
+        parserError.context.leafNodeIds,
+    );
+    expectPositionIdentifierEqual(triedInspect, expected);
+}
 
 function expectPositionIdentifierEqual(
     triedInspect: Inspection.TriedInspect,
@@ -121,40 +121,111 @@ function expectPositionIdentifierEqual(
 
 describe(`Inspection`, () => {
     describe(`AbridgedPositionIdentifier`, () => {
-        it(`let x = 1, y = 2 in x| * y`, () => {
-            const text: string = `let x = 1, y = 2 in x * y`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 21,
-            };
-            const expected: TAbridgedPositionIdentifier = {
-                kind: PositionIdentifierKind.Local,
-                identifierLiteral: `x`,
-                maybeDefinitionPositionStart: {
+        describe("Ast", () => {
+            it(`let x = 1 in y|`, () => {
+                const text: string = `let x = 1 in y`;
+                const position: Inspection.Position = {
                     lineNumber: 0,
-                    lineCodeUnit: 8,
-                    codeUnit: 8,
-                },
-            };
-            expectParseOkPositionIdentifierEqual(text, position, expected);
+                    lineCodeUnit: 24,
+                };
+                const expected: TAbridgedPositionIdentifier = {
+                    kind: PositionIdentifierKind.Undefined,
+                    identifierLiteral: `y`,
+                };
+                expectParseOkPositionIdentifierEqual(text, position, expected);
+            });
+
+            it(`let x = 1, y = 2 in x| * y`, () => {
+                const text: string = `let x = 1, y = 2 in x * y`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 21,
+                };
+                const expected: TAbridgedPositionIdentifier = {
+                    kind: PositionIdentifierKind.Local,
+                    identifierLiteral: `x`,
+                    maybeDefinitionPositionStart: {
+                        lineNumber: 0,
+                        lineCodeUnit: 8,
+                        codeUnit: 8,
+                    },
+                };
+                expectParseOkPositionIdentifierEqual(text, position, expected);
+            });
+
+            it(`let x = 1, y = 2 in x * y|`, () => {
+                const text: string = `let x = 1, y = 2 in x * y`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 24,
+                };
+                const expected: TAbridgedPositionIdentifier = {
+                    kind: PositionIdentifierKind.Local,
+                    identifierLiteral: `y`,
+                    maybeDefinitionPositionStart: {
+                        lineNumber: 0,
+                        lineCodeUnit: 15,
+                        codeUnit: 15,
+                    },
+                };
+                expectParseOkPositionIdentifierEqual(text, position, expected);
+            });
+
+            it(`let x = 1 in [y = x|]`, () => {
+                const text: string = `let x = 1 in [y = x|]`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 19,
+                };
+                const expected: TAbridgedPositionIdentifier = {
+                    kind: PositionIdentifierKind.Local,
+                    identifierLiteral: `x`,
+                    maybeDefinitionPositionStart: {
+                        lineNumber: 0,
+                        lineCodeUnit: 8,
+                        codeUnit: 8,
+                    },
+                };
+                expectParseOkPositionIdentifierEqual(text, position, expected);
+            });
         });
 
-        it(`let x = 1, y = 2 in x * y|`, () => {
-            const text: string = `let x = 1, y = 2 in x * y`;
-            const position: Inspection.Position = {
-                lineNumber: 0,
-                lineCodeUnit: 24,
-            };
-            const expected: TAbridgedPositionIdentifier = {
-                kind: PositionIdentifierKind.Local,
-                identifierLiteral: `y`,
-                maybeDefinitionPositionStart: {
+        describe("ParserContext", () => {
+            it(`let x = 1, y = 2 in x| *`, () => {
+                const text: string = `let x = 1, y = 2 in x *`;
+                const position: Inspection.Position = {
                     lineNumber: 0,
-                    lineCodeUnit: 15,
-                    codeUnit: 15,
-                },
-            };
-            expectParseOkPositionIdentifierEqual(text, position, expected);
+                    lineCodeUnit: 21,
+                };
+                const expected: TAbridgedPositionIdentifier = {
+                    kind: PositionIdentifierKind.Local,
+                    identifierLiteral: `x`,
+                    maybeDefinitionPositionStart: {
+                        lineNumber: 0,
+                        lineCodeUnit: 8,
+                        codeUnit: 8,
+                    },
+                };
+                expectParseErrPositionIdentifierEqual(text, position, expected);
+            });
+
+            it(`let x = 1 in [y = x|`, () => {
+                const text: string = `let x = 1 in [y = x|`;
+                const position: Inspection.Position = {
+                    lineNumber: 0,
+                    lineCodeUnit: 19,
+                };
+                const expected: TAbridgedPositionIdentifier = {
+                    kind: PositionIdentifierKind.Local,
+                    identifierLiteral: `x`,
+                    maybeDefinitionPositionStart: {
+                        lineNumber: 0,
+                        lineCodeUnit: 8,
+                        codeUnit: 8,
+                    },
+                };
+                expectParseErrPositionIdentifierEqual(text, position, expected);
+            });
         });
     });
 });

--- a/src/test/inspection/abridgedPositionIdentifier.ts
+++ b/src/test/inspection/abridgedPositionIdentifier.ts
@@ -157,7 +157,7 @@ describe(`Inspection`, () => {
                 const text: string = `let x = 1, y = 2 in x * y`;
                 const position: Inspection.Position = {
                     lineNumber: 0,
-                    lineCodeUnit: 24,
+                    lineCodeUnit: 25,
                 };
                 const expected: TAbridgedPositionIdentifier = {
                     kind: PositionIdentifierKind.Local,

--- a/src/test/inspection/common.ts
+++ b/src/test/inspection/common.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { Option, ResultKind } from "../../common";
+import { Lexer, LexerSnapshot, TriedLexerSnapshot } from "../../lexer";
+import { Parser, ParserError } from "../../parser";
+
+export function expectParseErr(text: string): ParserError.ParserError {
+    const triedParse: Parser.TriedParse = expectTriedParse(text);
+    if (!(triedParse.kind === ResultKind.Err)) {
+        throw new Error(`AssertFailed: triedParse.kind === ResultKind.Err`);
+    }
+
+    if (!(triedParse.error instanceof ParserError.ParserError)) {
+        throw new Error(`AssertFailed: triedParse.error instanceof ParserError: ${triedParse.error.message}`);
+    }
+
+    return triedParse.error;
+}
+
+export function expectParseOk(text: string): Parser.ParseOk {
+    const triedParse: Parser.TriedParse = expectTriedParse(text);
+    if (!(triedParse.kind === ResultKind.Ok)) {
+        throw new Error(`AssertFailed: triedParse.kind === ResultKind.Ok: ${triedParse.error.message}`);
+    }
+    return triedParse.value;
+}
+
+function expectTriedParse(text: string): Parser.TriedParse {
+    const state: Lexer.State = Lexer.stateFrom(text);
+    const maybeErrorLineMap: Option<Lexer.ErrorLineMap> = Lexer.maybeErrorLineMap(state);
+    if (!(maybeErrorLineMap === undefined)) {
+        throw new Error(`AssertFailed: maybeErrorLineMap === undefined`);
+    }
+
+    const triedSnapshot: TriedLexerSnapshot = LexerSnapshot.tryFrom(state);
+    if (!(triedSnapshot.kind === ResultKind.Ok)) {
+        throw new Error(`AssertFailed: triedSnapshot.kind === ResultKind.Ok: ${triedSnapshot.error.message}`);
+    }
+    const snapshot: LexerSnapshot = triedSnapshot.value;
+
+    return Parser.tryParse(snapshot);
+}


### PR DESCRIPTION
Adds a new field to Inspection, `maybePositionIdentifier`, which holds some metadata about the identifier at the inspection's position (if one exists).