### PR TITLE
Test against DataConnectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,12 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "12.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+      "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "devDependencies": {
         "@types/chai": "^4.1.7",
         "@types/mocha": "^5.2.5",
+        "@types/node": "^12.7.1",
         "chai": "^4.2.0",
         "mocha": "^5.2.0",
         "mocha-junit-reporter": "^1.22.0",

--- a/specification.md
+++ b/specification.md
@@ -4,6 +4,7 @@ There are a few differences between the [Power Query / M Language Specification]
 
 ## Where the Power Query parser differs from the specification
 
+* An additional primitive type named `#time` exists.
 * The `field-specification` construct requires an `identifier`. Instead `identifer` is replaced with `generalized-identifier`.
 * The `type` construct matches either `parenthesized-expression` or `primary-type`. Instead `parenthesized-expression` is replaced with `primary-expression`.
 * The `table-type` construct matches on `row-type`. An additional match of `primary-expression` is added on the following tokens: `@`, `identifier`, or `left-parenthesis`.

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -495,7 +495,7 @@ function tokenize(line: TLine, lineNumber: number): TLine {
     }
 
     const newTokens: LineToken[] = [];
-    let continueLexing: boolean = true;
+    let continueLexing: boolean = currentPosition !== text.length;
     let maybeError: Option<LexerError.TLexerError>;
 
     // While neither eof nor having encountered an error:

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -376,10 +376,6 @@ export class Parser {
 
     // 12.2.3.10 Primary expression
     private readPrimaryExpression(): Ast.TPrimaryExpression {
-        // I'd prefer to use a switch statement here but there's an issue with Typescript.
-        // Doing a switch on this.currentTokenKind makes all child expressions think it's constant,
-        // but it gets updated with readX calls.
-
         let primaryExpression: Option<Ast.TPrimaryExpression>;
         const maybeCurrentTokenKind: Option<TokenKind> = this.maybeCurrentTokenKind;
         const isIdentifierExpressionNext: boolean =
@@ -1439,7 +1435,11 @@ export class Parser {
         ];
         const maybeErr: Option<ParserError.ExpectedAnyTokenKindError> = this.expectAnyTokenKind(expectedTokenKinds);
         if (maybeErr) {
-            throw maybeErr;
+            const error: ParserError.ExpectedAnyTokenKindError = maybeErr;
+            return {
+                kind: ResultKind.Err,
+                error,
+            };
         }
 
         let primitiveType: Ast.Constant;
@@ -2242,12 +2242,12 @@ export function tryParse(lexerSnapshot: LexerSnapshot): TriedParse {
 
 type TriedReadPrimaryType = Result<
     Ast.TPrimaryType,
-    ParserError.InvalidPrimitiveTypeError | CommonError.InvariantError
+    ParserError.ExpectedAnyTokenKindError | ParserError.InvalidPrimitiveTypeError | CommonError.InvariantError
 >;
 
 type TriedReadPrimitiveType = Result<
     Ast.PrimitiveType,
-    ParserError.InvalidPrimitiveTypeError | CommonError.InvariantError
+    ParserError.ExpectedAnyTokenKindError | ParserError.InvalidPrimitiveTypeError | CommonError.InvariantError
 >;
 
 const enum ParenthesisDisambiguation {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1461,6 +1461,7 @@ export class Parser {
                 case Ast.IdentifierConstant.Record:
                 case Ast.IdentifierConstant.Table:
                 case Ast.IdentifierConstant.Text:
+                case Ast.IdentifierConstant.Time:
                     primitiveType = this.readIdentifierConstantAsConstant(currentTokenData);
                     break;
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -421,8 +421,13 @@ export class Parser {
                     primaryExpression = this.readNotImplementedExpression();
                     break;
 
+                case TokenKind.KeywordHashSections:
+                    primaryExpression = this.readKeyword();
+                    break;
+
                 case TokenKind.KeywordHashShared:
-                    throw new CommonError.NotYetImplementedError("todo");
+                    primaryExpression = this.readKeyword();
+                    break;
 
                 case TokenKind.KeywordHashBinary:
                     primaryExpression = this.readKeyword();
@@ -1648,6 +1653,9 @@ export class Parser {
     private readKeyword(): Ast.IdentifierExpression {
         const identifierExpressionNodeKind: Ast.NodeKind.IdentifierExpression = Ast.NodeKind.IdentifierExpression;
         this.startContext(identifierExpressionNodeKind);
+
+        // Keywords can't have a "@" prefix constant
+        this.incrementAttributeCounter();
 
         const identifierNodeKind: Ast.NodeKind.Identifier = Ast.NodeKind.Identifier;
         this.startContext(identifierNodeKind);

--- a/src/test/lexer/simple.ts
+++ b/src/test/lexer/simple.ts
@@ -193,6 +193,12 @@ type
 });
 
 describe(`Lexer.Simple.Whitespace`, () => {
+    it(`only whitespace`, () => {
+        const text: string = `  `;
+        const expected: ReadonlyArray<[TokenKind, string]> = [];
+        expectSnapshotAbridgedTokens(text, expected, true);
+    });
+
     it(`spaces`, () => {
         const text: string = ` a b `;
         const expected: ReadonlyArray<[TokenKind, string]> = [[TokenKind.Identifier, `a`], [TokenKind.Identifier, `b`]];

--- a/src/test/parser/files.ts
+++ b/src/test/parser/files.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import { ResultKind } from "../../common";
 import { TriedLexAndParse, tryLexAndParse } from "../../jobs";
 
-const PowerQueryExtensions: ReadonlyArray<string> = [".m", ".pq", ".mout"];
+const PowerQueryExtensions: ReadonlyArray<string> = [".m", ".mout", ".pq", "pqm"];
 
 function isDirectory(maybePath: string): boolean {
     return statSync(maybePath).isDirectory();

--- a/src/test/parser/files.ts
+++ b/src/test/parser/files.ts
@@ -55,8 +55,12 @@ describe("files", () => {
     const fileDirectory: string = path.join(path.dirname(__filename), "files");
 
     for (const filepath of getPowerQueryFilesRecursively(fileDirectory)) {
-        it(testNameFromFilePath(filepath), () => {
-            const contents: string = readFileSync(filepath, "utf8");
+        const testName: string = testNameFromFilePath(filepath);
+
+        it(testName, () => {
+            let contents: string = readFileSync(filepath, "utf8");
+            contents = contents.replace(/^\uFEFF/, "");
+
             const triedLexAndParse: TriedLexAndParse = tryLexAndParse(contents);
             if (!(triedLexAndParse.kind === ResultKind.Ok)) {
                 throw triedLexAndParse.error;

--- a/src/test/parser/files.ts
+++ b/src/test/parser/files.ts
@@ -1,0 +1,66 @@
+import { readdirSync, readFileSync, statSync } from "fs";
+import "mocha";
+import * as path from "path";
+import { ResultKind } from "../../common";
+import { TriedLexAndParse, tryLexAndParse } from "../../jobs";
+
+const PowerQueryExtensions: ReadonlyArray<string> = [".m", ".pq", ".mout"];
+
+function isDirectory(maybePath: string): boolean {
+    return statSync(maybePath).isDirectory();
+}
+
+function isFile(filepath: string): boolean {
+    return statSync(filepath).isFile();
+}
+
+function isPowerQueryFile(filepath: string): boolean {
+    return isFile && isPowerQueryExtension(path.extname(filepath));
+}
+
+function isPowerQueryExtension(extension: string): boolean {
+    return PowerQueryExtensions.indexOf(extension) !== -1;
+}
+
+function getDirectoryPaths(filePath: string): ReadonlyArray<string> {
+    return readdirSync(filePath)
+        .map(name => path.join(filePath, name))
+        .filter(isDirectory);
+}
+
+function getPowerQueryFilePaths(filepath: string): ReadonlyArray<string> {
+    return readdirSync(filepath)
+        .map(name => path.join(filepath, name))
+        .filter(isPowerQueryFile);
+}
+
+function getPowerQueryFilesRecursively(filepath: string): ReadonlyArray<string> {
+    const dirs: ReadonlyArray<string> = getDirectoryPaths(filepath);
+    let files: ReadonlyArray<String> = dirs
+        .map(getPowerQueryFilesRecursively) // go through each directory
+        .reduce((a, b) => a.concat(b), []); // map returns a 2d array (array of file arrays) so flatten
+
+    // Get files in root folder
+    files = files.concat(getPowerQueryFilePaths(filepath));
+
+    // String -> string
+    return files.map(str => str.toString());
+}
+
+function testNameFromFilePath(filepath: string): string {
+    return filepath.replace(path.dirname(__filename), ".");
+}
+
+describe("files", () => {
+    const fileDirectory: string = path.join(path.dirname(__filename), "files");
+
+    for (const filepath of getPowerQueryFilesRecursively(fileDirectory)) {
+        it(testNameFromFilePath(filepath), () => {
+            const contents: string = readFileSync(filepath, "utf8");
+            const triedLexAndParse: TriedLexAndParse = tryLexAndParse(contents);
+            if (!(triedLexAndParse.kind === ResultKind.Ok)) {
+                throw triedLexAndParse.error;
+            }
+        });
+    }
+});

--- a/src/test/parser/files/microsoft-DataConnectors/DataWorldSwagger/DataWorldSwagger.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/DataWorldSwagger/DataWorldSwagger.pq
@@ -1,0 +1,88 @@
+﻿// This file contains your Data Connector logic
+section DataWorldSwagger;
+
+// TODO: add your client id and secret to the embedded files
+client_id = Text.FromBinary(Extension.Contents("client_id"));
+client_secret = Text.FromBinary(Extension.Contents("client_secret"));
+
+redirect_uri = "https://oauth.powerbi.com/views/oauthredirect.html";
+windowWidth = 800;
+windowHeight = 800;
+
+BaseUrl = "https://api.data.world/v0";
+OAuthBaseUrl = "https://data.world/oauth";
+
+[DataSource.Kind="DataWorldSwagger", Publish="DataWorldSwagger.Publish"]
+shared DataWorldSwagger.Contents = () =>
+    let
+        credential = Extension.CurrentCredential(),
+        token = if (credential[AuthenticationKind] = "Key") then credential[Key] else credential[access_token],        
+        headers = [ Authorization = "Bearer " & token ],
+        navTable = OpenApi.Document(Web.Contents("https://api.data.world/v0/swagger.json"), [ Headers = headers, ManualCredentials = true ])
+    in
+        navTable;
+
+// Data Source Kind description
+DataWorldSwagger = [
+    // enable both OAuth and Key based auth
+    Authentication = [
+        OAuth = [
+            StartLogin = StartLogin,
+            FinishLogin = FinishLogin,
+            Refresh=Refresh
+        ],
+        Key = [
+        ]
+    ],
+    Label = Extension.LoadString("DataSourceLabel")
+];
+
+// Data Source UI publishing description
+DataWorldSwagger.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { Extension.LoadString("ButtonTitle"), Extension.LoadString("ButtonHelp") },
+    LearnMoreUrl = "https://data.world/"
+];
+
+//
+// OAuth2 flow definition
+//
+
+StartLogin = (resourceUrl, state, display) =>
+    let
+        AuthorizeUrl = OAuthBaseUrl & "/authorize?" & Uri.BuildQueryString([
+            client_id = client_id,
+            response_type = "code",
+            state = state,
+            redirect_uri = redirect_uri])
+    in
+        [
+            LoginUri = AuthorizeUrl,
+            CallbackUri = redirect_uri,
+            WindowHeight = windowHeight,
+            WindowWidth = windowWidth,
+            Context = null
+        ];
+
+FinishLogin = (context, callbackUri, state) =>
+    let
+        Parts = Uri.Parts(callbackUri)[Query]
+    in
+        TokenMethod(Parts[code], "authorization_code");
+
+TokenMethod = (code, grant_type) =>
+    let
+        Response = Web.Contents(OAuthBaseUrl & "/access_token", [
+            Content = Text.ToBinary(Uri.BuildQueryString([
+                client_id = client_id,
+                client_secret = client_secret,
+                code = code,
+                grant_type = grant_type,
+                redirect_uri = redirect_uri])),
+            Headers=[#"Content-type" = "application/x-www-form-urlencoded",#"Accept" = "application/json"]]),
+        Parts = Json.Document(Response)
+    in
+        Parts;
+
+Refresh = (resourceUrl, refresh_token) => TokenMethod(refresh_token, "refresh_token");

--- a/src/test/parser/files/microsoft-DataConnectors/DataWorldSwagger/DataWorldSwagger.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/DataWorldSwagger/DataWorldSwagger.query.pq
@@ -1,0 +1,5 @@
+﻿// Use this file to write queries to test your data connector
+let
+    result = DataWorldSwagger.Contents()
+in
+    result

--- a/src/test/parser/files/microsoft-DataConnectors/DirectQueryForSQL/DirectQueryForSQL.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/DirectQueryForSQL/DirectQueryForSQL.pq
@@ -1,0 +1,104 @@
+﻿section DirectSQL;
+
+[DataSource.Kind="DirectSQL", Publish="DirectSQL.UI"]
+shared DirectSQL.Database = (server as text, database as text) as table =>
+    let
+        // This record contains all of the connection string properties we 
+        // will set for this ODBC driver. The 'Driver' field is required for 
+        // all ODBC connections. Other properties will vary between ODBC drivers,
+        // but generally take Server and Database properties. Note that
+        // credential related properties will be set separately. 
+        ConnectionString =
+        [
+            Driver = "SQL Server Native Client 11.0",
+            Server = server,
+            Database = database
+        ],
+        // Get the current credential, and check what type of authentication we're using
+        Credential = Extension.CurrentCredential(),
+        // Credentials are passed to the ODBC driver using the CredentialConnectionString field.
+        // If the user has selected SQL auth (i.e. UsernamePassword), we'll set the 
+        // UID and PWD connection string properties. This should be standard across ODBC drivers.
+        // If the user has selected Windows auth, we'll set the Trusted_Connection property. 
+        // Trusted_Connection is specific to the SQL Server Native Client ODBC driver.
+        // Other drivers might require additional connection string properties to be set.
+        CredentialConnectionString =
+            if (Credential[AuthenticationKind]?) = "UsernamePassword" then 
+                [ UID = Credential[Username], PWD = Credential[Password] ]
+            else if (Credential[AuthenticationKind]?) = "Windows" then
+                [ Trusted_Connection="Yes" ]
+            // unknown authentication kind - return an 'unimplemented' error
+            else
+                ..., 
+        // Here our connector is wrapping M's Odbc.DataSource() function. 
+        //
+        // The first argument will be the connection string. It can be passed in as a record,
+        // or an actual text value. When using a record, M will ensure that the values will be 
+        // property encoded. 
+        // 
+        // The second argument is the options record which allows us to set the credential
+        // connection string properties, and override default behaviors.  
+        OdbcDataSource = Odbc.DataSource(ConnectionString, CredentialConnectionString & [
+            // Enables client side connection pooling for the ODBC driver.
+            // Most drivers will want to set this value to true.
+            ClientConnectionPooling = true,
+            // When HierarchialNavigation is set to true, the navigation tree
+            // will be organized by Database -> Schema -> Table. When set to false,
+            // all tables will be displayed in a flat list using fully qualified names. 
+            HierarchicalNavigation = true,
+            // Use the SqlCapabilities record to specify driver capabilities that are not
+            // discoverable through ODBC 3.8, and to override capabilities reported by
+            // the driver. 
+            SqlCapabilities = [
+                SupportsTop = true,
+                Sql92Conformance = 8 /* SQL_SC_SQL92_FULL */,
+                GroupByCapabilities = 4 /* SQL_GB_NO_RELATION */,
+                FractionalSecondsScale = 3
+            ],
+            SoftNumbers = true,
+            HideNativeQuery = true,
+            // Use the SQLGetInfo record to override values returned by the driver.
+            SQLGetInfo = [
+                SQL_SQL92_PREDICATES = 0x0000FFFF,
+                SQL_AGGREGATE_FUNCTIONS = 0xFF
+            ]
+        ]),
+        // The first level of the navigation table will be the name of the database the user
+        // passed in. Rather than repeating it again, we'll select it ({[Name = database]}) 
+        // and access the next level of the navigation table.
+        Database = OdbcDataSource{[Name = database]}[Data]
+    in
+        Database;
+
+// Data Source definition
+DirectSQL = [
+    TestConnection = (dataSourcePath) => 
+        let
+            json = Json.Document(dataSourcePath),
+            server = json[server],
+            database = json[database]
+        in
+            { "DirectSQL.Database", server, database }, 
+    Authentication = [
+        Windows = [],
+        UsernamePassword = []
+    ],
+    Label = "Direct Query for SQL",
+
+    // This sample doesn't enable the use of SSL.
+    SupportsEncryption = false
+];
+
+// UI Export definition
+DirectSQL.UI = [   
+    SupportsDirectQuery = true,     // enables direct query
+    Category = "Database",
+    ButtonText = { "Direct Query for SQL", "Direct Query via ODBC sample for SQL Server" },
+    SourceImage = DirectSQL.Icons,
+    SourceTypeImage = DirectSQL.Icons
+];
+
+DirectSQL.Icons = [
+    Icon16 = { Extension.Contents("DirectQueryForSQL16.png"), Extension.Contents("DirectQueryForSQL20.png"), Extension.Contents("DirectQueryForSQL24.png"), Extension.Contents("DirectQueryForSQL32.png") },
+    Icon32 = { Extension.Contents("DirectQueryForSQL32.png"), Extension.Contents("DirectQueryForSQL40.png"), Extension.Contents("DirectQueryForSQL48.png"), Extension.Contents("DirectQueryForSQL64.png") }
+];

--- a/src/test/parser/files/microsoft-DataConnectors/DirectQueryForSQL/DirectQueryForSQL.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/DirectQueryForSQL/DirectQueryForSQL.query.pq
@@ -1,0 +1,8 @@
+﻿//Use this file to write queries.
+let
+    Host = "localhost",
+    Database = "AdventureWorksDW2012",
+    Source = DirectSQL.Database(Host, Database),
+    dbo_Schema = Source{[Name="dbo",Kind="Schema"]}[Data]
+in
+    dbo_Schema

--- a/src/test/parser/files/microsoft-DataConnectors/Github/github.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/Github/github.pq
@@ -1,0 +1,185 @@
+﻿section GithubSample;
+
+//
+// OAuth configuration settings
+//
+// You MUST replace the values below for values for your own application.
+// Signin to GitHub and navigate to https://github.com/settings/applications/new.
+// Follow the steps and obtain your client_id and client_secret.
+// Set your Redirect URI value in your application registration to match the value below.
+// Update the values within the "client_id" and "client_secret" files in the project.
+// 
+// Note: due to incompatibilities with the Internet Explorer control used in Visual Studio,
+// you will not be able to authorize a new github application during the OAuth flow. You can workaround
+// this by loading your extension in Power BI Desktop, and completing the OAuth flow there. 
+// Once the application has been authorized for a given user, then the OAuth flow will work when 
+// run in Visual Studio.
+
+client_id = Text.FromBinary(Extension.Contents("client_id"));
+client_secret = Text.FromBinary(Extension.Contents("client_secret"));
+redirect_uri = "https://oauth.powerbi.com/views/oauthredirect.html";
+windowWidth = 1200;
+windowHeight = 1000;
+
+//
+// Exported functions
+//
+// These functions are exported to the M Engine (making them visible to end users), and associates 
+// them with the specified Data Source Kind. The Data Source Kind is used when determining which 
+// credentials to use during evaluation. Credential matching is done based on the function's parameters. 
+// All data source functions associated to the same Data Source Kind must have a matching set of required 
+// function parameters, including type, name, and the order in which they appear. 
+
+[DataSource.Kind="GithubSample", Publish="GithubSample.UI"]
+shared GithubSample.Contents = Value.ReplaceType(Github.Contents, type function (url as Uri.Type) as any);
+
+[DataSource.Kind="GithubSample"]
+shared GithubSample.PagedTable = Value.ReplaceType(Github.PagedTable, type function (url as Uri.Type) as nullable table);
+
+//
+// Data Source definition
+//
+GithubSample = [
+    TestConnection = (dataSourcePath) => {"GithubSample.Contents", dataSourcePath},
+    Authentication = [
+        OAuth = [
+            StartLogin = StartLogin,
+            FinishLogin = FinishLogin,
+            Label = Extension.LoadString("AuthenticationLabel")
+        ]
+    ]
+];
+
+//
+// UI Export definition
+//
+GithubSample.UI = [
+    Beta = true,
+    ButtonText = { Extension.LoadString("FormulaTitle"), Extension.LoadString("FormulaHelp") },
+    SourceImage = GithubSample.Icons,
+    SourceTypeImage = GithubSample.Icons
+];
+
+GithubSample.Icons = [
+    Icon16 = { Extension.Contents("github16.png"), Extension.Contents("github20.png"), Extension.Contents("github24.png"), Extension.Contents("github32.png") },
+    Icon32 = { Extension.Contents("github32.png"), Extension.Contents("github40.png"), Extension.Contents("github48.png"), Extension.Contents("github64.png") }
+];
+
+//
+// Github.Contents - retrieves a single page of data from github and sets a 
+// Next link value as meta on the returned json response. We parse the json
+// result (which will be a list of records) into a table.
+//
+Github.Contents = (url as text) =>
+    let
+        content = Web.Contents(url),
+        link = GetNextLink(content),
+        json = Json.Document(content),
+        table = Table.FromList(json, Splitter.SplitByNothing())
+    in
+        table meta [Next=link];
+
+Github.PagedTable = (url as text) => Table.GenerateByPage((previous) =>
+    let
+        // If we have a previous page, get its Next link from metadata on the page.
+        next = if (previous <> null) then Value.Metadata(previous)[Next] else null,
+        // If we have a next link, use it, otherwise use the original URL that was passed in.
+        urlToUse = if (next <> null) then next else url,
+        // If we have a previous page, but don't have a next link, then we're done paging.
+        // Otherwise retrieve the next page.
+        current = if (previous <> null and next = null) then null else Github.Contents(urlToUse),
+        // If we got data back from the current page, get the link for the next page
+        link = if (current <> null) then Value.Metadata(current)[Next] else null
+    in
+        current meta [Next=link]);
+
+// This function returns an absolute URL to the next page of data.
+// 
+// The 'response' parameter typically contains the result of the call to Web.Contents. 
+// The 'request' parameter is optional and contains values to formulate the request.
+// It is typically used when the next link is a relative URL and needs to be 
+// appended to a base URL from the request. Its format is up to the extension author. 
+//
+// The current implementation is specific to Github, which returns its next link 
+// in a "Link" header in the response. The 'request' parameter is not used.
+// You will most likely need to replace the logic below with whatever paging
+// mechanism is used by your data source.
+//
+GetNextLink = (response, optional request) =>
+    let
+        // extract the "Link" header if it exists
+        link = Value.Metadata(response)[Headers][#"Link"]?,
+        links = Text.Split(link, ","),
+        splitLinks = List.Transform(links, each Text.Split(Text.Trim(_), ";")),
+        next = List.Select(splitLinks, each Text.Trim(_{1}) = "rel=""next"""),
+        first = List.First(next),
+        removedBrackets = Text.Range(first{0}, 1, Text.Length(first{0}) - 2)
+    in
+        try removedBrackets otherwise null;
+
+//
+// OAuth2 flow definition
+//
+
+StartLogin = (resourceUrl, state, display) =>
+    let
+        AuthorizeUrl = "https://github.com/login/oauth/authorize?" & Uri.BuildQueryString([
+            client_id = client_id,
+            scope = "user, repo",
+            state = state,
+            redirect_uri = redirect_uri])
+    in
+        [
+            LoginUri = AuthorizeUrl,
+            CallbackUri = redirect_uri,
+            WindowHeight = windowHeight,
+            WindowWidth = windowWidth,
+            Context = null
+        ];
+
+FinishLogin = (context, callbackUri, state) =>
+    let
+        Parts = Uri.Parts(callbackUri)[Query]
+    in
+        TokenMethod(Parts[code]);
+
+TokenMethod = (code) =>
+    let
+        Response = Web.Contents("https://github.com/login/oauth/access_token", [
+            Content = Text.ToBinary(Uri.BuildQueryString([
+                client_id = client_id,
+                client_secret = client_secret,
+                code = code,
+                redirect_uri = redirect_uri])),
+            Headers=[#"Content-type" = "application/x-www-form-urlencoded",#"Accept" = "application/json"]]),
+        Parts = Json.Document(Response)
+    in
+        Parts;
+
+//
+// Common code
+//
+
+// Calls the getNextPage function until it returns null. 
+// Each call to getNextPage expects a table of data to be returned.
+// The result of the previous call to getNextPage is passed along to the next call.
+// Appends all pages (tables) together into a single result.
+// Returns an empty table if the first call to getNextPage returns null.
+Table.GenerateByPage = (getNextPage as function) as table =>
+    let
+        listOfPages = List.Generate(
+            () => getNextPage(null),
+            (lastPage) => lastPage <> null,
+            (lastPage) => getNextPage(lastPage)
+        ),
+        tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
+        firstRow = tableOfPages{0}?
+    in
+        if (firstRow = null) then
+            Table.FromRows({})
+        else
+            Value.ReplaceType(
+                Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
+                Value.Type(firstRow[Column1])
+            );
+

--- a/src/test/parser/files/microsoft-DataConnectors/Github/github.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/Github/github.query.pq
@@ -1,0 +1,5 @@
+﻿// This is where you can write sample queries to test your extension.
+let
+    source = GithubSample.Contents("https://api.github.com/")
+in
+    source

--- a/src/test/parser/files/microsoft-DataConnectors/HelloWorld/HelloWorld.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/HelloWorld/HelloWorld.pq
@@ -1,0 +1,28 @@
+﻿section HelloWorld;
+
+[DataSource.Kind="HelloWorld", Publish="HelloWorld.Publish"]
+shared HelloWorld.Contents = (optional message as text) =>
+    let
+        message = if (message <> null) then message else "Hello world"
+    in
+        message;
+
+HelloWorld = [
+    TestConnection = (dataSourcePath) => {"HelloWorld.Contents"},
+    Authentication = [
+        Anonymous = []
+    ],
+    Label = Extension.LoadString("DataSourceLabel")
+];
+
+HelloWorld.Publish = [
+    Beta = true,
+    ButtonText = { Extension.LoadString("FormulaTitle"), Extension.LoadString("FormulaHelp") },
+    SourceImage = HelloWorld.Icons,
+    SourceTypeImage = HelloWorld.Icons
+];
+
+HelloWorld.Icons = [
+    Icon16 = { Extension.Contents("HelloWorld16.png"), Extension.Contents("HelloWorld20.png"), Extension.Contents("HelloWorld24.png"), Extension.Contents("HelloWorld32.png") },
+    Icon32 = { Extension.Contents("HelloWorld32.png"), Extension.Contents("HelloWorld40.png"), Extension.Contents("HelloWorld48.png"), Extension.Contents("HelloWorld64.png") }
+];

--- a/src/test/parser/files/microsoft-DataConnectors/HelloWorld/HelloWorld.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/HelloWorld/HelloWorld.query.pq
@@ -1,0 +1,2 @@
+﻿//Use this file to write queries.
+HelloWorld.Contents("hello this is my message")

--- a/src/test/parser/files/microsoft-DataConnectors/HelloWorldWithDocs/HelloWorldWithDocs.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/HelloWorldWithDocs/HelloWorldWithDocs.pq
@@ -1,0 +1,52 @@
+﻿section HelloWorldWithDocs;
+
+[DataSource.Kind="HelloWorldWithDocs", Publish="HelloWorldWithDocs.Publish"]
+shared HelloWorldWithDocs.Contents = Value.ReplaceType(HelloWorldImpl, HelloWorldType);
+
+HelloWorldType = type function (
+    message as (type text meta [
+        Documentation.FieldCaption = "Message",
+        Documentation.FieldDescription = "Text to display",
+        Documentation.SampleValues = {"Hello world", "Hola mundo"}
+    ]),
+    optional count as (type number meta [
+        Documentation.FieldCaption = "Count",
+        Documentation.FieldDescription = "Number of times to repeat the message",
+        Documentation.AllowedValues = { 1, 2, 3 }
+    ]))
+    as table meta [
+        Documentation.Name = "Hello - Name",
+        Documentation.LongDescription = "Hello - Long Description",
+        Documentation.Examples = {[
+            Description = "Returns a table with 'Hello world' repeated 2 times",
+            Code = "HelloWorldWithDocs.Contents(""Hello world"", 2)",
+            Result = "#table({""Column1""}, {{""Hello world""}, {""Hello world""}})"
+        ],[
+            Description = "Another example, new message, new count!",
+            Code = "HelloWorldWithDocs.Contents(""Goodbye"", 1)",
+            Result = "#table({""Column1""}, {{""Goodbye""}})"
+        ]}
+    ];
+
+HelloWorldImpl = (message as text, optional count as number) as table =>
+    let
+        _count = if (count <> null) then count else 5,
+        listOfMessages = List.Repeat({message}, _count),
+        table = Table.FromList(listOfMessages, Splitter.SplitByNothing())
+    in
+        table;
+
+// Data Source Kind description
+HelloWorldWithDocs = [
+    Authentication = [
+        Anonymous = []
+    ]//,
+    //Label = "Hello World With Docs"
+];
+
+// Data Source UI publishing description
+HelloWorldWithDocs.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "Hello World With Docs", "Provides an example of how to provide function documentation" }
+];

--- a/src/test/parser/files/microsoft-DataConnectors/HelloWorldWithDocs/HelloWorldWithDocs.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/HelloWorldWithDocs/HelloWorldWithDocs.query.pq
@@ -1,0 +1,5 @@
+﻿// Use this file to write queries to test your data connector
+let
+    result = HelloWorldWithDocs.Contents("Hello world", 2)
+in
+    result

--- a/src/test/parser/files/microsoft-DataConnectors/MyGraph/MyGraph.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/MyGraph/MyGraph.pq
@@ -1,0 +1,196 @@
+﻿section MyGraph;
+
+//
+// OAuth configuration settings
+//
+
+// TODO: set AAD client ID value in the client_id file
+client_id = Text.FromBinary(Extension.Contents("client_id")); 
+redirect_uri = "https://oauth.powerbi.com/views/oauthredirect.html";
+token_uri = "https://login.microsoftonline.com/organizations/oauth2/v2.0/token";
+authorize_uri = "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize";
+logout_uri = "https://login.microsoftonline.com/logout.srf";
+
+windowWidth = 720;
+windowHeight = 1024;
+
+// See https://developer.microsoft.com/en-us/graph/docs/authorization/permission_scopes 
+scope_prefix = "https://graph.microsoft.com/";
+scopes = {
+    "User.ReadWrite",
+    "Contacts.Read",
+    "User.ReadBasic.All",
+    "Calendars.ReadWrite",
+    "Mail.ReadWrite",
+    "Mail.Send",
+    "Contacts.ReadWrite",
+    "Files.ReadWrite",
+    "Tasks.ReadWrite",
+    "People.Read",
+    "Notes.ReadWrite.All",
+    "Sites.Read.All"
+};
+
+//
+// Exported function(s)
+//
+[DataSource.Kind="MyGraph", Publish="MyGraph.UI"]
+shared MyGraph.Feed = () =>
+    let
+        source = OData.Feed("https://graph.microsoft.com/v1.0/me/", null, [ ODataVersion = 4, MoreColumns = true ])
+    in
+        source;
+
+//
+// Data Source definition
+//
+MyGraph = [
+    TestConnection = (dataSourcePath) => { "MyGraph.Feed" },
+    Authentication = [
+        OAuth = [
+            StartLogin=StartLogin,
+            FinishLogin=FinishLogin,
+            Refresh=Refresh,
+            Logout=Logout
+        ]
+    ],
+    Label = "My Graph Connector"
+];
+
+//
+// UI Export definition
+//
+MyGraph.UI = [
+    Beta = true,
+    ButtonText = { "MyGraph.Feed", "Connect to Graph" },
+    SourceImage = MyGraph.Icons,
+    SourceTypeImage = MyGraph.Icons
+];
+
+MyGraph.Icons = [
+    Icon16 = { Extension.Contents("MyGraph16.png"), Extension.Contents("MyGraph20.png"), Extension.Contents("MyGraph24.png"), Extension.Contents("MyGraph32.png") },
+    Icon32 = { Extension.Contents("MyGraph32.png"), Extension.Contents("MyGraph40.png"), Extension.Contents("MyGraph48.png"), Extension.Contents("MyGraph64.png") }
+];
+
+//
+// OAuth implementation
+//
+// See the following links for more details on AAD/Graph OAuth:
+// * https://docs.microsoft.com/en-us/azure/active-directory/active-directory-protocols-oauth-code 
+// * https://graph.microsoft.io/en-us/docs/authorization/app_authorization
+//
+// StartLogin builds a record containing the information needed for the client
+// to initiate an OAuth flow. Note for the AAD flow, the display parameter is
+// not used.
+//
+// resourceUrl: Derived from the required arguments to the data source function
+//              and is used when the OAuth flow requires a specific resource to 
+//              be passed in, or the authorization URL is calculated (i.e. when
+//              the tenant name/ID is included in the URL). In this example, we
+//              are hardcoding the use of the "common" tenant, as specified by
+//              the 'authorize_uri' variable.
+// state:       Client state value we pass through to the service.
+// display:     Used by certain OAuth services to display information to the
+//              user.
+//
+// Returns a record containing the following fields:
+// LoginUri:     The full URI to use to initiate the OAuth flow dialog.
+// CallbackUri:  The return_uri value. The client will consider the OAuth
+//               flow complete when it receives a redirect to this URI. This
+//               generally needs to match the return_uri value that was
+//               registered for your application/client. 
+// WindowHeight: Suggested OAuth window height (in pixels).
+// WindowWidth:  Suggested OAuth window width (in pixels).
+// Context:      Optional context value that will be passed in to the FinishLogin
+//               function once the redirect_uri is reached. 
+//
+StartLogin = (resourceUrl, state, display) =>
+    let
+        authorizeUrl = authorize_uri & "?" & Uri.BuildQueryString([
+            client_id = client_id,  
+            redirect_uri = redirect_uri,
+            state = state,
+            scope = GetScopeString(scopes, scope_prefix),
+            response_type = "code",
+            response_mode = "query",
+            login = "login"
+        ])
+    in
+        [
+            LoginUri = authorizeUrl,
+            CallbackUri = redirect_uri,
+            WindowHeight = 720,
+            WindowWidth = 1024,
+            Context = null
+        ];
+
+// FinishLogin is called when the OAuth flow reaches the specified redirect_uri. 
+// Note for the AAD flow, the context and state parameters are not used. 
+//
+// context:     The value of the Context field returned by StartLogin. Use this to 
+//              pass along information derived during the StartLogin call (such as
+//              tenant ID)
+// callbackUri: The callbackUri containing the authorization_code from the service.
+// state:       State information that was specified during the call to StartLogin. 
+FinishLogin = (context, callbackUri, state) =>
+    let
+        // parse the full callbackUri, and extract the Query string
+        parts = Uri.Parts(callbackUri)[Query],
+        // if the query string contains an "error" field, raise an error
+        // otherwise call TokenMethod to exchange our code for an access_token
+        result = if (Record.HasFields(parts, {"error", "error_description"})) then 
+                    error Error.Record(parts[error], parts[error_description], parts)
+                 else
+                    TokenMethod("authorization_code", "code", parts[code])
+    in
+        result;
+
+// Called when the access_token has expired, and a refresh_token is available.
+// 
+Refresh = (resourceUrl, refresh_token) => TokenMethod("refresh_token", "refresh_token", refresh_token);
+
+Logout = (token) => logout_uri;
+
+
+// grantType:  Maps to the "grant_type" query parameter.
+// tokenField: The name of the query parameter to pass in the code.
+// code:       Is the actual code (authorization_code or refresh_token) to send to the service.
+TokenMethod = (grantType, tokenField, code) =>
+    let
+        queryString = [
+            client_id = client_id,
+            scope = GetScopeString(scopes, scope_prefix),
+            grant_type = grantType,
+            redirect_uri = redirect_uri
+        ],
+        queryWithCode = Record.AddField(queryString, tokenField, code),
+
+        tokenResponse = Web.Contents(token_uri, [
+            Content = Text.ToBinary(Uri.BuildQueryString(queryWithCode)),
+            Headers = [
+                #"Content-type" = "application/x-www-form-urlencoded",
+                #"Accept" = "application/json"
+            ],
+            ManualStatusHandling = {400} 
+        ]),
+        body = Json.Document(tokenResponse),
+        result = if (Record.HasFields(body, {"error", "error_description"})) then 
+                    error Error.Record(body[error], body[error_description], body)
+                 else
+                    body
+    in
+        result;
+
+//
+// Helper Functions
+//
+Value.IfNull = (a, b) => if a <> null then a else b;
+
+GetScopeString = (scopes as list, optional scopePrefix as text) as text =>
+    let
+        prefix = Value.IfNull(scopePrefix, ""),
+        addPrefix = List.Transform(scopes, each prefix & _),
+        asText = Text.Combine(addPrefix, " ")
+    in
+        asText;
+

--- a/src/test/parser/files/microsoft-DataConnectors/MyGraph/MyGraph.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/MyGraph/MyGraph.query.pq
@@ -1,0 +1,2 @@
+﻿
+MyGraph.Feed()

--- a/src/test/parser/files/microsoft-DataConnectors/NavigationTable/NavigationTable.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/NavigationTable/NavigationTable.pq
@@ -1,0 +1,135 @@
+﻿// This file contains your Data Connector logic
+section NavigationTable;
+
+[DataSource.Kind="NavigationTable", Publish="NavigationTable.Publish"]
+shared NavigationTable.Simple = () as table =>
+    let
+        objects = #table(
+            {"Name",       "Key",        "Data",                           "ItemKind", "ItemName", "IsLeaf"},{
+            {"Item1",      "item1",      #table({"Column1"}, {{"Item1"}}), "Table",    "Table",    true},
+            {"Item2",      "item2",      #table({"Column1"}, {{"Item2"}}), "Table",    "Table",    true},
+            {"Item3",      "item3",      FunctionCallThatReturnsATable(),  "Table",    "Table",    true},            
+            {"MyFunction", "myfunction", AnotherFunction.Contents(),       "Function", "Function", true}
+        }),
+        NavTable = Table.ToNavigationTable(objects, {"Key"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        NavTable;
+
+[DataSource.Kind="NavigationTable", Publish="NavigationTable.Publish2"]
+shared NavigationTable.Nested = () as table =>
+    let
+        objects = #table(
+            {"Name",       "Key",  "Data",                "ItemKind", "ItemName", "IsLeaf"},{
+            {"Nested A",   "n1",   CreateNavTable("AAA"), "Database",    "Database",    false},
+            {"Nested B",   "n2",   CreateNavTable("BBB"), "Folder",    "Folder",    false},
+            {"Nested C",   "n3",   CreateNavTable("CCC"), "Sheet",    "Sheet",    false}
+        }),
+        NavTable = Table.ToNavigationTable(objects, {"Key"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        NavTable;
+
+[DataSource.Kind="NavigationTable", Publish="NavigationTable.Publish3"]
+shared NavigationTable.Icons = () as table =>
+    let
+        // Dynamically builds a navigation table that uses all possible item kind icons
+        itemKinds = {
+            "Feed",
+            "Cube",
+            "CubeDatabase",
+            "CubeView",
+            "CubeViewFolder",
+            "Database",
+            "DatabaseServer",
+            "Dimension",
+            "Table",
+            "Folder",
+            "View",
+            "Sheet",
+            "Subcube",
+            "DefinedName",
+            "Record",
+            "Function"
+        },
+
+        asTable = Table.FromList(itemKinds, Splitter.SplitByNothing()),
+        rename = Table.RenameColumns(asTable, {{"Column1", "Name"}}),
+        // Add Data as a calculated column
+        withData = Table.AddColumn(rename, "Data", each CreateNavTable([Name]), type table),
+        // Add ItemKind and ItemName as fixed text values
+        withItemKind = Table.AddColumn(withData, "ItemKind", each [Name], type text),
+        withItemName = Table.AddColumn(withItemKind, "ItemName", each [Name], type text),
+        // Indicate that the node should not be expandable
+        withIsLeaf = Table.AddColumn(withItemName, "IsLeaf", each false, type logical),
+        // Generate the nav table
+        navTable = Table.ToNavigationTable(withIsLeaf, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        navTable;
+
+// Data Source Kind description
+NavigationTable = [
+    Authentication = [
+        Implicit = []
+    ],
+    Label = "Navigation Table Sample"
+];
+
+// Data Source UI publishing description
+NavigationTable.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "NavTable Simple", "NavTable Simple" }
+];
+
+// Data Source UI publishing description
+NavigationTable.Publish2 = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "NavTable Nested", "NavTable Nested" }
+];
+
+// Data Source UI publishing description
+NavigationTable.Publish3 = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "NavTable Icons", "NavTable Icons" }
+];
+
+// Implementation functions
+FunctionCallThatReturnsATable = () as table => #table({"DynamicColumn"}, {{"Dynamic Value"}});
+AnotherFunction.Contents = () => "Returns a static string when invoked.";
+
+CreateNavTable = (message as text) as table => 
+    let
+        objects = #table(
+            {"Name",  "Key",   "Data",                           "ItemKind", "ItemName", "IsLeaf"},{
+            {"Item1", "item1", #table({"Column1"}, {{message}}), "Table",    "Table",    true},
+            {"Item2", "item2", #table({"Column1"}, {{message}}), "Table",    "Table",    true}
+        }),
+        NavTable = Table.ToNavigationTable(objects, {"Key"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        NavTable;
+
+// Common library code
+
+Table.ToNavigationTable = (
+    table as table,
+    keyColumns as list,
+    nameColumn as text,
+    dataColumn as text,
+    itemKindColumn as text,
+    itemNameColumn as text,
+    isLeafColumn as text
+) as table =>
+    let
+        tableType = Value.Type(table),
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
+        [
+            NavigationTable.NameColumn = nameColumn, 
+            NavigationTable.DataColumn = dataColumn,
+            NavigationTable.ItemKindColumn = itemKindColumn, 
+            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.IsLeafColumn = isLeafColumn
+        ],
+        navigationTable = Value.ReplaceType(table, newTableType)
+    in
+        navigationTable;

--- a/src/test/parser/files/microsoft-DataConnectors/NavigationTable/NavigationTable.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/NavigationTable/NavigationTable.query.pq
@@ -1,0 +1,5 @@
+﻿// Use this file to write queries to test your data connector
+let
+    result = NavigationTable.Icons()
+in
+    result

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/HiveSample/Diagnostics.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/HiveSample/Diagnostics.pqm
@@ -1,0 +1,275 @@
+﻿let
+    Diagnostics.LogValue = (prefix, value) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogFailure = (text, function) =>
+        let
+            result = try function()
+        in
+            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
+
+    Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
+        Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
+
+    Diagnostics.WrapHandlers = (handlers as record) as record =>
+        Record.FromList(
+            List.Transform(
+                Record.FieldNames(handlers),
+                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
+            Record.FieldNames(handlers)),
+
+    Diagnostics.ValueToText = (value) =>
+        let
+            _canBeIdentifier = (x) =>
+                                            let
+                                                keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                                charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                                charDigit = (c as number) => c>= 48 and c <= 57
+                                            in
+                                                try
+                                                    charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                    and
+                                                        List.MatchesAll(
+                                                            Text.ToList(x),
+                                                            (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                        )
+                                                    and not 
+                                                        List.MatchesAny( keywords, (li)=> li=x )
+                                                otherwise 
+                                                    false,
+    
+            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+            Serialize.Date =        (x) => "#date(" & 
+                                           Text.From(Date.Year(x))  & ", " & 
+                                           Text.From(Date.Month(x)) & ", " & 
+                                           Text.From(Date.Day(x))   & ") ",
+
+            Serialize.Datetime =    (x) => "#datetime(" &
+                                           Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                           Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                           Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                           Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                           Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                           Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+            Serialize.Datetimezone =(x) => let 
+                                              dtz = DateTimeZone.ToRecord(x) 
+                                           in
+                                              "#datetimezone(" & 
+                                              Text.From(dtz[Year])        & ", " &
+                                              Text.From(dtz[Month])       & ", " &
+                                              Text.From(dtz[Day])         & ", " &
+                                              Text.From(dtz[Hour])        & ", " &
+                                              Text.From(dtz[Minute])      & ", " &
+                                              Text.From(dtz[Second])      & ", " &
+                                              Text.From(dtz[ZoneHours])   & ", " &
+                                              Text.From(dtz[ZoneMinutes]) & ") ",
+
+            Serialize.Duration =    (x) => let
+                                              dur = Duration.ToRecord(x)
+                                           in
+                                              "#duration(" &
+                                              Text.From(dur[Days])    & ", " &
+                                              Text.From(dur[Hours])   & ", " &
+                                              Text.From(dur[Minutes]) & ", " &
+                                              Text.From(dur[Seconds]) & ") ",
+
+            Serialize.Function =    (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(Value.Type(x)),
+                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                           " as " &
+                                           _serialize_function_return_type(Value.Type(x)) &
+                                           " => (...) ",
+
+            Serialize.List =        (x) => "{" & 
+                                           List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                           "} ",
+
+            Serialize.Logical =     (x) => Text.From(x),
+
+            Serialize.Null =        (x) => "null",
+
+            Serialize.Number =      (x) => 
+                                        let Text.From = (i as number) as text => 
+                                            if Number.IsNaN(i) then "#nan" else
+                                            if i=Number.PositiveInfinity then "#infinity" else
+                                            if i=Number.NegativeInfinity then "-#infinity" else
+                                            Text.From(i)
+                                        in
+                                            Text.From(x),
+
+            Serialize.Record =      (x) => "[ " &
+                                           List.Accumulate(
+                                                Record.FieldNames(x), 
+                                                "", 
+                                                (seed,item) => 
+                                                    (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                           ) &
+                                           " ] ",
+
+            Serialize.Table =       (x) => "#table( type " &
+                                            _serialize_table_type(Value.Type(x)) &
+                                            ", " &
+                                            Serialize(Table.ToRows(x)) &
+                                            ") ",
+                                    
+            Serialize.Text =        (x) => """" & 
+                                           _serialize_text_content(x) & 
+                                           """",
+
+            _serialize_text_content =  (x) => let 
+                                                escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                            in
+                                            List.Accumulate(
+                                               List.Transform(
+                                                   Text.ToList(x),
+                                                   (c) => let n=Character.ToNumber(c) in 
+                                                            if n = 9   then "#(#)(tab)" else
+                                                            if n = 10  then "#(#)(lf)"  else
+                                                            if n = 13  then "#(#)(cr)"  else
+                                                            if n = 34  then """"""      else
+                                                            if n = 35  then "#(#)(#)"   else
+                                                            if n < 32  then escapeText(n) else 
+                                                            if n < 127 then Character.FromNumber(n) else 
+                                                            escapeText(n) 
+                                                ),
+                                                "",
+                                                (s,i)=>s&i
+                                            ),
+        
+            Serialize.Identifier =   (x) => 
+                                            if _canBeIdentifier(x) then 
+                                                x 
+                                            else 
+                                                "#""" &
+                                                _serialize_text_content(x) &
+                                                """",
+
+            Serialize.Time =        (x) => "#time(" &
+                                           Text.From(Time.Hour(x))   & ", " & 
+                                           Text.From(Time.Minute(x)) & ", " & 
+                                           Text.From(Time.Second(x)) & ") ",
+                                
+            Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                        let
+                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                        in
+                                
+                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                            if x = type any then "any" else
+                                            let base = Type.NonNullable(x) in
+                                              (if Type.IsNullable(x) then "nullable " else "") &       
+                                              (if base = type anynonnull then "anynonnull" else                
+                                              if base = type binary then "binary" else                
+                                              if base = type date   then "date"   else
+                                              if base = type datetime then "datetime" else
+                                              if base = type datetimezone then "datetimezone" else
+                                              if base = type duration then "duration" else
+                                              if base = type logical then "logical" else
+                                              if base = type none then "none" else
+                                              if base = type null then "null" else
+                                              if base = type number then "number" else
+                                              if base = type text then "text" else 
+                                              if base = type time then "time" else 
+                                              if base = type type then "type" else 
+                                      
+                                              /* Abstract types: */
+                                              if base = type function then "function" else
+                                              if base = type table then "table" else
+                                              if base = type record then "record" else
+                                              if base = type list then "list" else
+                                      
+                                              "any /*Actually unknown type*/"),
+
+            _serialize_table_type =     (x) => 
+                                               let 
+                                                 schema = Type.TableSchema(x)
+                                               in
+                                                 "table " &
+                                                 (if Table.IsEmpty(schema) then "" else 
+                                                     "[" & List.Accumulate(
+                                                        List.Transform(
+                                                            Table.ToRecords(Table.Sort(schema,"Position")),
+                                                            each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                        "",
+                                                        (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                    ) & "] " ),
+
+            _serialize_record_type =    (x) => 
+                                                let flds = Type.RecordFields(x)
+                                                in
+                                                    if Record.FieldCount(flds)=0 then "record" else
+                                                        "[" & List.Accumulate(
+                                                            Record.FieldNames(flds),
+                                                            "",
+                                                            (seed,item) => 
+                                                                seed &
+                                                                (if seed<>"" then ", " else "") &
+                                                                (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                        ) & 
+                                                        (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                        "]",
+
+            _serialize_function_type =  (x) => _serialize_function_param_type(
+                                                  Type.FunctionParameters(x),
+                                                  Type.FunctionRequiredParameters(x) ) &
+                                                " as " &
+                                                _serialize_function_return_type(x),
+    
+            _serialize_function_param_type = (t,n) => 
+                                    let
+                                        funsig = Table.ToRecords(
+                                            Table.TransformColumns(
+                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                                { "isOptional", (x)=> x>n } ) )
+                                    in
+                                        "(" & 
+                                        List.Accumulate(
+                                            funsig,
+                                            "",
+                                            (seed,item)=>
+                                                (if seed="" then "" else seed & ", ") &
+                                                (if item[isOptional] then "optional " else "") &
+                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                         & ")",
+
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+            Serialize = (x) as text => 
+                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                               if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                               if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                               if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                               if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                               if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                               if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                               if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                               if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                               if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                               "[#_unable_to_serialize_#]"                     
+        in
+            try Serialize(value) otherwise "<serialization failed>"
+in
+    [ 
+        LogValue = Diagnostics.LogValue,
+        LogValue2 = Diagnostics.LogValue2,
+        LogFailure = Diagnostics.LogFailure,
+        WrapFunctionResult = Diagnostics.WrapFunctionResult,
+        WrapHandlers = Diagnostics.WrapHandlers,
+        ValueToText = Diagnostics.ValueToText
+    ]

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/HiveSample/HiveSample.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/HiveSample/HiveSample.pq
@@ -1,0 +1,357 @@
+﻿section HiveSample;
+
+// When set to true, additional trace information will be written out to the User log. 
+// This should be set to false before release. Tracing is done through a call to 
+// Diagnostics.LogValue(). When EnableTraceOutput is set to false, the call becomes a 
+// no-op and simply returns the original value.
+EnableTraceOutput = false;
+
+/****************************
+ * ODBC Driver Configuration
+ ****************************/
+
+Config_DriverName = "Microsoft Hive ODBC Driver";
+// Config_DriverName = "Hortonworks Hive ODBC Driver";
+
+Config_SqlConformance = SQL_SC[SQL_SC_SQL92_FULL];  // null, 1, 2, 4, 8
+Config_DefaultUsernamePasswordHandling = true;  // true, false
+Config_UseParameterBindings = false;  // true, false, null
+Config_StringLiterateEscapeCharacters  = { "\" }; // ex. { "\" }
+Config_UseCastInsteadOfConvert = null; // true, false, null
+Config_SupportsTop = false; // true, false
+
+// Set this to true to enable Direct Query in addition to Import mode.
+//
+// *** IMPORTANT ***: Direct Query will only provide a decent user experience
+// if you are connecting to a Hive LLAP instance.
+//
+Config_EnableDirectQuery = true;    // true, false
+
+[DataSource.Kind="HiveSample", Publish="HiveSample.Publish"]
+shared HiveSample.Contents = (host as text, port as number) =>
+    let
+        //
+        // Connection string settings
+        //
+        ConnectionString = [
+            Driver = Config_DriverName,
+
+            // set all connection string properties
+            host = host,
+            port = port,
+            authmech = 3,       // UsernamePassword
+            thrifttransport=1   // SASL
+        ],
+
+        //
+        // Handle credentials
+        // Credentials are not persisted with the query and are set through a separate 
+        // record field - CredentialConnectionString. The base Odbc.DataSource function
+        // will handle UsernamePassword authentication automatically, but it is explictly
+        // handled here as an example. 
+        //
+        Credential = Extension.CurrentCredential(),
+		CredentialConnectionString =
+            if Credential[AuthenticationKind]? = "UsernamePassword" then
+                // set connection string parameters used for basic authentication
+                [ UID = Credential[Username], PWD = Credential[Password] ]
+            else
+                error Error.Record("Error", "Unhandled authentication kind: " & Credential[AuthenticationKind]?),
+        
+        //
+        // Configuration options for the call to Odbc.DataSource
+        //
+        defaultConfig = BuildOdbcConfig(),
+
+        SqlCapabilities = defaultConfig[SqlCapabilities] & [
+            // place custom overrides here
+            GroupByCapabilities = SQL_GB[SQL_GB_COLLATE]
+        ],
+
+        // Please refer to the ODBC specification for SQLGetInfo properties and values.
+        // https://github.com/Microsoft/ODBC-Specification/blob/master/Windows/inc/sqlext.h
+        SQLGetInfo = defaultConfig[SQLGetInfo] & [
+            // place custom overrides here
+            SQL_STRING_FUNCTIONS =
+                let
+                    // this is the value reported by the driver: 277753
+                    driverDefault = {
+                        SQL_FN_STR[SQL_FN_STR_CONCAT],
+                        SQL_FN_STR[SQL_FN_STR_LTRIM],
+                        SQL_FN_STR[SQL_FN_STR_LENGTH],
+                        SQL_FN_STR[SQL_FN_STR_LOCATE],
+                        SQL_FN_STR[SQL_FN_STR_LCASE],
+                        SQL_FN_STR[SQL_FN_STR_REPEAT],
+                        SQL_FN_STR[SQL_FN_STR_RTRIM],
+                        SQL_FN_STR[SQL_FN_STR_SUBSTRING],
+                        SQL_FN_STR[SQL_FN_STR_UCASE],
+                        SQL_FN_STR[SQL_FN_STR_ASCII],
+                        SQL_FN_STR[SQL_FN_STR_SPACE]
+                    },
+                    // add missing string functions
+                    updated = driverDefault & {
+                        SQL_FN_STR[SQL_FN_STR_LEFT],
+                        SQL_FN_STR[SQL_FN_STR_RIGHT] 
+                    }
+                in
+                    Flags(updated),
+
+            SQL_NUMERIC_FUNCTIONS =
+                let
+                    // this is the value reported by the driver: 8386415
+                    driverDefault = {
+                        SQL_FN_NUM[SQL_FN_NUM_ABS],
+                        SQL_FN_NUM[SQL_FN_NUM_ASIN],
+                        SQL_FN_NUM[SQL_FN_NUM_ATAN2],
+                        SQL_FN_NUM[SQL_FN_NUM_LOG],
+                        SQL_FN_NUM[SQL_FN_NUM_SIN],
+                        SQL_FN_NUM[SQL_FN_NUM_SQRT],
+                        SQL_FN_NUM[SQL_FN_NUM_LOG10],
+                        SQL_FN_NUM[SQL_FN_NUM_POWER],
+                        SQL_FN_NUM[SQL_FN_NUM_RADIANS]
+                    },
+                    // add missing functions
+                    updated = driverDefault & {
+                        SQL_FN_NUM[SQL_FN_NUM_MOD]
+                    }
+                in
+                    Flags(updated)
+        ],
+
+        // SQLGetTypeInfo can be specified in two ways:
+        // 1. A #table() value that returns the same type information as an ODBC
+        //    call to SQLGetTypeInfo.
+        // 2. A function that accepts a table argument, and returns a table. The 
+        //    argument will contain the original results of the ODBC call to SQLGetTypeInfo.
+        //    Your function implementation can modify/add to this table.
+        //
+        // For details of the format of the types table parameter and expected return value,
+        // please see: https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgettypeinfo-function
+        //
+        // The sample implementation provided here will simply output the original table
+        // to the user trace log, without any modification. 
+        SQLGetTypeInfo = (types) => 
+            if (EnableTraceOutput <> true) then types else
+            let
+                // Outputting the entire table might be too large, and result in the value being truncated.
+                // We can output a row at a time instead with Table.TransformRows()
+                rows = Table.TransformRows(types, each Diagnostics.LogValue("SQLGetTypeInfo " & _[TYPE_NAME], _)),
+                toTable = Table.FromRecords(rows)
+            in
+                Value.ReplaceType(toTable, Value.Type(types)),                
+
+        // SQLColumns is a function handler that receives the results of an ODBC call
+        // to SQLColumns(). The source parameter contains a table with the data type 
+        // information. This override is typically used to fix up data type mismatches
+        // between calls to SQLGetTypeInfo and SQLColumns. 
+        //
+        // For details of the format of the source table parameter, please see:
+        // https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlcolumns-function
+        //
+        // The sample implementation provided here will simply output the original table
+        // to the user trace log, without any modification. 
+        SQLColumns = (catalogName, schemaName, tableName, columnName, source) =>
+            if (EnableTraceOutput <> true) then source else
+            // the if statement conditions will force the values to evaluated/written to diagnostics
+            if (Diagnostics.LogValue("SQLColumns.TableName", tableName) <> "***" and Diagnostics.LogValue("SQLColumns.ColumnName", columnName) <> "***") then
+                let
+                    // Outputting the entire table might be too large, and result in the value being truncated.
+                    // We can output a row at a time instead with Table.TransformRows()
+                    rows = Table.TransformRows(source, each Diagnostics.LogValue("SQLColumns", _)),
+                    toTable = Table.FromRecords(rows)
+                in
+                    Value.ReplaceType(toTable, Value.Type(source))
+            else
+                source,
+
+        // This record allows you to customize the generated SQL for certain
+        // operations. The most common usage is to define syntax for LIMIT/OFFSET operators 
+        // when TOP is not supported. 
+        // 
+        AstVisitor = [
+            // format is "LIMIT [<skip>,]<take>" - ex. LIMIT 2,10 or LIMIT 10
+            LimitClause = (skip, take) =>
+                if (take = null) then
+                    ...
+                else
+                    let
+                        skip =
+                            if (skip = null or skip = 0) then
+                                ""
+                            else
+                                Number.ToText(skip) & ","
+                    in
+                        [
+                            Text = Text.Format("LIMIT #{0}#{1}", { skip, take }),
+                            Location = "AfterQuerySpecification"
+                        ]
+        ],
+
+        OdbcDatasource = Odbc.DataSource(ConnectionString, [
+            // A logical (true/false) that sets whether to view the tables grouped by their schema names
+            HierarchicalNavigation = true, 
+            // Prevents execution of native SQL statements. Extensions should set this to true.
+            HideNativeQuery = true,
+            // Enables connection pooling via the system ODBC manager
+            ClientConnectionPooling = true,
+            // Show table relationships
+            CreateNavigationProperties = true,
+
+            // These values should be set by previous steps
+            CredentialConnectionString = CredentialConnectionString,
+            AstVisitor = AstVisitor,
+            SqlCapabilities = SqlCapabilities,
+            SQLColumns = SQLColumns,
+            SQLGetInfo = SQLGetInfo,
+            SQLGetTypeInfo = SQLGetTypeInfo
+        ])
+    in
+        OdbcDatasource;  
+
+// Data Source Kind description
+HiveSample = [
+    // Set the TestConnection handler to enable gateway support.
+    // The TestConnection handler will invoke your data source function to 
+    // validate the credentials the user has provider. Ideally, this is not 
+    // an expensive operation to perform. By default, the dataSourcePath value 
+    // will be a json string containing the required parameters of your data  
+    // source function. These should be parsed and parsed as individual parameters
+    // to the specified data source function.
+    TestConnection = (dataSourcePath) => 
+        let
+            json = Json.Document(dataSourcePath),
+            host = json[host],   // name of function parameter
+            port = json[port]   // name of function parameter
+        in
+            { "HiveSample.Contents", host, port },
+    // Set supported types of authentication
+    Authentication = [
+        UsernamePassword = []
+    ],
+    Label = Extension.LoadString("DataSourceLabel")
+];
+
+// Data Source UI publishing description
+HiveSample.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { Extension.LoadString("ButtonTitle"), Extension.LoadString("ButtonHelp") },
+    LearnMoreUrl = "https://powerbi.microsoft.com/",
+
+    SupportsDirectQuery = Config_EnableDirectQuery,
+
+    SourceImage = HiveSample.Icons,
+    SourceTypeImage = HiveSample.Icons
+];
+
+HiveSample.Icons = [
+    Icon16 = { Extension.Contents("HiveSample16.png"), Extension.Contents("HiveSample20.png"), Extension.Contents("HiveSample24.png"), Extension.Contents("HiveSample32.png") },
+    Icon32 = { Extension.Contents("HiveSample32.png"), Extension.Contents("HiveSample40.png"), Extension.Contents("HiveSample48.png"), Extension.Contents("HiveSample64.png") }
+];
+
+// build settings based on configuration variables
+BuildOdbcConfig = () as record =>
+    let        
+        defaultConfig = [
+            SqlCapabilities = [],
+            SQLGetFunctions = [],
+            SQLGetInfo = []
+        ],
+
+        withParams =
+            if (Config_UseParameterBindings = false) then
+                let 
+                    caps = defaultConfig[SqlCapabilities] & [ 
+                        SqlCapabilities = [
+                            SupportsNumericLiterals = true,
+                            SupportsStringLiterals = true,                
+                            SupportsOdbcDateLiterals = true,
+                            SupportsOdbcTimeLiterals = true,
+                            SupportsOdbcTimestampLiterals = true
+                        ]
+                    ],
+                    funcs = defaultConfig[SQLGetFunctions] & [
+                        SQLGetFunctions = [
+                            SQL_API_SQLBINDPARAMETER = false
+                        ]
+                    ]
+                in
+                    defaultConfig & caps & funcs
+            else
+                defaultConfig,
+                
+        withEscape = 
+            if (Config_StringLiterateEscapeCharacters <> null) then 
+                let
+                    caps = withParams[SqlCapabilities] & [ 
+                        SqlCapabilities = [
+                            StringLiteralEscapeCharacters = Config_StringLiterateEscapeCharacters
+                        ]
+                    ]
+                in
+                    withParams & caps
+            else
+                withParams,
+
+        withTop =
+            let
+                caps = withEscape[SqlCapabilities] & [ 
+                    SqlCapabilities = [
+                        SupportsTop = Config_SupportsTop
+                    ]
+                ]
+            in
+                withEscape & caps,
+
+        withCastOrConvert = 
+            if (Config_UseCastInsteadOfConvert = true) then
+                let
+                    caps = withTop[SQLGetFunctions] & [ 
+                        SQLGetFunctions = [
+                            SQL_CONVERT_FUNCTIONS = 0x2 /* SQL_FN_CVT_CAST */
+                        ]
+                    ]
+                in
+                    withTop & caps
+            else
+                withTop,
+
+        withSqlConformance =
+            if (Config_SqlConformance <> null) then
+                let
+                    caps = withCastOrConvert[SQLGetInfo] & [
+                        SQLGetInfo = [
+                            SQL_SQL_CONFORMANCE = Config_SqlConformance
+                        ]
+                    ]
+                in
+                    withCastOrConvert & caps
+            else
+                withCastOrConvert
+    in
+        withSqlConformance;
+
+// 
+// Load common library functions
+// 
+Extension.LoadFunction = (name as text) =>
+    let
+        binary = Extension.Contents(name),
+        asText = Text.FromBinary(binary)
+    in
+        Expression.Evaluate(asText, #shared);
+
+// Diagnostics module contains multiple functions. We can take the ones we need.
+Diagnostics = Extension.LoadFunction("Diagnostics.pqm");
+Diagnostics.LogValue = if (EnableTraceOutput) then Diagnostics[LogValue] else (prefix, value) => value;
+
+// OdbcConstants contains numeric constants from the ODBC header files, and a 
+// helper function to create bitfield values.
+ODBC = Extension.LoadFunction("OdbcConstants.pqm");
+
+// Expose the constants and bitfield helpers
+Flags = ODBC[Flags];
+SQL_FN_STR = ODBC[SQL_FN_STR];
+SQL_SC = ODBC[SQL_SC];
+SQL_GB = ODBC[SQL_GB];
+SQL_FN_NUM = ODBC[SQL_FN_NUM];

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/HiveSample/HiveSample.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/HiveSample/HiveSample.query.pq
@@ -1,0 +1,9 @@
+﻿// Tested with Hortonworks Sandbox
+let
+    Source = HiveSample.Contents("127.0.0.1", 10500),
+    HIVE_Database = Source{[Name="HIVE",Kind="Database"]}[Data],
+    foodmart_Schema = HIVE_Database{[Name="foodmart",Kind="Schema"]}[Data],
+    customer_Table = foodmart_Schema{[Name="customer",Kind="Table"]}[Data],
+    #"Kept First Rows" = Table.FirstN(customer_Table,5)
+in
+    #"Kept First Rows"

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/HiveSample/OdbcConstants.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/HiveSample/OdbcConstants.pqm
@@ -1,0 +1,1258 @@
+// values from https://github.com/Microsoft/ODBC-Specification/blob/master/Windows/inc/sqlext.h
+[
+    Flags = (flags as list) => 
+        if (List.IsEmpty(flags)) then 0 else
+        let
+            Loop = List.Generate(()=> [i = 0, Combined = flags{0}],
+                                    each [i] < List.Count(flags),
+                                    each [Combined = Number.BitwiseOr([Combined], flags{i}), i = [i]+1],
+                                    each [Combined]),
+            Result = List.Last(Loop)
+        in
+            Result,
+
+    SQL_HANDLE =
+    [
+        ENV = 1,
+        DBC = 2,
+        STMT = 3,
+        DESC = 4
+    ],
+
+    RetCode =
+    [
+        SUCCESS = 0,
+        SUCCESS_WITH_INFO = 1,
+        ERROR = -1,
+        INVALID_HANDLE = -2,
+        NO_DATA = 100
+    ],
+
+    SQL_CONVERT =
+    [
+        BIGINT = 53,
+        BINARY = 54,
+        BIT = 55,
+        CHAR = 56,
+        DATE = 57,
+        DECIMAL = 58,
+        DOUBLE = 59,
+        FLOAT = 60,
+        INTEGER = 61,
+        LONGVARCHAR = 62,
+        NUMERIC = 63,
+        REAL = 64,
+        SMALLINT = 65,
+        TIME = 66,
+        TIMESTAMP = 67,
+        TINYINT = 68,
+        VARBINARY = 69,
+        VARCHAR = 70,
+        LONGVARBINARY = 71
+    ],
+
+    SQL_ROW =
+    [
+        PROCEED = 0,
+        IGNORE = 1,
+        SUCCESS = 0,
+        DELETED = 1,
+        UPDATED = 2,
+        NOROW = 3,
+        ADDED = 4,
+        ERROR = 5,
+        SUCCESS_WITH_INFO = 6
+    ],
+
+SQL_CVT =
+[
+    //None = 0,
+
+    CHAR = 0x00000001,
+    NUMERIC = 0x00000002,
+    DECIMAL = 0x00000004,
+    INTEGER = 0x00000008,
+    SMALLINT = 0x00000010,
+    FLOAT = 0x00000020,
+    REAL = 0x00000040,
+    DOUBLE = 0x00000080,
+    VARCHAR = 0x00000100,
+    LONGVARCHAR = 0x00000200,
+    BINARY = 0x00000400,
+    VARBINARY = 0x00000800,
+    BIT = 0x00001000,
+    TINYINT = 0x00002000,
+    BIGINT = 0x00004000,
+    DATE = 0x00008000,
+    TIME = 0x00010000,
+    TIMESTAMP = 0x00020000,
+    LONGVARBINARY = 0x00040000,
+    INTERVAL_YEAR_MONTH = 0x00080000,
+    INTERVAL_DAY_TIME = 0x00100000,
+    WCHAR = 0x00200000,
+    WLONGVARCHAR = 0x00400000,
+    WVARCHAR = 0x00800000,
+    GUID = 0x01000000
+],
+
+    STMT =
+    [
+        CLOSE = 0,
+        DROP = 1,
+        UNBIND = 2,
+        RESET_PARAMS = 3
+    ],
+
+    SQL_MAX =
+    [
+        NUMERIC_LEN = 16
+    ],
+
+    SQL_IS =
+    [
+        POINTER = -4,
+        INTEGER = -6,
+        UINTEGER = -5,
+        SMALLINT = -8
+    ],
+
+    //SQL Server specific defines
+    //
+    SQL_HC =                        // from Odbcss.h
+    [
+        OFF = 0,                //  FOR BROWSE columns are hidden
+        ON = 1                //  FOR BROWSE columns are exposed
+    ],
+
+    SQL_NB =                         // from Odbcss.h
+    [
+        OFF = 0,                //  NO_BROWSETABLE is off
+        ON = 1                //  NO_BROWSETABLE is on
+    ],
+
+    //  SQLColAttributes driver specific defines.
+    //  SQLSet/GetDescField driver specific defines.
+    //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
+    //
+    SQL_CA_SS =                      // from Odbcss.h
+    [
+        BASE = 1200,           // SQL_CA_SS_BASE
+
+        COLUMN_HIDDEN = 1200 + 11,      //  Column is hidden (FOR BROWSE)
+        COLUMN_KEY = 1200 + 12,      //  Column is key column (FOR BROWSE)
+        VARIANT_TYPE = 1200 + 15,
+        VARIANT_SQL_TYPE = 1200 + 16,
+        VARIANT_SERVER_TYPE = 1200 + 17
+
+    ],
+
+    SQL_SOPT_SS =                    // from Odbcss.h
+    [
+        BASE = 1225,                // SQL_SOPT_SS_BASE
+        HIDDEN_COLUMNS = 1225 + 2,  // Expose FOR BROWSE hidden columns
+        NOBROWSETABLE = 1225 + 3    // Set NOBROWSETABLE option
+    ],
+
+    SQL_COMMIT = 0,      //Commit
+    SQL_ROLLBACK = 1,      //Abort
+
+    //static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
+    //static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
+
+    SQL_TRANSACTION =
+    [
+        READ_UNCOMMITTED = 0x00000001,
+        READ_COMMITTED = 0x00000002,
+        REPEATABLE_READ = 0x00000004,
+        SERIALIZABLE = 0x00000008,
+        SNAPSHOT = 0x00000020 // VSDD 414121: SQL_TXN_SS_SNAPSHOT == 0x20 (sqlncli.h)
+    ],
+
+    SQL_PARAM =
+    [
+        TYPE_UNKNOWN = 0,          // SQL_PARAM_TYPE_UNKNOWN
+        INPUT = 1,                 // SQL_PARAM_INPUT
+        INPUT_OUTPUT = 2,          // SQL_PARAM_INPUT_OUTPUT
+        RESULT_COL =   3,          // SQL_RESULT_COL
+        OUTPUT = 4,                // SQL_PARAM_OUTPUT
+        RETURN_VALUE = 5           // SQL_RETURN_VALUE
+    ],
+
+    SQL_DESC =
+    [
+        // from sql.h (ODBCVER >= 3.0)
+        //
+        COUNT = 1001,
+        TYPE = 1002,
+        LENGTH = 1003,
+        OCTET_LENGTH_PTR = 1004,
+        PRECISION = 1005,
+        SCALE = 1006,
+        DATETIME_INTERVAL_CODE = 1007,
+        NULLABLE = 1008,
+        INDICATOR_PTR = 1009,
+        DATA_PTR = 1010,
+        NAME = 1011,
+        UNNAMED = 1012,
+        OCTET_LENGTH = 1013,
+        ALLOC_TYPE = 1099,
+
+        // from sqlext.h (ODBCVER >= 3.0)
+        //
+        CONCISE_TYPE = SQL_COLUMN[TYPE],
+        DISPLAY_SIZE = SQL_COLUMN[DISPLAY_SIZE],
+        UNSIGNED = SQL_COLUMN[UNSIGNED],
+        UPDATABLE = SQL_COLUMN[UPDATABLE],
+        AUTO_UNIQUE_VALUE = SQL_COLUMN[AUTO_INCREMENT],
+
+        TYPE_NAME = SQL_COLUMN[TYPE_NAME],
+        TABLE_NAME = SQL_COLUMN[TABLE_NAME],
+        SCHEMA_NAME = SQL_COLUMN[OWNER_NAME],
+        CATALOG_NAME = SQL_COLUMN[QUALIFIER_NAME],
+
+        BASE_COLUMN_NAME = 22,
+        BASE_TABLE_NAME = 23,
+
+        NUM_PREC_RADIX = 32
+    ],
+
+    // ODBC version 2.0 style attributes
+    // All IdentifierValues are ODBC 1.0 unless marked differently
+    //
+    SQL_COLUMN =
+    [
+        COUNT = 0,
+        NAME = 1,
+        TYPE = 2,
+        LENGTH = 3,
+        PRECISION = 4,
+        SCALE = 5,
+        DISPLAY_SIZE = 6,
+        NULLABLE = 7,
+        UNSIGNED = 8,
+        MONEY = 9,
+        UPDATABLE = 10,
+        AUTO_INCREMENT = 11,
+        CASE_SENSITIVE = 12,
+        SEARCHABLE = 13,
+        TYPE_NAME = 14,
+        TABLE_NAME = 15,    // (ODBC 2.0)
+        OWNER_NAME = 16,    // (ODBC 2.0)
+        QUALIFIER_NAME = 17,    // (ODBC 2.0)
+        LABEL = 18
+    ],
+
+    // values from sqlext.h
+    SQL_SQL92_RELATIONAL_JOIN_OPERATORS =
+    [
+        CORRESPONDING_CLAUSE = 0x00000001,    // SQL_SRJO_CORRESPONDING_CLAUSE
+        CROSS_JOIN = 0x00000002,    // SQL_SRJO_CROSS_JOIN
+        EXCEPT_JOIN = 0x00000004,    // SQL_SRJO_EXCEPT_JOIN
+        FULL_OUTER_JOIN = 0x00000008,    // SQL_SRJO_FULL_OUTER_JOIN
+        INNER_JOIN = 0x00000010,    // SQL_SRJO_INNER_JOIN
+        INTERSECT_JOIN = 0x00000020,    // SQL_SRJO_INTERSECT_JOIN
+        LEFT_OUTER_JOIN = 0x00000040,    // SQL_SRJO_LEFT_OUTER_JOIN
+        NATURAL_JOIN = 0x00000080,    // SQL_SRJO_NATURAL_JOIN
+        RIGHT_OUTER_JOIN = 0x00000100,  // SQL_SRJO_RIGHT_OUTER_JOIN
+        UNION_JOIN = 0x00000200         // SQL_SRJO_UNION_JOIN
+    ],
+
+    // values from sqlext.h
+    SQL_QU = 
+    [
+        SQL_QU_DML_STATEMENTS = 0x00000001,
+        SQL_QU_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_QU_TABLE_DEFINITION     = 0x00000004,
+        SQL_QU_INDEX_DEFINITION     = 0x00000008,
+        SQL_QU_PRIVILEGE_DEFINITION = 0x00000010
+    ],
+
+    // values from sql.h
+    SQL_OJ_CAPABILITIES =
+    [
+        LEFT = 0x00000001,    // SQL_OJ_LEFT
+        RIGHT = 0x00000002,    // SQL_OJ_RIGHT
+        FULL = 0x00000004,    // SQL_OJ_FULL
+        NESTED = 0x00000008,    // SQL_OJ_NESTED
+        NOT_ORDERED = 0x00000010,    // SQL_OJ_NOT_ORDERED
+        INNER = 0x00000020,    // SQL_OJ_INNER
+        ALL_COMPARISON_OPS = 0x00000040  //SQL_OJ_ALLCOMPARISION+OPS
+    ],
+
+    SQL_UPDATABLE =
+    [
+        READONLY = 0,          // SQL_ATTR_READ_ONLY
+        WRITE = 1,             // SQL_ATTR_WRITE
+        READWRITE_UNKNOWN = 2  // SQL_ATTR_READWRITE_UNKNOWN
+    ],
+
+    SQL_IDENTIFIER_CASE =
+    [
+        UPPER = 1,    // SQL_IC_UPPER
+        LOWER = 2,    // SQL_IC_LOWER
+        SENSITIVE = 3,    // SQL_IC_SENSITIVE
+        MIXED = 4    // SQL_IC_MIXED
+    ],
+
+    // Uniqueness parameter in the SQLStatistics function
+    SQL_INDEX =
+    [
+        UNIQUE = 0,
+        ALL = 1
+    ],
+
+    // Reserved parameter in the SQLStatistics function
+    SQL_STATISTICS_RESERVED =
+    [
+        QUICK = 0,                // SQL_QUICK
+        ENSURE = 1                // SQL_ENSURE
+    ],
+
+    // Identifier type parameter in the SQLSpecialColumns function
+    SQL_SPECIALCOLS =
+    [
+        BEST_ROWID = 1,            // SQL_BEST_ROWID
+        ROWVER = 2            // SQL_ROWVER
+    ],
+
+    // Scope parameter in the SQLSpecialColumns function
+    SQL_SCOPE =
+    [
+        CURROW = 0,            // SQL_SCOPE_CURROW
+        TRANSACTION = 1,           // SQL_SCOPE_TRANSACTION
+        SESSION = 2           // SQL_SCOPE_SESSION
+    ],
+
+    SQL_NULLABILITY =
+    [
+        NO_NULLS = 0,                // SQL_NO_NULLS
+        NULLABLE = 1,                // SQL_NULLABLE
+        UNKNOWN = 2                 // SQL_NULLABLE_UNKNOWN
+    ],
+
+    SQL_SEARCHABLE =
+    [
+        UNSEARCHABLE = 0,        // SQL_UNSEARCHABLE
+        LIKE_ONLY = 1,        // SQL_LIKE_ONLY
+        ALL_EXCEPT_LIKE = 2,        // SQL_ALL_EXCEPT_LIKE
+        SEARCHABLE = 3        // SQL_SEARCHABLE
+    ],
+
+    SQL_UNNAMED =
+    [
+        NAMED = 0,                   // SQL_NAMED
+        UNNAMED = 1                  // SQL_UNNAMED
+    ],
+    // todo:move
+    // internal constants
+    // not odbc specific
+    //
+    HANDLER =
+    [
+        IGNORE = 0x00000000,
+        THROW = 0x00000001
+    ],
+
+    // values for SQLStatistics TYPE column
+    SQL_STATISTICSTYPE =
+    [
+        TABLE_STAT = 0,                    // TABLE Statistics
+        INDEX_CLUSTERED = 1,               // CLUSTERED index statistics
+        INDEX_HASHED = 2,                  // HASHED index statistics
+        INDEX_OTHER = 3                    // OTHER index statistics
+    ],
+
+    // values for SQLProcedures PROCEDURE_TYPE column
+    SQL_PROCEDURETYPE =
+    [
+        UNKNOWN = 0,                    // procedure is of unknow type
+        PROCEDURE = 1,                    // procedure is a procedure
+        FUNCTION = 2                     // procedure is a function
+    ],
+
+    // private constants
+    // to define data types (see below)
+    //
+    SIGNED_OFFSET = -20,      // SQL_SIGNED_OFFSET
+    UNSIGNED_OFFSET = -22,    // SQL_UNSIGNED_OFFSET
+
+    // C Data Types
+    SQL_C =
+    [
+        CHAR            = 1,
+        WCHAR           = -8,
+        SLONG           = 4     + SIGNED_OFFSET,
+        ULONG           = 4     + UNSIGNED_OFFSET,
+        SSHORT          = 5     + SIGNED_OFFSET,
+        USHORT          = 5     + UNSIGNED_OFFSET,
+        FLOAT           = 7,
+        DOUBLE          = 8,
+        BIT             = -7,
+        STINYINT        = -6    + SIGNED_OFFSET,
+        UTINYINT        = -6    + UNSIGNED_OFFSET,
+        SBIGINT         = -5    + SIGNED_OFFSET,
+        UBIGINT         = -5    + UNSIGNED_OFFSET,
+        BINARY          = -2,
+        TIMESTAMP       = 11,
+
+        TYPE_DATE       = 91,
+        TYPE_TIME       = 92,
+        TYPE_TIMESTAMP  = 93,
+
+        NUMERIC         = 2,
+        GUID            = -11,
+        DEFAULT         = 99,
+        ARD_TYPE        = -99
+    ],
+
+    // SQL Data Types
+    SQL_TYPE =
+    [
+        // Base data types (sql.h)
+        UNKNOWN             = 0,
+        NULL                = 0,
+        CHAR                = 1,
+        NUMERIC             = 2,
+        DECIMAL             = 3,
+        INTEGER             = 4,
+        SMALLINT            = 5,
+        FLOAT               = 6,
+        REAL                = 7,
+        DOUBLE              = 8,
+        DATETIME            = 9,      // V3 Only
+        VARCHAR             = 12,
+
+        // Unicode types (sqlucode.h)
+        WCHAR               = -8,
+        WVARCHAR            = -9,
+        WLONGVARCHAR        = -10,
+
+        // Extended data types (sqlext.h)
+        INTERVAL            = 10,    // V3 Only
+        TIME                = 10,
+        TIMESTAMP           = 11,
+        LONGVARCHAR         = -1,
+        BINARY              = -2,
+        VARBINARY           = -3,
+        LONGVARBINARY       = -4,
+        BIGINT              = -5,
+        TINYINT             = -6,
+        BIT                 = -7,
+        GUID                = -11,   // V3 Only
+
+        // One-parameter shortcuts for date/time data types.
+        TYPE_DATE           = 91,
+        TYPE_TIME           = 92,
+        TYPE_TIMESTAMP      = 93,
+
+        // SQL Server Types -150 to -159 (sqlncli.h)
+        SS_VARIANT          = -150,
+        SS_UDT              = -151,
+        SS_XML              = -152,
+        SS_TABLE            = -153,
+        SS_TIME2            = -154,
+        SS_TIMESTAMPOFFSET  = -155
+    ],
+
+    //SQL_ALL_TYPES = 0,
+    //static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
+
+    SQL_LENGTH = 
+    [
+        SQL_IGNORE = -6,
+        SQL_DEFAULT_PARAM = -5,
+        SQL_NO_TOTAL = -4,
+        SQL_NTS = -3,
+        SQL_DATA_AT_EXEC = -2,
+        SQL_NULL_DATA = -1
+    ],
+
+    SQL_DEFAULT_PARAM = -5,        
+
+    // column ordinals for SQLProcedureColumns result set
+    // this column ordinals are not defined in any c/c++ header but in the ODBC Programmer's Reference under SQLProcedureColumns
+    //
+    COLUMN_NAME = 4,
+    COLUMN_TYPE = 5,
+    DATA_TYPE = 6,
+    COLUMN_SIZE = 8,
+    DECIMAL_DIGITS = 10,
+    NUM_PREC_RADIX = 11,
+
+    SQL_ATTR = 
+    [
+        ODBC_VERSION = 200,
+        CONNECTION_POOLING = 201,
+        AUTOCOMMIT = 102,
+        TXN_ISOLATION = 108,
+        CURRENT_CATALOG = 109,
+        LOGIN_TIMEOUT = 103,
+        QUERY_TIMEOUT = 0,
+        CONNECTION_DEAD = 1209,
+
+        SQL_COPT_SS_BASE = 1200,
+        SQL_COPT_SS_ENLIST_IN_DTC = (1200 + 7),
+        SQL_COPT_SS_TXN_ISOLATION = (1200 + 27),
+
+        MAX_LENGTH = 3,
+        ROW_BIND_TYPE = 5,
+        CURSOR_TYPE = 6,
+        RETRIEVE_DATA = 11,
+        ROW_STATUS_PTR = 25, 
+        ROWS_FETCHED_PTR = 26,
+        ROW_ARRAY_SIZE = 27,
+
+        // ODBC 3.0
+        APP_ROW_DESC = 10010,
+        APP_PARAM_DESC = 10011,
+        IMP_ROW_DESC = 10012,
+        IMP_PARAM_DESC = 10013,
+        METADATA_ID = 10014,
+
+        // ODBC 4.0
+        PRIVATE_DRIVER_LOCATION = 204
+    ],
+
+    SQL_RD = 
+    [
+        OFF = 0,
+        ON = 1
+    ],
+
+    SQL_GD = 
+    [
+        //None =  0,
+        ANY_COLUMN = 1,
+        ANY_ORDER = 2,
+        BLOCK = 4,
+        BOUND = 8,
+        OUTPUT_PARAMS = 16
+    ],
+
+    //SQLGetInfo
+/*
+    SQL_INFO =
+    [
+        SQL_ACTIVE_CONNECTIONS = 0,        
+        SQL_MAX_DRIVER_CONNECTIONS = 0,
+        SQL_MAX_CONCURRENT_ACTIVITIES = 1,
+        SQL_ACTIVE_STATEMENTS = 1,         
+        SQL_DATA_SOURCE_NAME = 2,          
+        SQL_DRIVER_HDBC,                   
+        SQL_DRIVER_HENV,                   
+        SQL_DRIVER_HSTMT,                  
+        SQL_DRIVER_NAME,                   
+        SQL_DRIVER_VER,                    
+        SQL_FETCH_DIRECTION,               
+        SQL_ODBC_API_CONFORMANCE,          
+        SQL_ODBC_VER,                      
+        SQL_ROW_UPDATES,                   
+        SQL_ODBC_SAG_CLI_CONFORMANCE,      
+        SQL_SERVER_NAME,                   
+        SQL_SEARCH_PATTERN_ESCAPE,         
+        SQL_ODBC_SQL_CONFORMANCE,          
+
+        SQL_DATABASE_NAME,                 
+        SQL_DBMS_NAME,                     
+        SQL_DBMS_VER,                      
+
+        SQL_ACCESSIBLE_TABLES,             
+        SQL_ACCESSIBLE_PROCEDURES,         
+        SQL_PROCEDURES,                    
+        SQL_CONCAT_NULL_BEHAVIOR,          
+        SQL_CURSOR_COMMIT_BEHAVIOR,        
+        SQL_CURSOR_ROLLBACK_BEHAVIOR,      
+        SQL_DATA_SOURCE_READ_ONLY,         
+        SQL_DEFAULT_TXN_ISOLATION,         
+        SQL_EXPRESSIONS_IN_ORDERBY,        
+        SQL_IDENTIFIER_CASE,               
+        SQL_IDENTIFIER_QUOTE_CHAR,         
+        SQL_MAX_COLUMN_NAME_LEN,           
+        SQL_MAX_CURSOR_NAME_LEN,           
+        SQL_MAX_OWNER_NAME_LEN,            
+        SQL_MAX_SCHEMA_NAME_LEN = 32,
+        SQL_MAX_PROCEDURE_NAME_LEN,        
+        SQL_MAX_QUALIFIER_NAME_LEN,        
+        SQL_MAX_CATALOG_NAME_LEN = 34,
+        SQL_MAX_TABLE_NAME_LEN,            
+        SQL_MULT_RESULT_SETS,              
+        SQL_MULTIPLE_ACTIVE_TXN,           
+        SQL_OUTER_JOINS,                   
+        SQL_SCHEMA_TERM,                   
+        SQL_PROCEDURE_TERM,                
+        SQL_CATALOG_NAME_SEPARATOR,        
+        SQL_CATALOG_TERM,                  
+        SQL_SCROLL_CONCURRENCY,            
+        SQL_SCROLL_OPTIONS,                
+        SQL_TABLE_TERM,                    
+        SQL_TXN_CAPABLE,                   
+        SQL_USER_NAME,                     
+
+        SQL_CONVERT_FUNCTIONS,             
+        SQL_NUMERIC_FUNCTIONS,             
+        SQL_STRING_FUNCTIONS,              
+        SQL_SYSTEM_FUNCTIONS,              
+        SQL_TIMEDATE_FUNCTIONS,            
+
+        SQL_CONVERT_BIGINT,
+        SQL_CONVERT_BINARY,
+        SQL_CONVERT_BIT,
+        SQL_CONVERT_CHAR,
+        SQL_CONVERT_DATE,
+        SQL_CONVERT_DECIMAL,
+        SQL_CONVERT_DOUBLE,
+        SQL_CONVERT_FLOAT,            
+        SQL_CONVERT_INTEGER,
+        SQL_CONVERT_LONGVARCHAR,
+        SQL_CONVERT_NUMERIC,
+        SQL_CONVERT_REAL,
+        SQL_CONVERT_SMALLINT,
+        SQL_CONVERT_TIME,
+        SQL_CONVERT_TIMESTAMP,
+        SQL_CONVERT_TINYINT,
+        SQL_CONVERT_VARBINARY,
+        SQL_CONVERT_VARCHAR,          
+        SQL_CONVERT_LONGVARBINARY,
+
+        SQL_TXN_ISOLATION_OPTION,     
+        SQL_ODBC_SQL_OPT_IEF,
+        SQL_INTEGRITY = 73,
+        SQL_CORRELATION_NAME,
+        SQL_NON_NULLABLE_COLUMNS,
+        SQL_DRIVER_HLIB,
+        SQL_DRIVER_ODBC_VER,
+        SQL_LOCK_TYPES,
+        SQL_POS_OPERATIONS,
+        SQL_POSITIONED_STATEMENTS,        
+        SQL_GETDATA_EXTENSIONS,
+        SQL_BOOKMARK_PERSISTENCE,
+        SQL_STATIC_SENSITIVITY,
+        SQL_FILE_USAGE,
+        SQL_NULL_COLLATION,
+        SQL_ALTER_TABLE,
+        SQL_COLUMN_ALIAS,
+        SQL_GROUP_BY,
+        SQL_KEYWORDS,
+        SQL_ORDER_BY_COLUMNS_IN_SELECT,   
+        SQL_SCHEMA_USAGE,
+        SQL_CATALOG_USAGE,
+        SQL_QUOTED_IDENTIFIER_CASE,
+        SQL_SPECIAL_CHARACTERS,
+        SQL_SUBQUERIES,
+        SQL_UNION_STATEMENT,
+        SQL_MAX_COLUMNS_IN_GROUP_BY,
+        SQL_MAX_COLUMNS_IN_INDEX,
+        SQL_MAX_COLUMNS_IN_ORDER_BY,
+        SQL_MAX_COLUMNS_IN_SELECT,        
+        SQL_MAX_COLUMNS_IN_TABLE,
+        SQL_MAX_INDEX_SIZE,
+        SQL_MAX_ROW_SIZE_INCLUDES_LONG,
+        SQL_MAX_ROW_SIZE,
+        SQL_MAX_STATEMENT_LEN,
+        SQL_MAX_TABLES_IN_SELECT,
+        SQL_MAX_USER_NAME_LEN,
+        SQL_MAX_CHAR_LITERAL_LEN,
+        SQL_TIMEDATE_ADD_INTERVALS,
+        SQL_TIMEDATE_DIFF_INTERVALS,      
+        SQL_NEED_LONG_DATA_LEN,
+        SQL_MAX_BINARY_LITERAL_LEN,
+        SQL_LIKE_ESCAPE_CLAUSE,
+        SQL_CATALOG_LOCATION,
+        SQL_OJ_CAPABILITIES,
+
+        SQL_ACTIVE_ENVIRONMENTS,
+        SQL_ALTER_DOMAIN,
+        SQL_SQL_CONFORMANCE,
+        SQL_DATETIME_LITERALS,
+        SQL_BATCH_ROW_COUNT,              
+        SQL_BATCH_SUPPORT,
+        SQL_CONVERT_WCHAR,
+        SQL_CONVERT_INTERVAL_DAY_TIME,
+        SQL_CONVERT_INTERVAL_YEAR_MONTH,
+        SQL_CONVERT_WLONGVARCHAR,
+        SQL_CONVERT_WVARCHAR,
+        SQL_CREATE_ASSERTION,
+        SQL_CREATE_CHARACTER_SET,
+        SQL_CREATE_COLLATION,
+        SQL_CREATE_DOMAIN,                  
+        SQL_CREATE_SCHEMA,
+        SQL_CREATE_TABLE,
+        SQL_CREATE_TRANSLATION,
+        SQL_CREATE_VIEW,
+        SQL_DRIVER_HDESC,
+        SQL_DROP_ASSERTION,
+        SQL_DROP_CHARACTER_SET,
+        SQL_DROP_COLLATION,
+        SQL_DROP_DOMAIN,
+        SQL_DROP_SCHEMA,                    
+        SQL_DROP_TABLE,
+        SQL_DROP_TRANSLATION,
+        SQL_DROP_VIEW,
+        SQL_DYNAMIC_CURSOR_ATTRIBUTES1,
+        SQL_DYNAMIC_CURSOR_ATTRIBUTES2,
+        SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1,
+        SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2,
+        SQL_INDEX_KEYWORDS,
+        SQL_INFO_SCHEMA_VIEWS,
+        SQL_KEYSET_CURSOR_ATTRIBUTES1,    
+        SQL_KEYSET_CURSOR_ATTRIBUTES2,
+        SQL_ODBC_INTERFACE_CONFORMANCE,
+        SQL_PARAM_ARRAY_ROW_COUNTS,
+        SQL_PARAM_ARRAY_SELECTS,
+        SQL_SQL92_DATETIME_FUNCTIONS,
+        SQL_SQL92_FOREIGN_KEY_DELETE_RULE,
+        SQL_SQL92_FOREIGN_KEY_UPDATE_RULE,
+        SQL_SQL92_GRANT,
+        SQL_SQL92_NUMERIC_VALUE_FUNCTIONS,
+        SQL_SQL92_PREDICATES,              
+        SQL_SQL92_RELATIONAL_JOIN_OPERATORS,
+        SQL_SQL92_REVOKE,
+        SQL_SQL92_ROW_VALUE_CONSTRUCTOR,
+        SQL_SQL92_STRING_FUNCTIONS,
+        SQL_SQL92_VALUE_EXPRESSIONS,
+        SQL_STANDARD_CLI_CONFORMANCE,
+        SQL_STATIC_CURSOR_ATTRIBUTES1,
+        SQL_STATIC_CURSOR_ATTRIBUTES2,
+        SQL_AGGREGATE_FUNCTIONS,
+        SQL_DDL_INDEX,                   
+        SQL_DM_VER,
+        SQL_INSERT_STATEMENT,
+        SQL_CONVERT_GUID,
+
+        SQL_XOPEN_CLI_YEAR = 10000,      
+        SQL_CURSOR_SENSITIVITY,
+        SQL_DESCRIBE_PARAMETER,
+        SQL_CATALOG_NAME,
+        SQL_COLLATION_SEQ,
+        SQL_MAX_IDENTIFIER_LEN,
+        SQL_ASYNC_MODE = 10021,          
+        SQL_MAX_ASYNC_CONCURRENT_STATEMENTS,
+
+        SQL_DTC_TRANSITION_COST = 1750,
+    ],
+*/
+    SQL_OAC = 
+    [
+        SQL_OAC_None = 0x0000,
+        SQL_OAC_LEVEL1 = 0x0001,
+        SQL_OAC_LEVEL2 = 0x0002
+    ],
+
+    SQL_OSC = 
+    [
+        SQL_OSC_MINIMUM = 0x0000,
+        SQL_OSC_CORE = 0x0001,
+        SQL_OSC_EXTENDED = 0x0002
+    ],
+
+    SQL_SCC = 
+    [
+        SQL_SCC_XOPEN_CLI_VERSION1 = 0x00000001,
+        SQL_SCC_ISO92_CLI = 0x00000002
+    ],
+
+    SQL_SVE = 
+    [
+        SQL_SVE_CASE = 0x00000001,
+        SQL_SVE_CAST = 0x00000002,
+        SQL_SVE_COALESCE = 0x00000004,
+        SQL_SVE_NULLIF = 0x00000008
+    ],
+
+    SQL_SSF = 
+    [
+        SQL_SSF_CONVERT = 0x00000001,
+        SQL_SSF_LOWER = 0x00000002,
+        SQL_SSF_UPPER = 0x00000004,
+        SQL_SSF_SUBSTRING = 0x00000008,
+        SQL_SSF_TRANSLATE = 0x00000010,
+        SQL_SSF_TRIM_BOTH = 0x00000020,
+        SQL_SSF_TRIM_LEADING = 0x00000040,
+        SQL_SSF_TRIM_TRAILING = 0x00000080
+    ],
+
+    SQL_SP = 
+    [
+        //None = 0,
+
+        SQL_SP_EXISTS = 0x00000001,
+        SQL_SP_ISNOTNULL = 0x00000002,
+        SQL_SP_ISNULL = 0x00000004,
+        SQL_SP_MATCH_FULL = 0x00000008,
+        SQL_SP_MATCH_PARTIAL = 0x00000010,
+        SQL_SP_MATCH_UNIQUE_FULL = 0x00000020,
+        SQL_SP_MATCH_UNIQUE_PARTIAL = 0x00000040,
+        SQL_SP_OVERLAPS = 0x00000080,
+        SQL_SP_UNIQUE = 0x00000100,
+        SQL_SP_LIKE = 0x00000200,
+        SQL_SP_IN = 0x00000400,
+        SQL_SP_BETWEEN = 0x00000800,
+        SQL_SP_COMPARISON = 0x00001000,
+        SQL_SP_QUANTIFIED_COMPARISON = 0x00002000,
+
+        All = 0x0000FFFF
+    ],
+
+    SQL_OIC =
+    [
+        SQL_OIC_CORE = 1,
+        SQL_OIC_LEVEL1 = 2,
+        SQL_OIC_LEVEL2 = 3
+    ],
+
+    SQL_USAGE = 
+    [
+        SQL_U_DML_STATEMENTS = 0x00000001,
+        SQL_U_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_U_TABLE_DEFINITION = 0x00000004,
+        SQL_U_INDEX_DEFINITION = 0x00000008,
+        SQL_U_PRIVILEGE_DEFINITION = 0x00000010
+    ],
+
+    SQL_GB = 
+    [
+            
+        SQL_GB_NOT_SUPPORTED = 0,
+        SQL_GB_GROUP_BY_EQUALS_SELECT = 1,
+        SQL_GB_GROUP_BY_CONTAINS_SELECT = 2,
+        SQL_GB_NO_RELATION = 3,
+        SQL_GB_COLLATE = 4
+    ],
+
+    SQL_NC =
+    [
+        SQL_NC_END = 0,
+        SQL_NC_HIGH = 1,
+        SQL_NC_LOW = 2,
+        SQL_NC_START = 3
+    ],
+
+    SQL_CN =
+    [
+        SQL_CN_None = 0,
+        SQL_CN_DIFFERENT = 1,
+        SQL_CN_ANY = 2
+    ],
+
+    SQL_NNC = 
+    [
+        SQL_NNC_NULL = 0,
+        SQL_NNC_NON_NULL = 1
+    ],
+
+    SQL_CB = 
+    [
+        SQL_CB_NULL = 0,
+        SQL_CB_NON_NULL = 1
+    ],
+
+    SQL_FD_FETCH = 
+    [
+        SQL_FD_FETCH_NEXT = 0x00000001,
+        SQL_FD_FETCH_FIRST = 0x00000002,
+        SQL_FD_FETCH_LAST = 0x00000004,
+        SQL_FD_FETCH_PRIOR = 0x00000008,
+        SQL_FD_FETCH_ABSOLUTE = 0x00000010,
+        SQL_FD_FETCH_RELATIVE = 0x00000020,
+        SQL_FD_FETCH_BOOKMARK = 0x00000080
+    ],
+
+    SQL_SQ = 
+    [
+        SQL_SQ_COMPARISON = 0x00000001,
+        SQL_SQ_EXISTS = 0x00000002,
+        SQL_SQ_IN = 0x00000004,
+        SQL_SQ_QUANTIFIED = 0x00000008,
+        SQL_SQ_CORRELATED_SUBQUERIES = 0x00000010
+    ],
+
+    SQL_U = 
+    [
+        SQL_U_UNION = 0x00000001,
+        SQL_U_UNION_ALL = 0x00000002
+    ],
+
+    SQL_BP = 
+    [
+        SQL_BP_CLOSE = 0x00000001,
+        SQL_BP_DELETE = 0x00000002,
+        SQL_BP_DROP = 0x00000004,
+        SQL_BP_TRANSACTION = 0x00000008,
+        SQL_BP_UPDATE = 0x00000010,
+        SQL_BP_OTHER_HSTMT = 0x00000020,
+        SQL_BP_SCROLL = 0x00000040
+    ],
+
+    SQL_QL = 
+    [
+        SQL_QL_START = 0x0001,
+        SQL_QL_END = 0x0002
+    ],
+
+    SQL_OJ = 
+    [
+        SQL_OJ_LEFT = 0x00000001,
+        SQL_OJ_RIGHT = 0x00000002,
+        SQL_OJ_FULL = 0x00000004,
+        SQL_OJ_NESTED = 0x00000008,
+        SQL_OJ_NOT_ORDERED = 0x00000010,
+        SQL_OJ_INNER = 0x00000020,
+        SQL_OJ_ALL_COMPARISON_OPS = 0x00000040
+    ],
+
+    SQL_FN_CVT = 
+    [
+        //None = 0,
+
+        SQL_FN_CVT_CONVERT        = 0x00000001,
+        SQL_FN_CVT_CAST        = 0x00000002
+    ],
+
+    SQL_FN_NUM = 
+    [
+        //None = 0,
+
+        SQL_FN_NUM_ABS        = 0x00000001,
+        SQL_FN_NUM_ACOS        = 0x00000002,
+        SQL_FN_NUM_ASIN        = 0x00000004,
+        SQL_FN_NUM_ATAN        = 0x00000008,
+
+        SQL_FN_NUM_ATAN2    = 0x00000010,
+        SQL_FN_NUM_CEILING    = 0x00000020,
+        SQL_FN_NUM_COS        = 0x00000040,
+        SQL_FN_NUM_COT        = 0x00000080,
+
+        SQL_FN_NUM_EXP        = 0x00000100,
+        SQL_FN_NUM_FLOOR    = 0x00000200,
+        SQL_FN_NUM_LOG        = 0x00000400,
+        SQL_FN_NUM_MOD        = 0x00000800,
+
+        SQL_FN_NUM_SIGN        = 0x00001000,
+        SQL_FN_NUM_SIN        = 0x00002000,
+        SQL_FN_NUM_SQRT        = 0x00004000,
+        SQL_FN_NUM_TAN      = 0x00008000,
+
+        SQL_FN_NUM_PI       = 0x00010000,
+        SQL_FN_NUM_RAND     = 0x00020000,
+        SQL_FN_NUM_DEGREES    = 0x00040000,
+        SQL_FN_NUM_LOG10    = 0x00080000,
+
+        SQL_FN_NUM_POWER    = 0x00100000,
+        SQL_FN_NUM_RADIANS    = 0x00200000,
+        SQL_FN_NUM_ROUND    = 0x00400000,
+        SQL_FN_NUM_TRUNCATE = 0x00800000
+    ],
+
+    SQL_SNVF = 
+    [
+        SQL_SNVF_BIT_LENGTH = 0x00000001,
+        SQL_SNVF_CHAR_LENGTH = 0x00000002,
+        SQL_SNVF_CHARACTER_LENGTH = 0x00000004,
+        SQL_SNVF_EXTRACT = 0x00000008,
+        SQL_SNVF_OCTET_LENGTH = 0x00000010,
+        SQL_SNVF_POSITION = 0x00000020
+    ],
+
+    SQL_FN_STR =
+    [
+        //None = 0,
+
+        SQL_FN_STR_CONCAT            = 0x00000001,
+        SQL_FN_STR_INSERT            = 0x00000002,
+        SQL_FN_STR_LEFT            = 0x00000004,
+        SQL_FN_STR_LTRIM            = 0x00000008,
+        SQL_FN_STR_LENGTH            = 0x00000010,
+        SQL_FN_STR_LOCATE            = 0x00000020,
+        SQL_FN_STR_LCASE            = 0x00000040,
+        SQL_FN_STR_REPEAT            = 0x00000080,
+        SQL_FN_STR_REPLACE            = 0x00000100,
+        SQL_FN_STR_RIGHT            = 0x00000200,
+        SQL_FN_STR_RTRIM            = 0x00000400,
+        SQL_FN_STR_SUBSTRING        = 0x00000800,
+        SQL_FN_STR_UCASE            = 0x00001000,
+        SQL_FN_STR_ASCII            = 0x00002000,
+        SQL_FN_STR_CHAR            = 0x00004000,
+        SQL_FN_STR_DIFFERENCE = 0x00008000,
+        SQL_FN_STR_LOCATE_2          = 0x00010000,
+        SQL_FN_STR_SOUNDEX          = 0x00020000,
+        SQL_FN_STR_SPACE          = 0x00040000,
+        SQL_FN_STR_BIT_LENGTH      = 0x00080000,
+        SQL_FN_STR_CHAR_LENGTH      = 0x00100000,
+        SQL_FN_STR_CHARACTER_LENGTH      = 0x00200000,
+        SQL_FN_STR_OCTET_LENGTH = 0x00400000,
+        SQL_FN_STR_POSITION = 0x00800000
+    ],
+
+    SQL_FN_SYSTEM = 
+    [
+        //None = 0,
+
+        SQL_FN_SYS_USERNAME = 0x00000001,
+        SQL_FN_SYS_DBNAME = 0x00000002,
+        SQL_FN_SYS_IFNULL = 0x00000004
+    ],
+
+    SQL_FN_TD = 
+    [
+        //None = 0,
+
+        SQL_FN_TD_NOW            = 0x00000001,
+        SQL_FN_TD_CURDATE            = 0x00000002,
+        SQL_FN_TD_DAYOFMONTH        = 0x00000004,
+        SQL_FN_TD_DAYOFWEEK            = 0x00000008,
+        SQL_FN_TD_DAYOFYEAR            = 0x00000010,
+        SQL_FN_TD_MONTH            = 0x00000020,
+        SQL_FN_TD_QUARTER            = 0x00000040,
+        SQL_FN_TD_WEEK            = 0x00000080,
+        SQL_FN_TD_YEAR            = 0x00000100,
+        SQL_FN_TD_CURTIME            = 0x00000200,
+        SQL_FN_TD_HOUR            = 0x00000400,
+        SQL_FN_TD_MINUTE            = 0x00000800,
+        SQL_FN_TD_SECOND            = 0x00001000,
+        SQL_FN_TD_TIMESTAMPADD        = 0x00002000,
+        SQL_FN_TD_TIMESTAMPDIFF        = 0x00004000,
+        SQL_FN_TD_DAYNAME          = 0x00008000,
+        SQL_FN_TD_MONTHNAME          = 0x00010000,
+        SQL_FN_TD_CURRENT_DATE      = 0x00020000,
+        SQL_FN_TD_CURRENT_TIME      = 0x00040000,
+        SQL_FN_TD_CURRENT_TIMESTAMP      = 0x00080000,
+        SQL_FN_TD_EXTRACT = 0x00100000
+    ],
+
+    SQL_SDF = 
+    [
+        SQL_SDF_CURRENT_DATE = 0x00000001,
+        SQL_SDF_CURRENT_TIME = 0x00000002,
+        SQL_SDF_CURRENT_TIMESTAMP = 0x00000004
+    ],
+
+    SQL_TSI =
+    [
+        //None = 0,
+
+        SQL_TSI_FRAC_SECOND = 0x00000001,
+        SQL_TSI_SECOND = 0x00000002,
+        SQL_TSI_MINUTE = 0x00000004,
+        SQL_TSI_HOUR = 0x00000008,
+        SQL_TSI_DAY = 0x00000010,
+        SQL_TSI_WEEK = 0x00000020,
+        SQL_TSI_MONTH = 0x00000040,
+        SQL_TSI_QUARTER = 0x00000080,
+        SQL_TSI_YEAR = 0x00000100
+    ],
+
+    SQL_AF = 
+    [
+        //None = 0,
+
+        SQL_AF_AVG        = 0x00000001,
+        SQL_AF_COUNT    = 0x00000002,
+        SQL_AF_MAX        = 0x00000004,
+        SQL_AF_MIN        = 0x00000008,
+        SQL_AF_SUM        = 0x00000010,
+        SQL_AF_DISTINCT    = 0x00000020,
+        SQL_AF_ALL        = 0x00000040,
+
+        All = 0xFF
+    ],
+
+    SQL_SC = 
+    [
+        //None = 0,
+
+        SQL_SC_SQL92_ENTRY            = 0x00000001,
+        SQL_SC_FIPS127_2_TRANSITIONAL    = 0x00000002,
+        SQL_SC_SQL92_INTERMEDIATE        = 0x00000004,
+        SQL_SC_SQL92_FULL            = 0x00000008
+    ],
+
+    SQL_DL_SQL92 = 
+    [
+        SQL_DL_SQL92_DATE                    = 0x00000001,
+        SQL_DL_SQL92_TIME                    = 0x00000002,
+        SQL_DL_SQL92_TIMESTAMP                = 0x00000004,
+        SQL_DL_SQL92_INTERVAL_YEAR                = 0x00000008,
+        SQL_DL_SQL92_INTERVAL_MONTH                = 0x00000010,
+        SQL_DL_SQL92_INTERVAL_DAY                = 0x00000020,
+        SQL_DL_SQL92_INTERVAL_HOUR                = 0x00000040,
+        SQL_DL_SQL92_INTERVAL_MINUTE            = 0x00000080,
+        SQL_DL_SQL92_INTERVAL_SECOND            = 0x00000100,
+        SQL_DL_SQL92_INTERVAL_YEAR_TO_MONTH            = 0x00000200,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_HOUR            = 0x00000400,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_MINUTE            = 0x00000800,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_SECOND            = 0x00001000,
+        SQL_DL_SQL92_INTERVAL_HOUR_TO_MINUTE        = 0x00002000,
+        SQL_DL_SQL92_INTERVAL_HOUR_TO_SECOND        = 0x00004000,
+        SQL_DL_SQL92_INTERVAL_MINUTE_TO_SECOND     = 0x00008000
+    ],
+
+    SQL_IK = 
+    [
+        SQL_IK_NONE        = 0x00000000,
+        SQL_IK_ASC        = 0x00000001,
+        SQL_IK_DESC        = 0x00000002,
+        SQL_IK_ALL = 0x00000003 //SQL_IK_ASC | SQL_IK_DESC
+    ],
+
+    SQL_ISV = 
+    [
+        SQL_ISV_ASSERTIONS            = 0x00000001,
+        SQL_ISV_CHARACTER_SETS        = 0x00000002,
+        SQL_ISV_CHECK_CONSTRAINTS        = 0x00000004,
+        SQL_ISV_COLLATIONS            = 0x00000008,
+        SQL_ISV_COLUMN_DOMAIN_USAGE        = 0x00000010,
+        SQL_ISV_COLUMN_PRIVILEGES        = 0x00000020,
+        SQL_ISV_COLUMNS            = 0x00000040,
+        SQL_ISV_CONSTRAINT_COLUMN_USAGE    = 0x00000080,
+        SQL_ISV_CONSTRAINT_TABLE_USAGE    = 0x00000100,
+        SQL_ISV_DOMAIN_CONSTRAINTS        = 0x00000200,
+        SQL_ISV_DOMAINS            = 0x00000400,
+        SQL_ISV_KEY_COLUMN_USAGE        = 0x00000800,
+        SQL_ISV_REFERENTIAL_CONSTRAINTS    = 0x00001000,
+        SQL_ISV_SCHEMATA            = 0x00002000,
+        SQL_ISV_SQL_LANGUAGES        = 0x00004000,
+        SQL_ISV_TABLE_CONSTRAINTS      = 0x00008000,
+        SQL_ISV_TABLE_PRIVILEGES      = 0x00010000,
+        SQL_ISV_TABLES          = 0x00020000,
+        SQL_ISV_TRANSLATIONS      = 0x00040000,
+        SQL_ISV_USAGE_PRIVILEGES      = 0x00080000,
+        SQL_ISV_VIEW_COLUMN_USAGE      = 0x00100000,
+        SQL_ISV_VIEW_TABLE_USAGE = 0x00200000,
+        SQL_ISV_VIEWS          = 0x00400000
+    ],
+
+    SQL_SRJO = 
+    [
+        //None = 0,
+
+        SQL_SRJO_CORRESPONDING_CLAUSE = 0x00000001,
+        SQL_SRJO_CROSS_JOIN = 0x00000002,
+        SQL_SRJO_EXCEPT_JOIN = 0x00000004,
+        SQL_SRJO_FULL_OUTER_JOIN = 0x00000008,
+        SQL_SRJO_INNER_JOIN = 0x00000010,
+        SQL_SRJO_INTERSECT_JOIN = 0x00000020,
+        SQL_SRJO_LEFT_OUTER_JOIN = 0x00000040,
+        SQL_SRJO_NATURAL_JOIN = 0x00000080,
+        SQL_SRJO_RIGHT_OUTER_JOIN = 0x00000100,
+        SQL_SRJO_UNION_JOIN = 0x00000200
+    ],
+
+    SQL_SRVC = 
+    [
+        SQL_SRVC_VALUE_EXPRESSION = 0x00000001,
+        SQL_SRVC_NULL = 0x00000002,
+        SQL_SRVC_DEFAULT = 0x00000004,
+        SQL_SRVC_ROW_SUBQUERY = 0x00000008
+    ],
+
+    //public static readonly int SQL_OV_ODBC3 = 3;
+    //public const Int32 SQL_NTS = -3;       //flags for null-terminated string
+
+    //Pooling
+    SQL_CP = 
+    [
+        OFF = 0,
+        ONE_PER_DRIVER = 1,
+        ONE_PER_HENV = 2
+    ],
+
+/*
+    public const Int32 SQL_CD_TRUE = 1;
+    public const Int32 SQL_CD_FALSE = 0;
+
+    public const Int32 SQL_DTC_DONE = 0;
+    public const Int32 SQL_IS_POINTER = -4;
+    public const Int32 SQL_IS_PTR = 1;
+*/
+    SQL_DRIVER =
+    [
+        NOPROMPT = 0,
+        COMPLETE = 1,
+        PROMPT = 2,
+        COMPLETE_REQUIRED = 3
+    ],
+
+    // Column set for SQLPrimaryKeys
+    SQL_PRIMARYKEYS =
+    [
+        /*
+                    CATALOGNAME         = 1,                    // TABLE_CAT
+                    SCHEMANAME          = 2,                    // TABLE_SCHEM
+                    TABLENAME           = 3,                    // TABLE_NAME
+        */
+        COLUMNNAME = 4                    // COLUMN_NAME
+        /*
+                    KEY_SEQ             = 5,                    // KEY_SEQ
+                    PKNAME              = 6,                    // PK_NAME
+        */
+    ],
+
+    // Column set for SQLStatistics
+    SQL_STATISTICS =
+    [
+        /*
+                    CATALOGNAME         = 1,                    // TABLE_CAT
+                    SCHEMANAME          = 2,                    // TABLE_SCHEM
+                    TABLENAME           = 3,                    // TABLE_NAME
+                    NONUNIQUE           = 4,                    // NON_UNIQUE
+                    INDEXQUALIFIER      = 5,                    // INDEX_QUALIFIER
+        */
+        INDEXNAME = 6,                    // INDEX_NAME
+        /*
+                    TYPE                = 7,                    // TYPE
+        */
+        ORDINAL_POSITION = 8,                    // ORDINAL_POSITION
+        COLUMN_NAME = 9                    // COLUMN_NAME
+        /*
+                    ASC_OR_DESC         = 10,                   // ASC_OR_DESC
+                    CARDINALITY         = 11,                   // CARDINALITY
+                    PAGES               = 12,                   // PAGES
+                    FILTER_CONDITION    = 13,                   // FILTER_CONDITION
+        */
+    ],
+
+    // Column set for SQLSpecialColumns
+    SQL_SPECIALCOLUMNSET =
+    [
+        /*
+                    SCOPE               = 1,                    // SCOPE
+        */
+        COLUMN_NAME = 2                    // COLUMN_NAME
+        /*
+                    DATA_TYPE           = 3,                    // DATA_TYPE
+                    TYPE_NAME           = 4,                    // TYPE_NAME
+                    COLUMN_SIZE         = 5,                    // COLUMN_SIZE
+                    BUFFER_LENGTH       = 6,                    // BUFFER_LENGTH
+                    DECIMAL_DIGITS      = 7,                    // DECIMAL_DIGITS
+                    PSEUDO_COLUMN       = 8,                    // PSEUDO_COLUMN
+        */
+    ],
+
+    SQL_DIAG =
+    [
+        CURSOR_ROW_COUNT= -1249,
+        ROW_NUMBER = -1248,
+        COLUMN_NUMBER = -1247,
+        RETURNCODE = 1,
+        NUMBER = 2,
+        ROW_COUNT = 3,
+        SQLSTATE = 4,
+        NATIVE = 5,
+        MESSAGE_TEXT = 6,
+        DYNAMIC_FUNCTION = 7,
+        CLASS_ORIGIN = 8,
+        SUBCLASS_ORIGIN = 9,
+        CONNECTION_NAME = 10,
+        SERVER_NAME = 11,
+        DYNAMIC_FUNCTION_CODE = 12
+    ],
+
+    SQL_SU =
+    [
+        SQL_SU_DML_STATEMENTS       = 0x00000001,
+        SQL_SU_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_SU_TABLE_DEFINITION     = 0x00000004,
+        SQL_SU_INDEX_DEFINITION     = 0x00000008,
+        SQL_SU_PRIVILEGE_DEFINITION = 0x00000010
+    ]
+]

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/ImpalaODBC/ImpalaODBC.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/ImpalaODBC/ImpalaODBC.pq
@@ -1,0 +1,131 @@
+﻿section ImpalaODBC;
+
+DefaultPort = 21050;
+AnonymousAuthMech = 0;
+UsernamePasswordAuthMech = 3;
+
+[DataSource.Kind="ImpalaODBC", Publish="ImpalaODBC.UI"]
+shared ImpalaODBC.Databases = (server as text, optional options as record) as table =>
+    let
+        Address = GetAddress(server),
+        HostAddress = Address[Host],
+        HostPort = Address[Port],
+        ConnectionString = [
+            Driver = "Cloudera Impala ODBC Driver",
+            Host = HostAddress,
+            Port = HostPort,
+            // We need a database name that doesn't exist in the server, because if the user doesn't have access to
+            // "default", it throws an exception. Specifying a DB that doesn't exist works fine, though.
+            Database = "DoesNotExist9A8CF2764FB34AECA572E2789EB6B2A2",
+            UseUnicodeSqlCharacterTypes = 1
+        ],
+
+        Credential = Extension.CurrentCredential(),
+        RequireEncryption = if Credential[EncryptConnection]? = null
+            then 1
+            else if Credential[EncryptConnection] = true
+                then 1 
+                else 0,
+        CredentialConnectionString = if Credential[AuthenticationKind]? = "UsernamePassword" then [
+                UID = Credential[Username], 
+                PWD = Credential[Password], 
+                AuthMech = UsernamePasswordAuthMech]
+            else [AuthMech = AnonymousAuthMech],
+        CommonOptions = [
+            CredentialConnectionString = CredentialConnectionString & [SSL = RequireEncryption],
+            ClientConnectionPooling = true,
+            OnError = OnError
+        ],
+        OdbcDatasource = Odbc.DataSource(ConnectionString, [
+            HierarchicalNavigation = true,
+            TolerateConcatOverflow = true,
+            SqlCapabilities = [
+                SupportsTop = true,
+                Sql92Conformance = 8,
+                SupportsNumericLiterals = true,
+                SupportsStringLiterals = true,
+                SupportsOdbcDateLiterals = true,
+                SupportsOdbcTimeLiterals = true,
+                SupportsOdbcTimestampLiterals = true
+            ],
+            SQLGetFunctions = [
+                // Disable using parameters in the queries that get generated.
+                // We enable numeric and string literals which should enable literals for all constants.
+                SQL_API_SQLBINDPARAMETER = false
+            ]
+        ] & CommonOptions),
+            
+        ComplexColumnsRemoved = RemoveComplexColumnsFromNavigation(OdbcDatasource{[Name="IMPALA",Kind="Database"]}[Data])
+    in
+        ComplexColumnsRemoved;
+
+RemoveComplexColumns = (data as table) as table =>
+    let
+        SchemaTable = Table.Schema(data),
+        ComplexColumnNames = Table.SelectRows(SchemaTable, each Text.Contains([NativeTypeName], "<"))[Name],
+        ComplexColumnsRemoved = 
+            if List.Count(ComplexColumnNames) = Table.RowCount(SchemaTable) then 
+                error [Reason = "DataSource.Error", Message = "No Scalar Columns available"]
+            else Table.RemoveColumns(data, ComplexColumnNames)
+    in
+        ComplexColumnsRemoved;
+            
+RemoveComplexColumnsFromNavigation = (source as table) as table =>
+    let
+        TableLevelNavigationTableType = Value.Type(source{0}[Data]),
+        TransformedTable = Table.TransformColumns(source,{{
+            "Data", 
+            (data) => Value.ReplaceType(
+                Table.TransformColumns(data, {{"Data", (rawTable) => RemoveComplexColumns(rawTable)}}),
+                TableLevelNavigationTableType)}})
+    in
+        Value.ReplaceType(TransformedTable, Value.Type(source));
+
+OnError = (errorRecord as record) =>
+    let
+        OdbcError = errorRecord[Detail][OdbcErrors]{0},
+        OdbcErrorMessage = OdbcError[Message],
+        OdbcErrorCode = OdbcError[NativeError],
+        HasCredentialError = errorRecord[Detail] <> null
+            and errorRecord[Detail][OdbcErrors]? <> null
+            and Text.Contains(OdbcErrorMessage, "[ThriftExtension]")
+            and OdbcErrorCode <> 0 and OdbcErrorCode <> 7,
+        IsSSLError = OdbcErrorCode = 6
+    in
+        if HasCredentialError then
+            if IsSSLError then 
+                error Extension.CredentialError(Credential.EncryptionNotSupported)
+            else 
+                error Extension.CredentialError(Credential.AccessDenied, OdbcErrorMessage)
+        else 
+            error errorRecord;
+
+GetAddress = (server as text) as record =>
+    let
+        Address = Uri.Parts("http://" & server),
+        BadServer = Address[Host] = "" or Address[Scheme] <> "http" or Address[Path] <> "/" or Address[Query] <> [] or Address[Fragment] <> ""
+            or Address[UserName] <> "" or Address[Password] <> "",
+        Port = if Address[Port] = 80 and not Text.EndsWith(server, ":80") then 
+                DefaultPort 
+            else Address[Port],
+        Host = Address[Host],
+        Result = [Host=Host, Port=Port]
+    in
+        if BadServer then 
+            error "Invalid server name"
+        else Result;
+
+ImpalaODBC = [
+    Authentication = [
+        UsernamePassword = [],
+        Implicit = []
+    ],
+    SupportsEncryption = true
+];
+
+ImpalaODBC.UI = [
+    Beta = true,
+    Category = "Database",
+    ButtonText = { "ImpalaODBC Sample", "ImpalaODBC Sample" },
+    SupportsDirectQuery = true
+];

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/ImpalaODBC/ImpalaODBC.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/ImpalaODBC/ImpalaODBC.query.pq
@@ -1,0 +1,5 @@
+﻿// Use this file to write queries to test your data connector
+let
+    result = ImpalaODBC.Databases("localhost")
+in
+    result

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/RedshiftODBC/Diagnostics.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/RedshiftODBC/Diagnostics.pqm
@@ -1,0 +1,275 @@
+﻿let
+    Diagnostics.LogValue = (prefix, value) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogFailure = (text, function) =>
+        let
+            result = try function()
+        in
+            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
+
+    Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
+        Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
+
+    Diagnostics.WrapHandlers = (handlers as record) as record =>
+        Record.FromList(
+            List.Transform(
+                Record.FieldNames(handlers),
+                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
+            Record.FieldNames(handlers)),
+
+    Diagnostics.ValueToText = (value) =>
+        let
+            _canBeIdentifier = (x) =>
+                                            let
+                                                keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                                charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                                charDigit = (c as number) => c>= 48 and c <= 57
+                                            in
+                                                try
+                                                    charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                    and
+                                                        List.MatchesAll(
+                                                            Text.ToList(x),
+                                                            (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                        )
+                                                    and not 
+                                                        List.MatchesAny( keywords, (li)=> li=x )
+                                                otherwise 
+                                                    false,
+    
+            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+            Serialize.Date =        (x) => "#date(" & 
+                                           Text.From(Date.Year(x))  & ", " & 
+                                           Text.From(Date.Month(x)) & ", " & 
+                                           Text.From(Date.Day(x))   & ") ",
+
+            Serialize.Datetime =    (x) => "#datetime(" &
+                                           Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                           Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                           Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                           Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                           Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                           Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+            Serialize.Datetimezone =(x) => let 
+                                              dtz = DateTimeZone.ToRecord(x) 
+                                           in
+                                              "#datetimezone(" & 
+                                              Text.From(dtz[Year])        & ", " &
+                                              Text.From(dtz[Month])       & ", " &
+                                              Text.From(dtz[Day])         & ", " &
+                                              Text.From(dtz[Hour])        & ", " &
+                                              Text.From(dtz[Minute])      & ", " &
+                                              Text.From(dtz[Second])      & ", " &
+                                              Text.From(dtz[ZoneHours])   & ", " &
+                                              Text.From(dtz[ZoneMinutes]) & ") ",
+
+            Serialize.Duration =    (x) => let
+                                              dur = Duration.ToRecord(x)
+                                           in
+                                              "#duration(" &
+                                              Text.From(dur[Days])    & ", " &
+                                              Text.From(dur[Hours])   & ", " &
+                                              Text.From(dur[Minutes]) & ", " &
+                                              Text.From(dur[Seconds]) & ") ",
+
+            Serialize.Function =    (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(Value.Type(x)),
+                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                           " as " &
+                                           _serialize_function_return_type(Value.Type(x)) &
+                                           " => (...) ",
+
+            Serialize.List =        (x) => "{" & 
+                                           List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                           "} ",
+
+            Serialize.Logical =     (x) => Text.From(x),
+
+            Serialize.Null =        (x) => "null",
+
+            Serialize.Number =      (x) => 
+                                        let Text.From = (i as number) as text => 
+                                            if Number.IsNaN(i) then "#nan" else
+                                            if i=Number.PositiveInfinity then "#infinity" else
+                                            if i=Number.NegativeInfinity then "-#infinity" else
+                                            Text.From(i)
+                                        in
+                                            Text.From(x),
+
+            Serialize.Record =      (x) => "[ " &
+                                           List.Accumulate(
+                                                Record.FieldNames(x), 
+                                                "", 
+                                                (seed,item) => 
+                                                    (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                           ) &
+                                           " ] ",
+
+            Serialize.Table =       (x) => "#table( type " &
+                                            _serialize_table_type(Value.Type(x)) &
+                                            ", " &
+                                            Serialize(Table.ToRows(x)) &
+                                            ") ",
+                                    
+            Serialize.Text =        (x) => """" & 
+                                           _serialize_text_content(x) & 
+                                           """",
+
+            _serialize_text_content =  (x) => let 
+                                                escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                            in
+                                            List.Accumulate(
+                                               List.Transform(
+                                                   Text.ToList(x),
+                                                   (c) => let n=Character.ToNumber(c) in 
+                                                            if n = 9   then "#(#)(tab)" else
+                                                            if n = 10  then "#(#)(lf)"  else
+                                                            if n = 13  then "#(#)(cr)"  else
+                                                            if n = 34  then """"""      else
+                                                            if n = 35  then "#(#)(#)"   else
+                                                            if n < 32  then escapeText(n) else 
+                                                            if n < 127 then Character.FromNumber(n) else 
+                                                            escapeText(n) 
+                                                ),
+                                                "",
+                                                (s,i)=>s&i
+                                            ),
+        
+            Serialize.Identifier =   (x) => 
+                                            if _canBeIdentifier(x) then 
+                                                x 
+                                            else 
+                                                "#""" &
+                                                _serialize_text_content(x) &
+                                                """",
+
+            Serialize.Time =        (x) => "#time(" &
+                                           Text.From(Time.Hour(x))   & ", " & 
+                                           Text.From(Time.Minute(x)) & ", " & 
+                                           Text.From(Time.Second(x)) & ") ",
+                                
+            Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                        let
+                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                        in
+                                
+                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                            if x = type any then "any" else
+                                            let base = Type.NonNullable(x) in
+                                              (if Type.IsNullable(x) then "nullable " else "") &       
+                                              (if base = type anynonnull then "anynonnull" else                
+                                              if base = type binary then "binary" else                
+                                              if base = type date   then "date"   else
+                                              if base = type datetime then "datetime" else
+                                              if base = type datetimezone then "datetimezone" else
+                                              if base = type duration then "duration" else
+                                              if base = type logical then "logical" else
+                                              if base = type none then "none" else
+                                              if base = type null then "null" else
+                                              if base = type number then "number" else
+                                              if base = type text then "text" else 
+                                              if base = type time then "time" else 
+                                              if base = type type then "type" else 
+                                      
+                                              /* Abstract types: */
+                                              if base = type function then "function" else
+                                              if base = type table then "table" else
+                                              if base = type record then "record" else
+                                              if base = type list then "list" else
+                                      
+                                              "any /*Actually unknown type*/"),
+
+            _serialize_table_type =     (x) => 
+                                               let 
+                                                 schema = Type.TableSchema(x)
+                                               in
+                                                 "table " &
+                                                 (if Table.IsEmpty(schema) then "" else 
+                                                     "[" & List.Accumulate(
+                                                        List.Transform(
+                                                            Table.ToRecords(Table.Sort(schema,"Position")),
+                                                            each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                        "",
+                                                        (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                    ) & "] " ),
+
+            _serialize_record_type =    (x) => 
+                                                let flds = Type.RecordFields(x)
+                                                in
+                                                    if Record.FieldCount(flds)=0 then "record" else
+                                                        "[" & List.Accumulate(
+                                                            Record.FieldNames(flds),
+                                                            "",
+                                                            (seed,item) => 
+                                                                seed &
+                                                                (if seed<>"" then ", " else "") &
+                                                                (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                        ) & 
+                                                        (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                        "]",
+
+            _serialize_function_type =  (x) => _serialize_function_param_type(
+                                                  Type.FunctionParameters(x),
+                                                  Type.FunctionRequiredParameters(x) ) &
+                                                " as " &
+                                                _serialize_function_return_type(x),
+    
+            _serialize_function_param_type = (t,n) => 
+                                    let
+                                        funsig = Table.ToRecords(
+                                            Table.TransformColumns(
+                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                                { "isOptional", (x)=> x>n } ) )
+                                    in
+                                        "(" & 
+                                        List.Accumulate(
+                                            funsig,
+                                            "",
+                                            (seed,item)=>
+                                                (if seed="" then "" else seed & ", ") &
+                                                (if item[isOptional] then "optional " else "") &
+                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                         & ")",
+
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+            Serialize = (x) as text => 
+                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                               if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                               if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                               if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                               if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                               if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                               if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                               if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                               if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                               if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                               "[#_unable_to_serialize_#]"                     
+        in
+            try Serialize(value) otherwise "<serialization failed>"
+in
+    [ 
+        LogValue = Diagnostics.LogValue,
+        LogValue2 = Diagnostics.LogValue2,
+        LogFailure = Diagnostics.LogFailure,
+        WrapFunctionResult = Diagnostics.WrapFunctionResult,
+        WrapHandlers = Diagnostics.WrapHandlers,
+        ValueToText = Diagnostics.ValueToText
+    ]

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/RedshiftODBC/OdbcConstants.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/RedshiftODBC/OdbcConstants.pqm
@@ -1,0 +1,1253 @@
+// values from https://github.com/Microsoft/ODBC-Specification/blob/master/Windows/inc/sqlext.h
+[
+    Flags = (flags as list) => 
+        if (List.IsEmpty(flags)) then 0 else
+        let
+            Loop = List.Generate(()=> [i = 0, Combined = flags{0}],
+                                    each [i] < List.Count(flags),
+                                    each [Combined = Number.BitwiseOr([Combined], flags{i}), i = [i]+1],
+                                    each [Combined]),
+            Result = List.Last(Loop)
+        in
+            Result,
+
+    SQL_HANDLE =
+    [
+        ENV = 1,
+        DBC = 2,
+        STMT = 3,
+        DESC = 4
+    ],
+
+    RetCode =
+    [
+        SUCCESS = 0,
+        SUCCESS_WITH_INFO = 1,
+        ERROR = -1,
+        INVALID_HANDLE = -2,
+        NO_DATA = 100
+    ],
+
+    SQL_CONVERT =
+    [
+        BIGINT = 53,
+        BINARY = 54,
+        BIT = 55,
+        CHAR = 56,
+        DATE = 57,
+        DECIMAL = 58,
+        DOUBLE = 59,
+        FLOAT = 60,
+        INTEGER = 61,
+        LONGVARCHAR = 62,
+        NUMERIC = 63,
+        REAL = 64,
+        SMALLINT = 65,
+        TIME = 66,
+        TIMESTAMP = 67,
+        TINYINT = 68,
+        VARBINARY = 69,
+        VARCHAR = 70,
+        LONGVARBINARY = 71
+    ],
+
+    SQL_ROW =
+    [
+        PROCEED = 0,
+        IGNORE = 1,
+        SUCCESS = 0,
+        DELETED = 1,
+        UPDATED = 2,
+        NOROW = 3,
+        ADDED = 4,
+        ERROR = 5,
+        SUCCESS_WITH_INFO = 6
+    ],
+
+SQL_CVT =
+[
+    //None = 0,
+
+    CHAR = 0x00000001,
+    NUMERIC = 0x00000002,
+    DECIMAL = 0x00000004,
+    INTEGER = 0x00000008,
+    SMALLINT = 0x00000010,
+    FLOAT = 0x00000020,
+    REAL = 0x00000040,
+    DOUBLE = 0x00000080,
+    VARCHAR = 0x00000100,
+    LONGVARCHAR = 0x00000200,
+    BINARY = 0x00000400,
+    VARBINARY = 0x00000800,
+    BIT = 0x00001000,
+    TINYINT = 0x00002000,
+    BIGINT = 0x00004000,
+    DATE = 0x00008000,
+    TIME = 0x00010000,
+    TIMESTAMP = 0x00020000,
+    LONGVARBINARY = 0x00040000,
+    INTERVAL_YEAR_MONTH = 0x00080000,
+    INTERVAL_DAY_TIME = 0x00100000,
+    WCHAR = 0x00200000,
+    WLONGVARCHAR = 0x00400000,
+    WVARCHAR = 0x00800000,
+    GUID = 0x01000000
+],
+
+    STMT =
+    [
+        CLOSE = 0,
+        DROP = 1,
+        UNBIND = 2,
+        RESET_PARAMS = 3
+    ],
+
+    SQL_MAX =
+    [
+        NUMERIC_LEN = 16
+    ],
+
+    SQL_IS =
+    [
+        POINTER = -4,
+        INTEGER = -6,
+        UINTEGER = -5,
+        SMALLINT = -8
+    ],
+
+    //SQL Server specific defines
+    //
+    SQL_HC =                        // from Odbcss.h
+    [
+        OFF = 0,                //  FOR BROWSE columns are hidden
+        ON = 1                //  FOR BROWSE columns are exposed
+    ],
+
+    SQL_NB =                         // from Odbcss.h
+    [
+        OFF = 0,                //  NO_BROWSETABLE is off
+        ON = 1                //  NO_BROWSETABLE is on
+    ],
+
+    //  SQLColAttributes driver specific defines.
+    //  SQLSet/GetDescField driver specific defines.
+    //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
+    //
+    SQL_CA_SS =                      // from Odbcss.h
+    [
+        BASE = 1200,           // SQL_CA_SS_BASE
+
+        COLUMN_HIDDEN = 1200 + 11,      //  Column is hidden (FOR BROWSE)
+        COLUMN_KEY = 1200 + 12,      //  Column is key column (FOR BROWSE)
+        VARIANT_TYPE = 1200 + 15,
+        VARIANT_SQL_TYPE = 1200 + 16,
+        VARIANT_SERVER_TYPE = 1200 + 17
+
+    ],
+
+    SQL_SOPT_SS =                    // from Odbcss.h
+    [
+        BASE = 1225,                // SQL_SOPT_SS_BASE
+        HIDDEN_COLUMNS = 1225 + 2,  // Expose FOR BROWSE hidden columns
+        NOBROWSETABLE = 1225 + 3    // Set NOBROWSETABLE option
+    ],
+
+    SQL_COMMIT = 0,      //Commit
+    SQL_ROLLBACK = 1,      //Abort
+
+    //static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
+    //static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
+
+    SQL_TRANSACTION =
+    [
+        READ_UNCOMMITTED = 0x00000001,
+        READ_COMMITTED = 0x00000002,
+        REPEATABLE_READ = 0x00000004,
+        SERIALIZABLE = 0x00000008,
+        SNAPSHOT = 0x00000020 // VSDD 414121: SQL_TXN_SS_SNAPSHOT == 0x20 (sqlncli.h)
+    ],
+
+    SQL_PARAM =
+    [
+        TYPE_UNKNOWN = 0,          // SQL_PARAM_TYPE_UNKNOWN
+        INPUT = 1,                 // SQL_PARAM_INPUT
+        INPUT_OUTPUT = 2,          // SQL_PARAM_INPUT_OUTPUT
+        RESULT_COL =   3,          // SQL_RESULT_COL
+        OUTPUT = 4,                // SQL_PARAM_OUTPUT
+        RETURN_VALUE = 5           // SQL_RETURN_VALUE
+    ],
+
+    SQL_DESC =
+    [
+        // from sql.h (ODBCVER >= 3.0)
+        //
+        COUNT = 1001,
+        TYPE = 1002,
+        LENGTH = 1003,
+        OCTET_LENGTH_PTR = 1004,
+        PRECISION = 1005,
+        SCALE = 1006,
+        DATETIME_INTERVAL_CODE = 1007,
+        NULLABLE = 1008,
+        INDICATOR_PTR = 1009,
+        DATA_PTR = 1010,
+        NAME = 1011,
+        UNNAMED = 1012,
+        OCTET_LENGTH = 1013,
+        ALLOC_TYPE = 1099,
+
+        // from sqlext.h (ODBCVER >= 3.0)
+        //
+        CONCISE_TYPE = SQL_COLUMN[TYPE],
+        DISPLAY_SIZE = SQL_COLUMN[DISPLAY_SIZE],
+        UNSIGNED = SQL_COLUMN[UNSIGNED],
+        UPDATABLE = SQL_COLUMN[UPDATABLE],
+        AUTO_UNIQUE_VALUE = SQL_COLUMN[AUTO_INCREMENT],
+
+        TYPE_NAME = SQL_COLUMN[TYPE_NAME],
+        TABLE_NAME = SQL_COLUMN[TABLE_NAME],
+        SCHEMA_NAME = SQL_COLUMN[OWNER_NAME],
+        CATALOG_NAME = SQL_COLUMN[QUALIFIER_NAME],
+
+        BASE_COLUMN_NAME = 22,
+        BASE_TABLE_NAME = 23,
+
+        NUM_PREC_RADIX = 32
+    ],
+
+    // ODBC version 2.0 style attributes
+    // All IdentifierValues are ODBC 1.0 unless marked differently
+    //
+    SQL_COLUMN =
+    [
+        COUNT = 0,
+        NAME = 1,
+        TYPE = 2,
+        LENGTH = 3,
+        PRECISION = 4,
+        SCALE = 5,
+        DISPLAY_SIZE = 6,
+        NULLABLE = 7,
+        UNSIGNED = 8,
+        MONEY = 9,
+        UPDATABLE = 10,
+        AUTO_INCREMENT = 11,
+        CASE_SENSITIVE = 12,
+        SEARCHABLE = 13,
+        TYPE_NAME = 14,
+        TABLE_NAME = 15,    // (ODBC 2.0)
+        OWNER_NAME = 16,    // (ODBC 2.0)
+        QUALIFIER_NAME = 17,    // (ODBC 2.0)
+        LABEL = 18
+    ],
+
+    // values from sqlext.h
+    SQL_SQL92_RELATIONAL_JOIN_OPERATORS =
+    [
+        CORRESPONDING_CLAUSE = 0x00000001,    // SQL_SRJO_CORRESPONDING_CLAUSE
+        CROSS_JOIN = 0x00000002,    // SQL_SRJO_CROSS_JOIN
+        EXCEPT_JOIN = 0x00000004,    // SQL_SRJO_EXCEPT_JOIN
+        FULL_OUTER_JOIN = 0x00000008,    // SQL_SRJO_FULL_OUTER_JOIN
+        INNER_JOIN = 0x00000010,    // SQL_SRJO_INNER_JOIN
+        INTERSECT_JOIN = 0x00000020,    // SQL_SRJO_INTERSECT_JOIN
+        LEFT_OUTER_JOIN = 0x00000040,    // SQL_SRJO_LEFT_OUTER_JOIN
+        NATURAL_JOIN = 0x00000080,    // SQL_SRJO_NATURAL_JOIN
+        RIGHT_OUTER_JOIN = 0x00000100,  // SQL_SRJO_RIGHT_OUTER_JOIN
+        UNION_JOIN = 0x00000200         // SQL_SRJO_UNION_JOIN
+    ],
+
+    // values from sqlext.h
+    SQL_QU = 
+    [
+        SQL_QU_DML_STATEMENTS = 0x00000001,
+        SQL_QU_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_QU_TABLE_DEFINITION     = 0x00000004,
+        SQL_QU_INDEX_DEFINITION     = 0x00000008,
+        SQL_QU_PRIVILEGE_DEFINITION = 0x00000010
+    ],
+
+    // values from sql.h
+    SQL_OJ_CAPABILITIES =
+    [
+        LEFT = 0x00000001,    // SQL_OJ_LEFT
+        RIGHT = 0x00000002,    // SQL_OJ_RIGHT
+        FULL = 0x00000004,    // SQL_OJ_FULL
+        NESTED = 0x00000008,    // SQL_OJ_NESTED
+        NOT_ORDERED = 0x00000010,    // SQL_OJ_NOT_ORDERED
+        INNER = 0x00000020,    // SQL_OJ_INNER
+        ALL_COMPARISON_OPS = 0x00000040  //SQL_OJ_ALLCOMPARISION+OPS
+    ],
+
+    SQL_UPDATABLE =
+    [
+        READONLY = 0,          // SQL_ATTR_READ_ONLY
+        WRITE = 1,             // SQL_ATTR_WRITE
+        READWRITE_UNKNOWN = 2  // SQL_ATTR_READWRITE_UNKNOWN
+    ],
+
+    SQL_IDENTIFIER_CASE =
+    [
+        UPPER = 1,    // SQL_IC_UPPER
+        LOWER = 2,    // SQL_IC_LOWER
+        SENSITIVE = 3,    // SQL_IC_SENSITIVE
+        MIXED = 4    // SQL_IC_MIXED
+    ],
+
+    // Uniqueness parameter in the SQLStatistics function
+    SQL_INDEX =
+    [
+        UNIQUE = 0,
+        ALL = 1
+    ],
+
+    // Reserved parameter in the SQLStatistics function
+    SQL_STATISTICS_RESERVED =
+    [
+        QUICK = 0,                // SQL_QUICK
+        ENSURE = 1                // SQL_ENSURE
+    ],
+
+    // Identifier type parameter in the SQLSpecialColumns function
+    SQL_SPECIALCOLS =
+    [
+        BEST_ROWID = 1,            // SQL_BEST_ROWID
+        ROWVER = 2            // SQL_ROWVER
+    ],
+
+    // Scope parameter in the SQLSpecialColumns function
+    SQL_SCOPE =
+    [
+        CURROW = 0,            // SQL_SCOPE_CURROW
+        TRANSACTION = 1,           // SQL_SCOPE_TRANSACTION
+        SESSION = 2           // SQL_SCOPE_SESSION
+    ],
+
+    SQL_NULLABILITY =
+    [
+        NO_NULLS = 0,                // SQL_NO_NULLS
+        NULLABLE = 1,                // SQL_NULLABLE
+        UNKNOWN = 2                 // SQL_NULLABLE_UNKNOWN
+    ],
+
+    SQL_SEARCHABLE =
+    [
+        UNSEARCHABLE = 0,        // SQL_UNSEARCHABLE
+        LIKE_ONLY = 1,        // SQL_LIKE_ONLY
+        ALL_EXCEPT_LIKE = 2,        // SQL_ALL_EXCEPT_LIKE
+        SEARCHABLE = 3        // SQL_SEARCHABLE
+    ],
+
+    SQL_UNNAMED =
+    [
+        NAMED = 0,                   // SQL_NAMED
+        UNNAMED = 1                  // SQL_UNNAMED
+    ],
+    // todo:move
+    // internal constants
+    // not odbc specific
+    //
+    HANDLER =
+    [
+        IGNORE = 0x00000000,
+        THROW = 0x00000001
+    ],
+
+    // values for SQLStatistics TYPE column
+    SQL_STATISTICSTYPE =
+    [
+        TABLE_STAT = 0,                    // TABLE Statistics
+        INDEX_CLUSTERED = 1,               // CLUSTERED index statistics
+        INDEX_HASHED = 2,                  // HASHED index statistics
+        INDEX_OTHER = 3                    // OTHER index statistics
+    ],
+
+    // values for SQLProcedures PROCEDURE_TYPE column
+    SQL_PROCEDURETYPE =
+    [
+        UNKNOWN = 0,                    // procedure is of unknow type
+        PROCEDURE = 1,                    // procedure is a procedure
+        FUNCTION = 2                     // procedure is a function
+    ],
+
+    // private constants
+    // to define data types (see below)
+    //
+    SIGNED_OFFSET = -20,      // SQL_SIGNED_OFFSET
+    UNSIGNED_OFFSET = -22,    // SQL_UNSIGNED_OFFSET
+
+    // C Data Types
+    SQL_C =
+    [
+        CHAR            = 1,
+        WCHAR           = -8,
+        SLONG           = 4     + SIGNED_OFFSET,
+        ULONG           = 4     + UNSIGNED_OFFSET,
+        SSHORT          = 5     + SIGNED_OFFSET,
+        USHORT          = 5     + UNSIGNED_OFFSET,
+        FLOAT           = 7,
+        DOUBLE          = 8,
+        BIT             = -7,
+        STINYINT        = -6    + SIGNED_OFFSET,
+        UTINYINT        = -6    + UNSIGNED_OFFSET,
+        SBIGINT         = -5    + SIGNED_OFFSET,
+        UBIGINT         = -5    + UNSIGNED_OFFSET,
+        BINARY          = -2,
+        TIMESTAMP       = 11,
+
+        TYPE_DATE       = 91,
+        TYPE_TIME       = 92,
+        TYPE_TIMESTAMP  = 93,
+
+        NUMERIC         = 2,
+        GUID            = -11,
+        DEFAULT         = 99,
+        ARD_TYPE        = -99
+    ],
+
+    // SQL Data Types
+    SQL_TYPE =
+    [
+        // Base data types (sql.h)
+        UNKNOWN             = 0,
+        NULL                = 0,
+        CHAR                = 1,
+        NUMERIC             = 2,
+        DECIMAL             = 3,
+        INTEGER             = 4,
+        SMALLINT            = 5,
+        FLOAT               = 6,
+        REAL                = 7,
+        DOUBLE              = 8,
+        DATETIME            = 9,      // V3 Only
+        VARCHAR             = 12,
+
+        // Unicode types (sqlucode.h)
+        WCHAR               = -8,
+        WVARCHAR            = -9,
+        WLONGVARCHAR        = -10,
+
+        // Extended data types (sqlext.h)
+        INTERVAL            = 10,    // V3 Only
+        TIME                = 10,
+        TIMESTAMP           = 11,
+        LONGVARCHAR         = -1,
+        BINARY              = -2,
+        VARBINARY           = -3,
+        LONGVARBINARY       = -4,
+        BIGINT              = -5,
+        TINYINT             = -6,
+        BIT                 = -7,
+        GUID                = -11,   // V3 Only
+
+        // One-parameter shortcuts for date/time data types.
+        TYPE_DATE           = 91,
+        TYPE_TIME           = 92,
+        TYPE_TIMESTAMP      = 93,
+
+        // SQL Server Types -150 to -159 (sqlncli.h)
+        SS_VARIANT          = -150,
+        SS_UDT              = -151,
+        SS_XML              = -152,
+        SS_TABLE            = -153,
+        SS_TIME2            = -154,
+        SS_TIMESTAMPOFFSET  = -155
+    ],
+
+    //SQL_ALL_TYPES = 0,
+    //static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
+
+    SQL_LENGTH = 
+    [
+        SQL_IGNORE = -6,
+        SQL_DEFAULT_PARAM = -5,
+        SQL_NO_TOTAL = -4,
+        SQL_NTS = -3,
+        SQL_DATA_AT_EXEC = -2,
+        SQL_NULL_DATA = -1
+    ],
+
+    SQL_DEFAULT_PARAM = -5,        
+
+    // column ordinals for SQLProcedureColumns result set
+    // this column ordinals are not defined in any c/c++ header but in the ODBC Programmer's Reference under SQLProcedureColumns
+    //
+    COLUMN_NAME = 4,
+    COLUMN_TYPE = 5,
+    DATA_TYPE = 6,
+    COLUMN_SIZE = 8,
+    DECIMAL_DIGITS = 10,
+    NUM_PREC_RADIX = 11,
+
+    SQL_ATTR = 
+    [
+        ODBC_VERSION = 200,
+        CONNECTION_POOLING = 201,
+        AUTOCOMMIT = 102,
+        TXN_ISOLATION = 108,
+        CURRENT_CATALOG = 109,
+        LOGIN_TIMEOUT = 103,
+        QUERY_TIMEOUT = 0,
+        CONNECTION_DEAD = 1209,
+
+        SQL_COPT_SS_BASE = 1200,
+        SQL_COPT_SS_ENLIST_IN_DTC = (1200 + 7),
+        SQL_COPT_SS_TXN_ISOLATION = (1200 + 27),
+
+        MAX_LENGTH = 3,
+        ROW_BIND_TYPE = 5,
+        CURSOR_TYPE = 6,
+        RETRIEVE_DATA = 11,
+        ROW_STATUS_PTR = 25, 
+        ROWS_FETCHED_PTR = 26,
+        ROW_ARRAY_SIZE = 27,
+
+        // ODBC 3.0
+        APP_ROW_DESC = 10010,
+        APP_PARAM_DESC = 10011,
+        IMP_ROW_DESC = 10012,
+        IMP_PARAM_DESC = 10013,
+        METADATA_ID = 10014,
+
+        // ODBC 4.0
+        PRIVATE_DRIVER_LOCATION = 204
+    ],
+
+    SQL_RD = 
+    [
+        OFF = 0,
+        ON = 1
+    ],
+
+    SQL_GD = 
+    [
+        //None =  0,
+        ANY_COLUMN = 1,
+        ANY_ORDER = 2,
+        BLOCK = 4,
+        BOUND = 8,
+        OUTPUT_PARAMS = 16
+    ],
+
+    //SQLGetInfo
+/*
+    SQL_INFO =
+    [
+        SQL_ACTIVE_CONNECTIONS = 0,        
+        SQL_MAX_DRIVER_CONNECTIONS = 0,
+        SQL_MAX_CONCURRENT_ACTIVITIES = 1,
+        SQL_ACTIVE_STATEMENTS = 1,         
+        SQL_DATA_SOURCE_NAME = 2,          
+        SQL_DRIVER_HDBC,                   
+        SQL_DRIVER_HENV,                   
+        SQL_DRIVER_HSTMT,                  
+        SQL_DRIVER_NAME,                   
+        SQL_DRIVER_VER,                    
+        SQL_FETCH_DIRECTION,               
+        SQL_ODBC_API_CONFORMANCE,          
+        SQL_ODBC_VER,                      
+        SQL_ROW_UPDATES,                   
+        SQL_ODBC_SAG_CLI_CONFORMANCE,      
+        SQL_SERVER_NAME,                   
+        SQL_SEARCH_PATTERN_ESCAPE,         
+        SQL_ODBC_SQL_CONFORMANCE,          
+
+        SQL_DATABASE_NAME,                 
+        SQL_DBMS_NAME,                     
+        SQL_DBMS_VER,                      
+
+        SQL_ACCESSIBLE_TABLES,             
+        SQL_ACCESSIBLE_PROCEDURES,         
+        SQL_PROCEDURES,                    
+        SQL_CONCAT_NULL_BEHAVIOR,          
+        SQL_CURSOR_COMMIT_BEHAVIOR,        
+        SQL_CURSOR_ROLLBACK_BEHAVIOR,      
+        SQL_DATA_SOURCE_READ_ONLY,         
+        SQL_DEFAULT_TXN_ISOLATION,         
+        SQL_EXPRESSIONS_IN_ORDERBY,        
+        SQL_IDENTIFIER_CASE,               
+        SQL_IDENTIFIER_QUOTE_CHAR,         
+        SQL_MAX_COLUMN_NAME_LEN,           
+        SQL_MAX_CURSOR_NAME_LEN,           
+        SQL_MAX_OWNER_NAME_LEN,            
+        SQL_MAX_SCHEMA_NAME_LEN = 32,
+        SQL_MAX_PROCEDURE_NAME_LEN,        
+        SQL_MAX_QUALIFIER_NAME_LEN,        
+        SQL_MAX_CATALOG_NAME_LEN = 34,
+        SQL_MAX_TABLE_NAME_LEN,            
+        SQL_MULT_RESULT_SETS,              
+        SQL_MULTIPLE_ACTIVE_TXN,           
+        SQL_OUTER_JOINS,                   
+        SQL_SCHEMA_TERM,                   
+        SQL_PROCEDURE_TERM,                
+        SQL_CATALOG_NAME_SEPARATOR,        
+        SQL_CATALOG_TERM,                  
+        SQL_SCROLL_CONCURRENCY,            
+        SQL_SCROLL_OPTIONS,                
+        SQL_TABLE_TERM,                    
+        SQL_TXN_CAPABLE,                   
+        SQL_USER_NAME,                     
+
+        SQL_CONVERT_FUNCTIONS,             
+        SQL_NUMERIC_FUNCTIONS,             
+        SQL_STRING_FUNCTIONS,              
+        SQL_SYSTEM_FUNCTIONS,              
+        SQL_TIMEDATE_FUNCTIONS,            
+
+        SQL_CONVERT_BIGINT,
+        SQL_CONVERT_BINARY,
+        SQL_CONVERT_BIT,
+        SQL_CONVERT_CHAR,
+        SQL_CONVERT_DATE,
+        SQL_CONVERT_DECIMAL,
+        SQL_CONVERT_DOUBLE,
+        SQL_CONVERT_FLOAT,            
+        SQL_CONVERT_INTEGER,
+        SQL_CONVERT_LONGVARCHAR,
+        SQL_CONVERT_NUMERIC,
+        SQL_CONVERT_REAL,
+        SQL_CONVERT_SMALLINT,
+        SQL_CONVERT_TIME,
+        SQL_CONVERT_TIMESTAMP,
+        SQL_CONVERT_TINYINT,
+        SQL_CONVERT_VARBINARY,
+        SQL_CONVERT_VARCHAR,          
+        SQL_CONVERT_LONGVARBINARY,
+
+        SQL_TXN_ISOLATION_OPTION,     
+        SQL_ODBC_SQL_OPT_IEF,
+        SQL_INTEGRITY = 73,
+        SQL_CORRELATION_NAME,
+        SQL_NON_NULLABLE_COLUMNS,
+        SQL_DRIVER_HLIB,
+        SQL_DRIVER_ODBC_VER,
+        SQL_LOCK_TYPES,
+        SQL_POS_OPERATIONS,
+        SQL_POSITIONED_STATEMENTS,        
+        SQL_GETDATA_EXTENSIONS,
+        SQL_BOOKMARK_PERSISTENCE,
+        SQL_STATIC_SENSITIVITY,
+        SQL_FILE_USAGE,
+        SQL_NULL_COLLATION,
+        SQL_ALTER_TABLE,
+        SQL_COLUMN_ALIAS,
+        SQL_GROUP_BY,
+        SQL_KEYWORDS,
+        SQL_ORDER_BY_COLUMNS_IN_SELECT,   
+        SQL_SCHEMA_USAGE,
+        SQL_CATALOG_USAGE,
+        SQL_QUOTED_IDENTIFIER_CASE,
+        SQL_SPECIAL_CHARACTERS,
+        SQL_SUBQUERIES,
+        SQL_UNION_STATEMENT,
+        SQL_MAX_COLUMNS_IN_GROUP_BY,
+        SQL_MAX_COLUMNS_IN_INDEX,
+        SQL_MAX_COLUMNS_IN_ORDER_BY,
+        SQL_MAX_COLUMNS_IN_SELECT,        
+        SQL_MAX_COLUMNS_IN_TABLE,
+        SQL_MAX_INDEX_SIZE,
+        SQL_MAX_ROW_SIZE_INCLUDES_LONG,
+        SQL_MAX_ROW_SIZE,
+        SQL_MAX_STATEMENT_LEN,
+        SQL_MAX_TABLES_IN_SELECT,
+        SQL_MAX_USER_NAME_LEN,
+        SQL_MAX_CHAR_LITERAL_LEN,
+        SQL_TIMEDATE_ADD_INTERVALS,
+        SQL_TIMEDATE_DIFF_INTERVALS,      
+        SQL_NEED_LONG_DATA_LEN,
+        SQL_MAX_BINARY_LITERAL_LEN,
+        SQL_LIKE_ESCAPE_CLAUSE,
+        SQL_CATALOG_LOCATION,
+        SQL_OJ_CAPABILITIES,
+
+        SQL_ACTIVE_ENVIRONMENTS,
+        SQL_ALTER_DOMAIN,
+        SQL_SQL_CONFORMANCE,
+        SQL_DATETIME_LITERALS,
+        SQL_BATCH_ROW_COUNT,              
+        SQL_BATCH_SUPPORT,
+        SQL_CONVERT_WCHAR,
+        SQL_CONVERT_INTERVAL_DAY_TIME,
+        SQL_CONVERT_INTERVAL_YEAR_MONTH,
+        SQL_CONVERT_WLONGVARCHAR,
+        SQL_CONVERT_WVARCHAR,
+        SQL_CREATE_ASSERTION,
+        SQL_CREATE_CHARACTER_SET,
+        SQL_CREATE_COLLATION,
+        SQL_CREATE_DOMAIN,                  
+        SQL_CREATE_SCHEMA,
+        SQL_CREATE_TABLE,
+        SQL_CREATE_TRANSLATION,
+        SQL_CREATE_VIEW,
+        SQL_DRIVER_HDESC,
+        SQL_DROP_ASSERTION,
+        SQL_DROP_CHARACTER_SET,
+        SQL_DROP_COLLATION,
+        SQL_DROP_DOMAIN,
+        SQL_DROP_SCHEMA,                    
+        SQL_DROP_TABLE,
+        SQL_DROP_TRANSLATION,
+        SQL_DROP_VIEW,
+        SQL_DYNAMIC_CURSOR_ATTRIBUTES1,
+        SQL_DYNAMIC_CURSOR_ATTRIBUTES2,
+        SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1,
+        SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2,
+        SQL_INDEX_KEYWORDS,
+        SQL_INFO_SCHEMA_VIEWS,
+        SQL_KEYSET_CURSOR_ATTRIBUTES1,    
+        SQL_KEYSET_CURSOR_ATTRIBUTES2,
+        SQL_ODBC_INTERFACE_CONFORMANCE,
+        SQL_PARAM_ARRAY_ROW_COUNTS,
+        SQL_PARAM_ARRAY_SELECTS,
+        SQL_SQL92_DATETIME_FUNCTIONS,
+        SQL_SQL92_FOREIGN_KEY_DELETE_RULE,
+        SQL_SQL92_FOREIGN_KEY_UPDATE_RULE,
+        SQL_SQL92_GRANT,
+        SQL_SQL92_NUMERIC_VALUE_FUNCTIONS,
+        SQL_SQL92_PREDICATES,              
+        SQL_SQL92_RELATIONAL_JOIN_OPERATORS,
+        SQL_SQL92_REVOKE,
+        SQL_SQL92_ROW_VALUE_CONSTRUCTOR,
+        SQL_SQL92_STRING_FUNCTIONS,
+        SQL_SQL92_VALUE_EXPRESSIONS,
+        SQL_STANDARD_CLI_CONFORMANCE,
+        SQL_STATIC_CURSOR_ATTRIBUTES1,
+        SQL_STATIC_CURSOR_ATTRIBUTES2,
+        SQL_AGGREGATE_FUNCTIONS,
+        SQL_DDL_INDEX,                   
+        SQL_DM_VER,
+        SQL_INSERT_STATEMENT,
+        SQL_CONVERT_GUID,
+
+        SQL_XOPEN_CLI_YEAR = 10000,      
+        SQL_CURSOR_SENSITIVITY,
+        SQL_DESCRIBE_PARAMETER,
+        SQL_CATALOG_NAME,
+        SQL_COLLATION_SEQ,
+        SQL_MAX_IDENTIFIER_LEN,
+        SQL_ASYNC_MODE = 10021,          
+        SQL_MAX_ASYNC_CONCURRENT_STATEMENTS,
+
+        SQL_DTC_TRANSITION_COST = 1750,
+    ],
+*/
+    SQL_OAC = 
+    [
+        SQL_OAC_None = 0x0000,
+        SQL_OAC_LEVEL1 = 0x0001,
+        SQL_OAC_LEVEL2 = 0x0002
+    ],
+
+    SQL_OSC = 
+    [
+        SQL_OSC_MINIMUM = 0x0000,
+        SQL_OSC_CORE = 0x0001,
+        SQL_OSC_EXTENDED = 0x0002
+    ],
+
+    SQL_SCC = 
+    [
+        SQL_SCC_XOPEN_CLI_VERSION1 = 0x00000001,
+        SQL_SCC_ISO92_CLI = 0x00000002
+    ],
+
+    SQL_SVE = 
+    [
+        SQL_SVE_CASE = 0x00000001,
+        SQL_SVE_CAST = 0x00000002,
+        SQL_SVE_COALESCE = 0x00000004,
+        SQL_SVE_NULLIF = 0x00000008
+    ],
+
+    SQL_SSF = 
+    [
+        SQL_SSF_CONVERT = 0x00000001,
+        SQL_SSF_LOWER = 0x00000002,
+        SQL_SSF_UPPER = 0x00000004,
+        SQL_SSF_SUBSTRING = 0x00000008,
+        SQL_SSF_TRANSLATE = 0x00000010,
+        SQL_SSF_TRIM_BOTH = 0x00000020,
+        SQL_SSF_TRIM_LEADING = 0x00000040,
+        SQL_SSF_TRIM_TRAILING = 0x00000080
+    ],
+
+    SQL_SP = 
+    [
+        //None = 0,
+
+        SQL_SP_EXISTS = 0x00000001,
+        SQL_SP_ISNOTNULL = 0x00000002,
+        SQL_SP_ISNULL = 0x00000004,
+        SQL_SP_MATCH_FULL = 0x00000008,
+        SQL_SP_MATCH_PARTIAL = 0x00000010,
+        SQL_SP_MATCH_UNIQUE_FULL = 0x00000020,
+        SQL_SP_MATCH_UNIQUE_PARTIAL = 0x00000040,
+        SQL_SP_OVERLAPS = 0x00000080,
+        SQL_SP_UNIQUE = 0x00000100,
+        SQL_SP_LIKE = 0x00000200,
+        SQL_SP_IN = 0x00000400,
+        SQL_SP_BETWEEN = 0x00000800,
+        SQL_SP_COMPARISON = 0x00001000,
+        SQL_SP_QUANTIFIED_COMPARISON = 0x00002000,
+
+        All = 0x0000FFFF
+    ],
+
+    SQL_OIC =
+    [
+        SQL_OIC_CORE = 1,
+        SQL_OIC_LEVEL1 = 2,
+        SQL_OIC_LEVEL2 = 3
+    ],
+
+    SQL_USAGE = 
+    [
+        SQL_U_DML_STATEMENTS = 0x00000001,
+        SQL_U_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_U_TABLE_DEFINITION = 0x00000004,
+        SQL_U_INDEX_DEFINITION = 0x00000008,
+        SQL_U_PRIVILEGE_DEFINITION = 0x00000010
+    ],
+
+    SQL_GB = 
+    [
+            
+        SQL_GB_NOT_SUPPORTED = 0,
+        SQL_GB_GROUP_BY_EQUALS_SELECT = 1,
+        SQL_GB_GROUP_BY_CONTAINS_SELECT = 2,
+        SQL_GB_NO_RELATION = 3,
+        SQL_GB_COLLATE = 4
+    ],
+
+    SQL_NC =
+    [
+        SQL_NC_END = 0,
+        SQL_NC_HIGH = 1,
+        SQL_NC_LOW = 2,
+        SQL_NC_START = 3
+    ],
+
+    SQL_CN =
+    [
+        SQL_CN_None = 0,
+        SQL_CN_DIFFERENT = 1,
+        SQL_CN_ANY = 2
+    ],
+
+    SQL_NNC = 
+    [
+        SQL_NNC_NULL = 0,
+        SQL_NNC_NON_NULL = 1
+    ],
+
+    SQL_CB = 
+    [
+        SQL_CB_NULL = 0,
+        SQL_CB_NON_NULL = 1
+    ],
+
+    SQL_FD_FETCH = 
+    [
+        SQL_FD_FETCH_NEXT = 0x00000001,
+        SQL_FD_FETCH_FIRST = 0x00000002,
+        SQL_FD_FETCH_LAST = 0x00000004,
+        SQL_FD_FETCH_PRIOR = 0x00000008,
+        SQL_FD_FETCH_ABSOLUTE = 0x00000010,
+        SQL_FD_FETCH_RELATIVE = 0x00000020,
+        SQL_FD_FETCH_BOOKMARK = 0x00000080
+    ],
+
+    SQL_SQ = 
+    [
+        SQL_SQ_COMPARISON = 0x00000001,
+        SQL_SQ_EXISTS = 0x00000002,
+        SQL_SQ_IN = 0x00000004,
+        SQL_SQ_QUANTIFIED = 0x00000008,
+        SQL_SQ_CORRELATED_SUBQUERIES = 0x00000010
+    ],
+
+    SQL_U = 
+    [
+        SQL_U_UNION = 0x00000001,
+        SQL_U_UNION_ALL = 0x00000002
+    ],
+
+    SQL_BP = 
+    [
+        SQL_BP_CLOSE = 0x00000001,
+        SQL_BP_DELETE = 0x00000002,
+        SQL_BP_DROP = 0x00000004,
+        SQL_BP_TRANSACTION = 0x00000008,
+        SQL_BP_UPDATE = 0x00000010,
+        SQL_BP_OTHER_HSTMT = 0x00000020,
+        SQL_BP_SCROLL = 0x00000040
+    ],
+
+    SQL_QL = 
+    [
+        SQL_QL_START = 0x0001,
+        SQL_QL_END = 0x0002
+    ],
+
+    SQL_OJ = 
+    [
+        SQL_OJ_LEFT = 0x00000001,
+        SQL_OJ_RIGHT = 0x00000002,
+        SQL_OJ_FULL = 0x00000004,
+        SQL_OJ_NESTED = 0x00000008,
+        SQL_OJ_NOT_ORDERED = 0x00000010,
+        SQL_OJ_INNER = 0x00000020,
+        SQL_OJ_ALL_COMPARISON_OPS = 0x00000040
+    ],
+
+    SQL_FN_CVT = 
+    [
+        //None = 0,
+
+        SQL_FN_CVT_CONVERT        = 0x00000001,
+        SQL_FN_CVT_CAST        = 0x00000002
+    ],
+
+    SQL_FN_NUM = 
+    [
+        //None = 0,
+
+        SQL_FN_NUM_ABS        = 0x00000001,
+        SQL_FN_NUM_ACOS        = 0x00000002,
+        SQL_FN_NUM_ASIN        = 0x00000004,
+        SQL_FN_NUM_ATAN        = 0x00000008,
+        SQL_FN_NUM_ATAN2    = 0x00000010,
+        SQL_FN_NUM_CEILING    = 0x00000020,
+        SQL_FN_NUM_COS        = 0x00000040,
+        SQL_FN_NUM_COT        = 0x00000080,
+        SQL_FN_NUM_EXP        = 0x00000100,
+        SQL_FN_NUM_FLOOR    = 0x00000200,
+        SQL_FN_NUM_LOG        = 0x00000400,
+        SQL_FN_NUM_MOD        = 0x00000800,
+        SQL_FN_NUM_SIGN        = 0x00001000,
+        SQL_FN_NUM_SIN        = 0x00002000,
+        SQL_FN_NUM_SQRT        = 0x00004000,
+        SQL_FN_NUM_TAN      = 0x00008000,
+        SQL_FN_NUM_PI       = 0x00010000,
+        SQL_FN_NUM_RAND     = 0x00020000,
+        SQL_FN_NUM_DEGREES    = 0x00040000,
+        SQL_FN_NUM_LOG10    = 0x00080000,
+        SQL_FN_NUM_POWER    = 0x00100000,
+        SQL_FN_NUM_RADIANS    = 0x00200000,
+        SQL_FN_NUM_ROUND    = 0x00400000,
+        SQL_FN_NUM_TRUNCATE = 0x00800000
+    ],
+
+    SQL_SNVF = 
+    [
+        SQL_SNVF_BIT_LENGTH = 0x00000001,
+        SQL_SNVF_CHAR_LENGTH = 0x00000002,
+        SQL_SNVF_CHARACTER_LENGTH = 0x00000004,
+        SQL_SNVF_EXTRACT = 0x00000008,
+        SQL_SNVF_OCTET_LENGTH = 0x00000010,
+        SQL_SNVF_POSITION = 0x00000020
+    ],
+
+    SQL_FN_STR =
+    [
+        //None = 0,
+
+        SQL_FN_STR_CONCAT            = 0x00000001,
+        SQL_FN_STR_INSERT            = 0x00000002,
+        SQL_FN_STR_LEFT            = 0x00000004,
+        SQL_FN_STR_LTRIM            = 0x00000008,
+        SQL_FN_STR_LENGTH            = 0x00000010,
+        SQL_FN_STR_LOCATE            = 0x00000020,
+        SQL_FN_STR_LCASE            = 0x00000040,
+        SQL_FN_STR_REPEAT            = 0x00000080,
+        SQL_FN_STR_REPLACE            = 0x00000100,
+        SQL_FN_STR_RIGHT            = 0x00000200,
+        SQL_FN_STR_RTRIM            = 0x00000400,
+        SQL_FN_STR_SUBSTRING        = 0x00000800,
+        SQL_FN_STR_UCASE            = 0x00001000,
+        SQL_FN_STR_ASCII            = 0x00002000,
+        SQL_FN_STR_CHAR            = 0x00004000,
+        SQL_FN_STR_DIFFERENCE = 0x00008000,
+        SQL_FN_STR_LOCATE_2          = 0x00010000,
+        SQL_FN_STR_SOUNDEX          = 0x00020000,
+        SQL_FN_STR_SPACE          = 0x00040000,
+        SQL_FN_STR_BIT_LENGTH      = 0x00080000,
+        SQL_FN_STR_CHAR_LENGTH      = 0x00100000,
+        SQL_FN_STR_CHARACTER_LENGTH      = 0x00200000,
+        SQL_FN_STR_OCTET_LENGTH = 0x00400000,
+        SQL_FN_STR_POSITION = 0x00800000
+    ],
+
+    SQL_FN_SYSTEM = 
+    [
+        //None = 0,
+
+        SQL_FN_SYS_USERNAME = 0x00000001,
+        SQL_FN_SYS_DBNAME = 0x00000002,
+        SQL_FN_SYS_IFNULL = 0x00000004
+    ],
+
+    SQL_FN_TD = 
+    [
+        //None = 0,
+
+        SQL_FN_TD_NOW            = 0x00000001,
+        SQL_FN_TD_CURDATE            = 0x00000002,
+        SQL_FN_TD_DAYOFMONTH        = 0x00000004,
+        SQL_FN_TD_DAYOFWEEK            = 0x00000008,
+        SQL_FN_TD_DAYOFYEAR            = 0x00000010,
+        SQL_FN_TD_MONTH            = 0x00000020,
+        SQL_FN_TD_QUARTER            = 0x00000040,
+        SQL_FN_TD_WEEK            = 0x00000080,
+        SQL_FN_TD_YEAR            = 0x00000100,
+        SQL_FN_TD_CURTIME            = 0x00000200,
+        SQL_FN_TD_HOUR            = 0x00000400,
+        SQL_FN_TD_MINUTE            = 0x00000800,
+        SQL_FN_TD_SECOND            = 0x00001000,
+        SQL_FN_TD_TIMESTAMPADD        = 0x00002000,
+        SQL_FN_TD_TIMESTAMPDIFF        = 0x00004000,
+        SQL_FN_TD_DAYNAME          = 0x00008000,
+        SQL_FN_TD_MONTHNAME          = 0x00010000,
+        SQL_FN_TD_CURRENT_DATE      = 0x00020000,
+        SQL_FN_TD_CURRENT_TIME      = 0x00040000,
+        SQL_FN_TD_CURRENT_TIMESTAMP      = 0x00080000,
+        SQL_FN_TD_EXTRACT = 0x00100000
+    ],
+
+    SQL_SDF = 
+    [
+        SQL_SDF_CURRENT_DATE = 0x00000001,
+        SQL_SDF_CURRENT_TIME = 0x00000002,
+        SQL_SDF_CURRENT_TIMESTAMP = 0x00000004
+    ],
+
+    SQL_TSI =
+    [
+        //None = 0,
+
+        SQL_TSI_FRAC_SECOND = 0x00000001,
+        SQL_TSI_SECOND = 0x00000002,
+        SQL_TSI_MINUTE = 0x00000004,
+        SQL_TSI_HOUR = 0x00000008,
+        SQL_TSI_DAY = 0x00000010,
+        SQL_TSI_WEEK = 0x00000020,
+        SQL_TSI_MONTH = 0x00000040,
+        SQL_TSI_QUARTER = 0x00000080,
+        SQL_TSI_YEAR = 0x00000100
+    ],
+
+    SQL_AF = 
+    [
+        //None = 0,
+
+        SQL_AF_AVG        = 0x00000001,
+        SQL_AF_COUNT    = 0x00000002,
+        SQL_AF_MAX        = 0x00000004,
+        SQL_AF_MIN        = 0x00000008,
+        SQL_AF_SUM        = 0x00000010,
+        SQL_AF_DISTINCT    = 0x00000020,
+        SQL_AF_ALL        = 0x00000040,
+
+        All = 0xFF
+    ],
+
+    SQL_SC = 
+    [
+        //None = 0,
+
+        SQL_SC_SQL92_ENTRY            = 0x00000001,
+        SQL_SC_FIPS127_2_TRANSITIONAL    = 0x00000002,
+        SQL_SC_SQL92_INTERMEDIATE        = 0x00000004,
+        SQL_SC_SQL92_FULL            = 0x00000008
+    ],
+
+    SQL_DL_SQL92 = 
+    [
+        SQL_DL_SQL92_DATE                    = 0x00000001,
+        SQL_DL_SQL92_TIME                    = 0x00000002,
+        SQL_DL_SQL92_TIMESTAMP                = 0x00000004,
+        SQL_DL_SQL92_INTERVAL_YEAR                = 0x00000008,
+        SQL_DL_SQL92_INTERVAL_MONTH                = 0x00000010,
+        SQL_DL_SQL92_INTERVAL_DAY                = 0x00000020,
+        SQL_DL_SQL92_INTERVAL_HOUR                = 0x00000040,
+        SQL_DL_SQL92_INTERVAL_MINUTE            = 0x00000080,
+        SQL_DL_SQL92_INTERVAL_SECOND            = 0x00000100,
+        SQL_DL_SQL92_INTERVAL_YEAR_TO_MONTH            = 0x00000200,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_HOUR            = 0x00000400,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_MINUTE            = 0x00000800,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_SECOND            = 0x00001000,
+        SQL_DL_SQL92_INTERVAL_HOUR_TO_MINUTE        = 0x00002000,
+        SQL_DL_SQL92_INTERVAL_HOUR_TO_SECOND        = 0x00004000,
+        SQL_DL_SQL92_INTERVAL_MINUTE_TO_SECOND     = 0x00008000
+    ],
+
+    SQL_IK = 
+    [
+        SQL_IK_NONE        = 0x00000000,
+        SQL_IK_ASC        = 0x00000001,
+        SQL_IK_DESC        = 0x00000002,
+        SQL_IK_ALL = 0x00000003 //SQL_IK_ASC | SQL_IK_DESC
+    ],
+
+    SQL_ISV = 
+    [
+        SQL_ISV_ASSERTIONS            = 0x00000001,
+        SQL_ISV_CHARACTER_SETS        = 0x00000002,
+        SQL_ISV_CHECK_CONSTRAINTS        = 0x00000004,
+        SQL_ISV_COLLATIONS            = 0x00000008,
+        SQL_ISV_COLUMN_DOMAIN_USAGE        = 0x00000010,
+        SQL_ISV_COLUMN_PRIVILEGES        = 0x00000020,
+        SQL_ISV_COLUMNS            = 0x00000040,
+        SQL_ISV_CONSTRAINT_COLUMN_USAGE    = 0x00000080,
+        SQL_ISV_CONSTRAINT_TABLE_USAGE    = 0x00000100,
+        SQL_ISV_DOMAIN_CONSTRAINTS        = 0x00000200,
+        SQL_ISV_DOMAINS            = 0x00000400,
+        SQL_ISV_KEY_COLUMN_USAGE        = 0x00000800,
+        SQL_ISV_REFERENTIAL_CONSTRAINTS    = 0x00001000,
+        SQL_ISV_SCHEMATA            = 0x00002000,
+        SQL_ISV_SQL_LANGUAGES        = 0x00004000,
+        SQL_ISV_TABLE_CONSTRAINTS      = 0x00008000,
+        SQL_ISV_TABLE_PRIVILEGES      = 0x00010000,
+        SQL_ISV_TABLES          = 0x00020000,
+        SQL_ISV_TRANSLATIONS      = 0x00040000,
+        SQL_ISV_USAGE_PRIVILEGES      = 0x00080000,
+        SQL_ISV_VIEW_COLUMN_USAGE      = 0x00100000,
+        SQL_ISV_VIEW_TABLE_USAGE = 0x00200000,
+        SQL_ISV_VIEWS          = 0x00400000
+    ],
+
+    SQL_SRJO = 
+    [
+        //None = 0,
+
+        SQL_SRJO_CORRESPONDING_CLAUSE = 0x00000001,
+        SQL_SRJO_CROSS_JOIN = 0x00000002,
+        SQL_SRJO_EXCEPT_JOIN = 0x00000004,
+        SQL_SRJO_FULL_OUTER_JOIN = 0x00000008,
+        SQL_SRJO_INNER_JOIN = 0x00000010,
+        SQL_SRJO_INTERSECT_JOIN = 0x00000020,
+        SQL_SRJO_LEFT_OUTER_JOIN = 0x00000040,
+        SQL_SRJO_NATURAL_JOIN = 0x00000080,
+        SQL_SRJO_RIGHT_OUTER_JOIN = 0x00000100,
+        SQL_SRJO_UNION_JOIN = 0x00000200
+    ],
+
+    SQL_SRVC = 
+    [
+        SQL_SRVC_VALUE_EXPRESSION = 0x00000001,
+        SQL_SRVC_NULL = 0x00000002,
+        SQL_SRVC_DEFAULT = 0x00000004,
+        SQL_SRVC_ROW_SUBQUERY = 0x00000008
+    ],
+
+    //public static readonly int SQL_OV_ODBC3 = 3;
+    //public const Int32 SQL_NTS = -3;       //flags for null-terminated string
+
+    //Pooling
+    SQL_CP = 
+    [
+        OFF = 0,
+        ONE_PER_DRIVER = 1,
+        ONE_PER_HENV = 2
+    ],
+
+/*
+    public const Int32 SQL_CD_TRUE = 1;
+    public const Int32 SQL_CD_FALSE = 0;
+
+    public const Int32 SQL_DTC_DONE = 0;
+    public const Int32 SQL_IS_POINTER = -4;
+    public const Int32 SQL_IS_PTR = 1;
+*/
+    SQL_DRIVER =
+    [
+        NOPROMPT = 0,
+        COMPLETE = 1,
+        PROMPT = 2,
+        COMPLETE_REQUIRED = 3
+    ],
+
+    // Column set for SQLPrimaryKeys
+    SQL_PRIMARYKEYS =
+    [
+        /*
+                    CATALOGNAME         = 1,                    // TABLE_CAT
+                    SCHEMANAME          = 2,                    // TABLE_SCHEM
+                    TABLENAME           = 3,                    // TABLE_NAME
+        */
+        COLUMNNAME = 4                    // COLUMN_NAME
+        /*
+                    KEY_SEQ             = 5,                    // KEY_SEQ
+                    PKNAME              = 6,                    // PK_NAME
+        */
+    ],
+
+    // Column set for SQLStatistics
+    SQL_STATISTICS =
+    [
+        /*
+                    CATALOGNAME         = 1,                    // TABLE_CAT
+                    SCHEMANAME          = 2,                    // TABLE_SCHEM
+                    TABLENAME           = 3,                    // TABLE_NAME
+                    NONUNIQUE           = 4,                    // NON_UNIQUE
+                    INDEXQUALIFIER      = 5,                    // INDEX_QUALIFIER
+        */
+        INDEXNAME = 6,                    // INDEX_NAME
+        /*
+                    TYPE                = 7,                    // TYPE
+        */
+        ORDINAL_POSITION = 8,                    // ORDINAL_POSITION
+        COLUMN_NAME = 9                    // COLUMN_NAME
+        /*
+                    ASC_OR_DESC         = 10,                   // ASC_OR_DESC
+                    CARDINALITY         = 11,                   // CARDINALITY
+                    PAGES               = 12,                   // PAGES
+                    FILTER_CONDITION    = 13,                   // FILTER_CONDITION
+        */
+    ],
+
+    // Column set for SQLSpecialColumns
+    SQL_SPECIALCOLUMNSET =
+    [
+        /*
+                    SCOPE               = 1,                    // SCOPE
+        */
+        COLUMN_NAME = 2                    // COLUMN_NAME
+        /*
+                    DATA_TYPE           = 3,                    // DATA_TYPE
+                    TYPE_NAME           = 4,                    // TYPE_NAME
+                    COLUMN_SIZE         = 5,                    // COLUMN_SIZE
+                    BUFFER_LENGTH       = 6,                    // BUFFER_LENGTH
+                    DECIMAL_DIGITS      = 7,                    // DECIMAL_DIGITS
+                    PSEUDO_COLUMN       = 8,                    // PSEUDO_COLUMN
+        */
+    ],
+
+    SQL_DIAG =
+    [
+        CURSOR_ROW_COUNT= -1249,
+        ROW_NUMBER = -1248,
+        COLUMN_NUMBER = -1247,
+        RETURNCODE = 1,
+        NUMBER = 2,
+        ROW_COUNT = 3,
+        SQLSTATE = 4,
+        NATIVE = 5,
+        MESSAGE_TEXT = 6,
+        DYNAMIC_FUNCTION = 7,
+        CLASS_ORIGIN = 8,
+        SUBCLASS_ORIGIN = 9,
+        CONNECTION_NAME = 10,
+        SERVER_NAME = 11,
+        DYNAMIC_FUNCTION_CODE = 12
+    ],
+
+    SQL_SU =
+    [
+        SQL_SU_DML_STATEMENTS       = 0x00000001,
+        SQL_SU_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_SU_TABLE_DEFINITION     = 0x00000004,
+        SQL_SU_INDEX_DEFINITION     = 0x00000008,
+        SQL_SU_PRIVILEGE_DEFINITION = 0x00000010
+    ]
+]

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/RedshiftODBC/RedshiftODBC.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/RedshiftODBC/RedshiftODBC.pq
@@ -1,0 +1,329 @@
+﻿section RedshiftODBC;
+
+// When set to true, additional trace information will be written out to the User log. 
+// This should be set to false before release. Tracing is done through a call to 
+// Diagnostics.LogValue(). When EnableTraceOutput is set to false, the call becomes a 
+// no-op and simply returns the original value.
+EnableTraceOutput = true;
+
+Config_DriverName = "Amazon Redshift (x86)";
+Config_SqlConformance = ODBC[SQL_SC][SQL_SC_SQL92_FULL];  // null, 1, 2, 4, 8
+Config_DefaultUsernamePasswordHandling = true;  // true, false
+Config_UseParameterBindings = true;  // true, false, null
+Config_StringLiterateEscapeCharacters  = { "\" }; // ex. { "\" }
+Config_UseCastInsteadOfConvert = true; // true, false, null
+Config_SupportsTop = true; // true, false
+Config_EnableDirectQuery = true;    // true, false
+
+// This is a work around for the lack of available conversion functions in the driver.
+ImplicitTypeConversions = #table(
+    { "Type1",        "Type2",         "ResultType" }, {
+    // 'bpchar' char is added here to allow it to be converted to 'char' when compared against constants.
+    { "bpchar",       "char",          "char" }
+});
+
+[DataSource.Kind="RedshiftODBC", Publish="RedshiftODBC.UI"]
+shared RedshiftODBC.Database = (server as text, database as text, optional options as record) as table =>
+    let
+        ConnectionString = GetAddress(server) & [
+            Driver = Config_DriverName,
+            UseUnicode = "yes",
+            Database = database
+        ],
+
+        Credential = Extension.CurrentCredential(),
+        encryptionEnabled = Credential[EncryptConnection]? = true,
+		CredentialConnectionString = [
+            SSLMode = if encryptionEnabled then "verify-full" else "prefer",
+            UID = Credential[Username],
+            PWD = Credential[Password],
+            BoolsAsChar = 0,
+            MaxVarchar = 65535
+        ],
+        
+        defaultConfig = BuildOdbcConfig(),
+
+        SqlCapabilities = defaultConfig[SqlCapabilities] & [
+            // place custom overrides here
+            GroupByCapabilities = ODBC[SQL_GB][SQL_GB_NO_RELATION],
+            FractionalSecondsScale = 3
+        ],
+
+        SQLGetInfo = defaultConfig[SQLGetInfo] & [
+
+        ],
+
+SQLGetTypeInfo = (types) => 
+    let
+        original =
+            if (EnableTraceOutput <> true) then
+                types 
+            else
+                let 
+                    // Outputting the entire table might be too large, and result in the value being truncated.
+                    // We can output a row at a time instead with Table.TransformRows()
+                    rows = Table.TransformRows(types, each Diagnostics.LogValue("SQLGetTypeInfo " & _[TYPE_NAME], _)),
+                    toTable = Table.FromRecords(rows)
+                in
+                    toTable,
+        modified = 
+            // older versions of the driver were missing an entry for 'bpchar'
+            if (Table.IsEmpty(Table.SelectRows(original, each [TYPE_NAME] = "bpchar"))) then 
+                let
+                    // add the missing bpchar type by copying the 'char' entry and modifying the relevant values
+                    charRecord = original{[TYPE_NAME="char",DATA_TYPE=-8]},
+                    bpChar = charRecord & [TYPE_NAME = "bpchar",LOCAL_TYPE_NAME = "bpchar"],
+                    finalTable = original & Table.FromRecords({bpChar})
+                in
+                    finalTable
+            else
+                original,
+
+        modified2 = 
+            // use of Redshift spectrum/external tables can add a "float" type
+            if (Table.IsEmpty(Table.SelectRows(modified, each [TYPE_NAME] = "float"))) then 
+                let
+                    origRecord = modified{[TYPE_NAME="float8",DATA_TYPE=6]},
+                    newRecord = origRecord & [TYPE_NAME = "float",LOCAL_TYPE_NAME = "float"],
+                    finalTable = modified & Table.FromRecords({newRecord})
+                in
+                    finalTable
+            else
+                modified
+    in
+        Value.ReplaceType(modified2, Value.Type(types)),
+
+        SQLColumns = (catalogName, schemaName, tableName, columnName, source) =>
+            if (EnableTraceOutput <> true) then source else
+            // the if statement conditions will force the values to evaluated/written to diagnostics
+            if (Diagnostics.LogValue("SQLColumns.TableName", tableName) <> "***" and Diagnostics.LogValue("SQLColumns.ColumnName", columnName) <> "***") then
+                let
+                    // Outputting the entire table might be too large, and result in the value being truncated.
+                    // We can output a row at a time instead with Table.TransformRows()
+                    rows = Table.TransformRows(source, each Diagnostics.LogValue("SQLColumns", _)),
+                    toTable = Table.FromRecords(rows)
+                in
+                    Value.ReplaceType(toTable, Value.Type(source))
+            else
+                source,
+
+        OnError = (errorRecord as record) =>
+            if Text.Contains(errorRecord[Message], "password authentication failed") then
+                error Extension.CredentialError(Credential.AccessDenied, errorRecord[Message])
+            else if encryptionEnabled and Text.Contains(errorRecord[Message], "root.crt"" does not exist") then
+                error Extension.CredentialError(Credential.EncryptionNotSupported, errorRecord[Message])
+            else 
+                error errorRecord,
+
+        AstVisitor = [
+            // Decimal literals are always of type "numeric" which prevents high range numbers to be used.
+            // We therefore wrap float4 and float8 with CAST for that purpose.
+            Constant =
+                let
+                    Cast = (value, typeName) => [
+                        Text = Text.Format("CAST(#{0} as #{1})", { value, typeName })
+                    ],
+                    Visitor = [
+                        float8 = each Cast(_, "float8"),
+                        float4 = each Cast(_, "float4")
+                    ]
+                in
+                    (typeInfo, ast) => Record.FieldOrDefault(Visitor, typeInfo[TYPE_NAME], each null)(ast[Value])
+        ],
+
+        OdbcDatasource = Odbc.DataSource(ConnectionString, [
+            HierarchicalNavigation = true, 
+            HideNativeQuery = true,
+            ClientConnectionPooling = true,
+
+            ImplicitTypeConversions = ImplicitTypeConversions,
+            OnError = OnError,
+
+            // These values should be set by previous steps
+            CredentialConnectionString = CredentialConnectionString,
+            AstVisitor = AstVisitor,
+            SqlCapabilities = SqlCapabilities,
+            SQLColumns = SQLColumns,
+            SQLGetInfo = SQLGetInfo,
+            SQLGetTypeInfo = SQLGetTypeInfo
+        ]),
+
+        Database = OdbcDatasource{[Name = database]}[Data],
+        RemovedSystemTable = Table.SelectRows(Database, each [Name] <> "pg_internal"), // non-queryable system table
+        FixNestedNavigationTables =
+            let
+                ColumnType = Type.TableColumn(Value.Type(RemovedSystemTable), "Data"),
+                AddColumn = Table.AddColumn(RemovedSystemTable, "Data2", each FixNavigationTable([Data]), ColumnType),
+                RemovePreviousColumn = Table.RemoveColumns(AddColumn, { "Data" }),
+                RenameColumn = Table.RenameColumns(RemovePreviousColumn, { { "Data2", "Data" } })
+            in
+                RenameColumn,
+        Fixed = FixNavigationTable(FixNestedNavigationTables)
+    in
+        Fixed;
+
+GetAddress = (server as text) as record =>
+    let
+        Address = Uri.Parts("http://" & server),
+        Port = if Address[Port] = 80 and not Text.EndsWith(server, ":80") then [] else [Port = Address[Port]],
+        Server = [Server = Address[Host]],
+        ConnectionString = Server & Port,
+        Result =
+            if Address[Host] = ""
+                or Address[Scheme] <> "http"
+                or Address[Path] <> "/"
+                or Address[Query] <> []
+                or Address[Fragment] <> ""
+                or Address[UserName] <> ""
+                or Address[Password] <> ""
+                or Text.StartsWith(server, "http:/", Comparer.OrdinalIgnoreCase) then
+                error "Invalid server name"
+            else
+                ConnectionString
+    in
+        Result;
+
+// Fixes navigation table return from ODBC hierarchical navigation
+// to not have Kind as part of the key and to remove columns that return
+// not value for this ODBC driver such as "Description".
+FixNavigationTable = (table) =>
+    let
+        SelectColumns = Table.SelectColumns(table, { "Name", "Data", "Kind" }),
+        OriginalType = Value.Type(SelectColumns),
+        Type = type table [
+            Name = Type.TableColumn(OriginalType, "Name"),
+            Data = Type.TableColumn(OriginalType, "Data"),
+            Kind = Type.TableColumn(OriginalType, "Kind")
+        ],
+        AddKey = Type.AddTableKey(Type, { "Name" }, true),
+        AddMetadata = AddKey meta [
+            NavigationTable.NameColumn = "Name",
+            NavigationTable.DataColumn = "Data",
+            NavigationTable.KindColumn = "Kind",
+            Preview.DelayColumn = "Data"
+        ],
+        ReplaceType = Value.ReplaceType(SelectColumns, AddMetadata)
+    in
+        ReplaceType;
+
+RedshiftODBC = [
+    TestConnection = (dataSourcePath) => 
+        let
+            json = Json.Document(dataSourcePath),
+            server = json[server],
+            database = json[database]
+        in
+            { "RedshiftODBC.Database", server, database },
+    Authentication = [
+        UsernamePassword = [
+        ]
+    ],
+    SupportsEncryption = true
+];
+
+RedshiftODBC.UI = [
+    ButtonText = { "RedshiftODBC Sample", "RedshiftODBC Sample" },
+    Category = "Database",
+    SupportsDirectQuery = true
+];
+
+// build settings based on configuration variables
+BuildOdbcConfig = () as record =>
+    let        
+        defaultConfig = [
+            SqlCapabilities = [],
+            SQLGetFunctions = [],
+            SQLGetInfo = []
+        ],
+
+        withParams =
+            if (Config_UseParameterBindings = false) then
+                let 
+                    caps = defaultConfig[SqlCapabilities] & [ 
+                        SqlCapabilities = [
+                            SupportsNumericLiterals = true,
+                            SupportsStringLiterals = true,                
+                            SupportsOdbcDateLiterals = true,
+                            SupportsOdbcTimeLiterals = true,
+                            SupportsOdbcTimestampLiterals = true
+                        ]
+                    ],
+                    funcs = defaultConfig[SQLGetFunctions] & [
+                        SQLGetFunctions = [
+                            SQL_API_SQLBINDPARAMETER = false
+                        ]
+                    ]
+                in
+                    defaultConfig & caps & funcs
+            else
+                defaultConfig,
+                
+        withEscape = 
+            if (Config_StringLiterateEscapeCharacters <> null) then 
+                let
+                    caps = withParams[SqlCapabilities] & [ 
+                        SqlCapabilities = [
+                            StringLiteralEscapeCharacters = Config_StringLiterateEscapeCharacters
+                        ]
+                    ]
+                in
+                    withParams & caps
+            else
+                withParams,
+
+        withTop =
+            let
+                caps = withEscape[SqlCapabilities] & [ 
+                    SqlCapabilities = [
+                        SupportsTop = Config_SupportsTop
+                    ]
+                ]
+            in
+                withEscape & caps,
+
+        withCastOrConvert = 
+            if (Config_UseCastInsteadOfConvert = true) then
+                let
+                    caps = withTop[SQLGetFunctions] & [ 
+                        SQLGetFunctions = [
+                            SQL_CONVERT_FUNCTIONS = 0x2 /* SQL_FN_CVT_CAST */
+                        ]
+                    ]
+                in
+                    withTop & caps
+            else
+                withTop,
+
+        withSqlConformance =
+            if (Config_SqlConformance <> null) then
+                let
+                    caps = withCastOrConvert[SQLGetInfo] & [
+                        SQLGetInfo = [
+                            SQL_SQL_CONFORMANCE = Config_SqlConformance
+                        ]
+                    ]
+                in
+                    withCastOrConvert & caps
+            else
+                withCastOrConvert
+    in
+        withSqlConformance;
+
+// 
+// Load common library functions
+// 
+Extension.LoadFunction = (name as text) =>
+    let
+        binary = Extension.Contents(name),
+        asText = Text.FromBinary(binary)
+    in
+        Expression.Evaluate(asText, #shared);
+
+// Diagnostics module contains multiple functions. We can take the ones we need.
+Diagnostics = Extension.LoadFunction("Diagnostics.pqm");
+Diagnostics.LogValue = if (EnableTraceOutput) then Diagnostics[LogValue] else (prefix, value) => value;
+
+// OdbcConstants contains numeric constants from the ODBC header files, and a 
+// helper function to create bitfield values.
+ODBC = Extension.LoadFunction("OdbcConstants.pqm");
+Odbc.Flags = ODBC[Flags];

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/RedshiftODBC/RedshiftODBC.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/RedshiftODBC/RedshiftODBC.query.pq
@@ -1,0 +1,4 @@
+﻿let
+    result = RedshiftODBC.Database("server.redshift.amazonaws.com:5439", "database")
+in
+    result

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/SnowflakeODBC/Diagnostics.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/SnowflakeODBC/Diagnostics.pqm
@@ -1,0 +1,275 @@
+﻿let
+    Diagnostics.LogValue = (prefix, value) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogFailure = (text, function) =>
+        let
+            result = try function()
+        in
+            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
+
+    Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
+        Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
+
+    Diagnostics.WrapHandlers = (handlers as record) as record =>
+        Record.FromList(
+            List.Transform(
+                Record.FieldNames(handlers),
+                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
+            Record.FieldNames(handlers)),
+
+    Diagnostics.ValueToText = (value) =>
+        let
+            _canBeIdentifier = (x) =>
+                                            let
+                                                keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                                charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                                charDigit = (c as number) => c>= 48 and c <= 57
+                                            in
+                                                try
+                                                    charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                    and
+                                                        List.MatchesAll(
+                                                            Text.ToList(x),
+                                                            (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                        )
+                                                    and not 
+                                                        List.MatchesAny( keywords, (li)=> li=x )
+                                                otherwise 
+                                                    false,
+    
+            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+            Serialize.Date =        (x) => "#date(" & 
+                                           Text.From(Date.Year(x))  & ", " & 
+                                           Text.From(Date.Month(x)) & ", " & 
+                                           Text.From(Date.Day(x))   & ") ",
+
+            Serialize.Datetime =    (x) => "#datetime(" &
+                                           Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                           Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                           Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                           Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                           Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                           Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+            Serialize.Datetimezone =(x) => let 
+                                              dtz = DateTimeZone.ToRecord(x) 
+                                           in
+                                              "#datetimezone(" & 
+                                              Text.From(dtz[Year])        & ", " &
+                                              Text.From(dtz[Month])       & ", " &
+                                              Text.From(dtz[Day])         & ", " &
+                                              Text.From(dtz[Hour])        & ", " &
+                                              Text.From(dtz[Minute])      & ", " &
+                                              Text.From(dtz[Second])      & ", " &
+                                              Text.From(dtz[ZoneHours])   & ", " &
+                                              Text.From(dtz[ZoneMinutes]) & ") ",
+
+            Serialize.Duration =    (x) => let
+                                              dur = Duration.ToRecord(x)
+                                           in
+                                              "#duration(" &
+                                              Text.From(dur[Days])    & ", " &
+                                              Text.From(dur[Hours])   & ", " &
+                                              Text.From(dur[Minutes]) & ", " &
+                                              Text.From(dur[Seconds]) & ") ",
+
+            Serialize.Function =    (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(Value.Type(x)),
+                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                           " as " &
+                                           _serialize_function_return_type(Value.Type(x)) &
+                                           " => (...) ",
+
+            Serialize.List =        (x) => "{" & 
+                                           List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                           "} ",
+
+            Serialize.Logical =     (x) => Text.From(x),
+
+            Serialize.Null =        (x) => "null",
+
+            Serialize.Number =      (x) => 
+                                        let Text.From = (i as number) as text => 
+                                            if Number.IsNaN(i) then "#nan" else
+                                            if i=Number.PositiveInfinity then "#infinity" else
+                                            if i=Number.NegativeInfinity then "-#infinity" else
+                                            Text.From(i)
+                                        in
+                                            Text.From(x),
+
+            Serialize.Record =      (x) => "[ " &
+                                           List.Accumulate(
+                                                Record.FieldNames(x), 
+                                                "", 
+                                                (seed,item) => 
+                                                    (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                           ) &
+                                           " ] ",
+
+            Serialize.Table =       (x) => "#table( type " &
+                                            _serialize_table_type(Value.Type(x)) &
+                                            ", " &
+                                            Serialize(Table.ToRows(x)) &
+                                            ") ",
+                                    
+            Serialize.Text =        (x) => """" & 
+                                           _serialize_text_content(x) & 
+                                           """",
+
+            _serialize_text_content =  (x) => let 
+                                                escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                            in
+                                            List.Accumulate(
+                                               List.Transform(
+                                                   Text.ToList(x),
+                                                   (c) => let n=Character.ToNumber(c) in 
+                                                            if n = 9   then "#(#)(tab)" else
+                                                            if n = 10  then "#(#)(lf)"  else
+                                                            if n = 13  then "#(#)(cr)"  else
+                                                            if n = 34  then """"""      else
+                                                            if n = 35  then "#(#)(#)"   else
+                                                            if n < 32  then escapeText(n) else 
+                                                            if n < 127 then Character.FromNumber(n) else 
+                                                            escapeText(n) 
+                                                ),
+                                                "",
+                                                (s,i)=>s&i
+                                            ),
+        
+            Serialize.Identifier =   (x) => 
+                                            if _canBeIdentifier(x) then 
+                                                x 
+                                            else 
+                                                "#""" &
+                                                _serialize_text_content(x) &
+                                                """",
+
+            Serialize.Time =        (x) => "#time(" &
+                                           Text.From(Time.Hour(x))   & ", " & 
+                                           Text.From(Time.Minute(x)) & ", " & 
+                                           Text.From(Time.Second(x)) & ") ",
+                                
+            Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                        let
+                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                        in
+                                
+                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                            if x = type any then "any" else
+                                            let base = Type.NonNullable(x) in
+                                              (if Type.IsNullable(x) then "nullable " else "") &       
+                                              (if base = type anynonnull then "anynonnull" else                
+                                              if base = type binary then "binary" else                
+                                              if base = type date   then "date"   else
+                                              if base = type datetime then "datetime" else
+                                              if base = type datetimezone then "datetimezone" else
+                                              if base = type duration then "duration" else
+                                              if base = type logical then "logical" else
+                                              if base = type none then "none" else
+                                              if base = type null then "null" else
+                                              if base = type number then "number" else
+                                              if base = type text then "text" else 
+                                              if base = type time then "time" else 
+                                              if base = type type then "type" else 
+                                      
+                                              /* Abstract types: */
+                                              if base = type function then "function" else
+                                              if base = type table then "table" else
+                                              if base = type record then "record" else
+                                              if base = type list then "list" else
+                                      
+                                              "any /*Actually unknown type*/"),
+
+            _serialize_table_type =     (x) => 
+                                               let 
+                                                 schema = Type.TableSchema(x)
+                                               in
+                                                 "table " &
+                                                 (if Table.IsEmpty(schema) then "" else 
+                                                     "[" & List.Accumulate(
+                                                        List.Transform(
+                                                            Table.ToRecords(Table.Sort(schema,"Position")),
+                                                            each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                        "",
+                                                        (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                    ) & "] " ),
+
+            _serialize_record_type =    (x) => 
+                                                let flds = Type.RecordFields(x)
+                                                in
+                                                    if Record.FieldCount(flds)=0 then "record" else
+                                                        "[" & List.Accumulate(
+                                                            Record.FieldNames(flds),
+                                                            "",
+                                                            (seed,item) => 
+                                                                seed &
+                                                                (if seed<>"" then ", " else "") &
+                                                                (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                        ) & 
+                                                        (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                        "]",
+
+            _serialize_function_type =  (x) => _serialize_function_param_type(
+                                                  Type.FunctionParameters(x),
+                                                  Type.FunctionRequiredParameters(x) ) &
+                                                " as " &
+                                                _serialize_function_return_type(x),
+    
+            _serialize_function_param_type = (t,n) => 
+                                    let
+                                        funsig = Table.ToRecords(
+                                            Table.TransformColumns(
+                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                                { "isOptional", (x)=> x>n } ) )
+                                    in
+                                        "(" & 
+                                        List.Accumulate(
+                                            funsig,
+                                            "",
+                                            (seed,item)=>
+                                                (if seed="" then "" else seed & ", ") &
+                                                (if item[isOptional] then "optional " else "") &
+                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                         & ")",
+
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+            Serialize = (x) as text => 
+                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                               if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                               if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                               if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                               if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                               if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                               if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                               if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                               if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                               if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                               "[#_unable_to_serialize_#]"                     
+        in
+            try Serialize(value) otherwise "<serialization failed>"
+in
+    [ 
+        LogValue = Diagnostics.LogValue,
+        LogValue2 = Diagnostics.LogValue2,
+        LogFailure = Diagnostics.LogFailure,
+        WrapFunctionResult = Diagnostics.WrapFunctionResult,
+        WrapHandlers = Diagnostics.WrapHandlers,
+        ValueToText = Diagnostics.ValueToText
+    ]

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/SnowflakeODBC/OdbcConstants.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/SnowflakeODBC/OdbcConstants.pqm
@@ -1,0 +1,1253 @@
+// values from https://github.com/Microsoft/ODBC-Specification/blob/master/Windows/inc/sqlext.h
+[
+    Flags = (flags as list) => 
+        if (List.IsEmpty(flags)) then 0 else
+        let
+            Loop = List.Generate(()=> [i = 0, Combined = flags{0}],
+                                    each [i] < List.Count(flags),
+                                    each [Combined = Number.BitwiseOr([Combined], flags{i}), i = [i]+1],
+                                    each [Combined]),
+            Result = List.Last(Loop)
+        in
+            Result,
+
+    SQL_HANDLE =
+    [
+        ENV = 1,
+        DBC = 2,
+        STMT = 3,
+        DESC = 4
+    ],
+
+    RetCode =
+    [
+        SUCCESS = 0,
+        SUCCESS_WITH_INFO = 1,
+        ERROR = -1,
+        INVALID_HANDLE = -2,
+        NO_DATA = 100
+    ],
+
+    SQL_CONVERT =
+    [
+        BIGINT = 53,
+        BINARY = 54,
+        BIT = 55,
+        CHAR = 56,
+        DATE = 57,
+        DECIMAL = 58,
+        DOUBLE = 59,
+        FLOAT = 60,
+        INTEGER = 61,
+        LONGVARCHAR = 62,
+        NUMERIC = 63,
+        REAL = 64,
+        SMALLINT = 65,
+        TIME = 66,
+        TIMESTAMP = 67,
+        TINYINT = 68,
+        VARBINARY = 69,
+        VARCHAR = 70,
+        LONGVARBINARY = 71
+    ],
+
+    SQL_ROW =
+    [
+        PROCEED = 0,
+        IGNORE = 1,
+        SUCCESS = 0,
+        DELETED = 1,
+        UPDATED = 2,
+        NOROW = 3,
+        ADDED = 4,
+        ERROR = 5,
+        SUCCESS_WITH_INFO = 6
+    ],
+
+SQL_CVT =
+[
+    //None = 0,
+
+    CHAR = 0x00000001,
+    NUMERIC = 0x00000002,
+    DECIMAL = 0x00000004,
+    INTEGER = 0x00000008,
+    SMALLINT = 0x00000010,
+    FLOAT = 0x00000020,
+    REAL = 0x00000040,
+    DOUBLE = 0x00000080,
+    VARCHAR = 0x00000100,
+    LONGVARCHAR = 0x00000200,
+    BINARY = 0x00000400,
+    VARBINARY = 0x00000800,
+    BIT = 0x00001000,
+    TINYINT = 0x00002000,
+    BIGINT = 0x00004000,
+    DATE = 0x00008000,
+    TIME = 0x00010000,
+    TIMESTAMP = 0x00020000,
+    LONGVARBINARY = 0x00040000,
+    INTERVAL_YEAR_MONTH = 0x00080000,
+    INTERVAL_DAY_TIME = 0x00100000,
+    WCHAR = 0x00200000,
+    WLONGVARCHAR = 0x00400000,
+    WVARCHAR = 0x00800000,
+    GUID = 0x01000000
+],
+
+    STMT =
+    [
+        CLOSE = 0,
+        DROP = 1,
+        UNBIND = 2,
+        RESET_PARAMS = 3
+    ],
+
+    SQL_MAX =
+    [
+        NUMERIC_LEN = 16
+    ],
+
+    SQL_IS =
+    [
+        POINTER = -4,
+        INTEGER = -6,
+        UINTEGER = -5,
+        SMALLINT = -8
+    ],
+
+    //SQL Server specific defines
+    //
+    SQL_HC =                        // from Odbcss.h
+    [
+        OFF = 0,                //  FOR BROWSE columns are hidden
+        ON = 1                //  FOR BROWSE columns are exposed
+    ],
+
+    SQL_NB =                         // from Odbcss.h
+    [
+        OFF = 0,                //  NO_BROWSETABLE is off
+        ON = 1                //  NO_BROWSETABLE is on
+    ],
+
+    //  SQLColAttributes driver specific defines.
+    //  SQLSet/GetDescField driver specific defines.
+    //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
+    //
+    SQL_CA_SS =                      // from Odbcss.h
+    [
+        BASE = 1200,           // SQL_CA_SS_BASE
+
+        COLUMN_HIDDEN = 1200 + 11,      //  Column is hidden (FOR BROWSE)
+        COLUMN_KEY = 1200 + 12,      //  Column is key column (FOR BROWSE)
+        VARIANT_TYPE = 1200 + 15,
+        VARIANT_SQL_TYPE = 1200 + 16,
+        VARIANT_SERVER_TYPE = 1200 + 17
+
+    ],
+
+    SQL_SOPT_SS =                    // from Odbcss.h
+    [
+        BASE = 1225,                // SQL_SOPT_SS_BASE
+        HIDDEN_COLUMNS = 1225 + 2,  // Expose FOR BROWSE hidden columns
+        NOBROWSETABLE = 1225 + 3    // Set NOBROWSETABLE option
+    ],
+
+    SQL_COMMIT = 0,      //Commit
+    SQL_ROLLBACK = 1,      //Abort
+
+    //static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
+    //static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
+
+    SQL_TRANSACTION =
+    [
+        READ_UNCOMMITTED = 0x00000001,
+        READ_COMMITTED = 0x00000002,
+        REPEATABLE_READ = 0x00000004,
+        SERIALIZABLE = 0x00000008,
+        SNAPSHOT = 0x00000020 // VSDD 414121: SQL_TXN_SS_SNAPSHOT == 0x20 (sqlncli.h)
+    ],
+
+    SQL_PARAM =
+    [
+        TYPE_UNKNOWN = 0,          // SQL_PARAM_TYPE_UNKNOWN
+        INPUT = 1,                 // SQL_PARAM_INPUT
+        INPUT_OUTPUT = 2,          // SQL_PARAM_INPUT_OUTPUT
+        RESULT_COL =   3,          // SQL_RESULT_COL
+        OUTPUT = 4,                // SQL_PARAM_OUTPUT
+        RETURN_VALUE = 5           // SQL_RETURN_VALUE
+    ],
+
+    SQL_DESC =
+    [
+        // from sql.h (ODBCVER >= 3.0)
+        //
+        COUNT = 1001,
+        TYPE = 1002,
+        LENGTH = 1003,
+        OCTET_LENGTH_PTR = 1004,
+        PRECISION = 1005,
+        SCALE = 1006,
+        DATETIME_INTERVAL_CODE = 1007,
+        NULLABLE = 1008,
+        INDICATOR_PTR = 1009,
+        DATA_PTR = 1010,
+        NAME = 1011,
+        UNNAMED = 1012,
+        OCTET_LENGTH = 1013,
+        ALLOC_TYPE = 1099,
+
+        // from sqlext.h (ODBCVER >= 3.0)
+        //
+        CONCISE_TYPE = SQL_COLUMN[TYPE],
+        DISPLAY_SIZE = SQL_COLUMN[DISPLAY_SIZE],
+        UNSIGNED = SQL_COLUMN[UNSIGNED],
+        UPDATABLE = SQL_COLUMN[UPDATABLE],
+        AUTO_UNIQUE_VALUE = SQL_COLUMN[AUTO_INCREMENT],
+
+        TYPE_NAME = SQL_COLUMN[TYPE_NAME],
+        TABLE_NAME = SQL_COLUMN[TABLE_NAME],
+        SCHEMA_NAME = SQL_COLUMN[OWNER_NAME],
+        CATALOG_NAME = SQL_COLUMN[QUALIFIER_NAME],
+
+        BASE_COLUMN_NAME = 22,
+        BASE_TABLE_NAME = 23,
+
+        NUM_PREC_RADIX = 32
+    ],
+
+    // ODBC version 2.0 style attributes
+    // All IdentifierValues are ODBC 1.0 unless marked differently
+    //
+    SQL_COLUMN =
+    [
+        COUNT = 0,
+        NAME = 1,
+        TYPE = 2,
+        LENGTH = 3,
+        PRECISION = 4,
+        SCALE = 5,
+        DISPLAY_SIZE = 6,
+        NULLABLE = 7,
+        UNSIGNED = 8,
+        MONEY = 9,
+        UPDATABLE = 10,
+        AUTO_INCREMENT = 11,
+        CASE_SENSITIVE = 12,
+        SEARCHABLE = 13,
+        TYPE_NAME = 14,
+        TABLE_NAME = 15,    // (ODBC 2.0)
+        OWNER_NAME = 16,    // (ODBC 2.0)
+        QUALIFIER_NAME = 17,    // (ODBC 2.0)
+        LABEL = 18
+    ],
+
+    // values from sqlext.h
+    SQL_SQL92_RELATIONAL_JOIN_OPERATORS =
+    [
+        CORRESPONDING_CLAUSE = 0x00000001,    // SQL_SRJO_CORRESPONDING_CLAUSE
+        CROSS_JOIN = 0x00000002,    // SQL_SRJO_CROSS_JOIN
+        EXCEPT_JOIN = 0x00000004,    // SQL_SRJO_EXCEPT_JOIN
+        FULL_OUTER_JOIN = 0x00000008,    // SQL_SRJO_FULL_OUTER_JOIN
+        INNER_JOIN = 0x00000010,    // SQL_SRJO_INNER_JOIN
+        INTERSECT_JOIN = 0x00000020,    // SQL_SRJO_INTERSECT_JOIN
+        LEFT_OUTER_JOIN = 0x00000040,    // SQL_SRJO_LEFT_OUTER_JOIN
+        NATURAL_JOIN = 0x00000080,    // SQL_SRJO_NATURAL_JOIN
+        RIGHT_OUTER_JOIN = 0x00000100,  // SQL_SRJO_RIGHT_OUTER_JOIN
+        UNION_JOIN = 0x00000200         // SQL_SRJO_UNION_JOIN
+    ],
+
+    // values from sqlext.h
+    SQL_QU = 
+    [
+        SQL_QU_DML_STATEMENTS = 0x00000001,
+        SQL_QU_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_QU_TABLE_DEFINITION     = 0x00000004,
+        SQL_QU_INDEX_DEFINITION     = 0x00000008,
+        SQL_QU_PRIVILEGE_DEFINITION = 0x00000010
+    ],
+
+    // values from sql.h
+    SQL_OJ_CAPABILITIES =
+    [
+        LEFT = 0x00000001,    // SQL_OJ_LEFT
+        RIGHT = 0x00000002,    // SQL_OJ_RIGHT
+        FULL = 0x00000004,    // SQL_OJ_FULL
+        NESTED = 0x00000008,    // SQL_OJ_NESTED
+        NOT_ORDERED = 0x00000010,    // SQL_OJ_NOT_ORDERED
+        INNER = 0x00000020,    // SQL_OJ_INNER
+        ALL_COMPARISON_OPS = 0x00000040  //SQL_OJ_ALLCOMPARISION+OPS
+    ],
+
+    SQL_UPDATABLE =
+    [
+        READONLY = 0,          // SQL_ATTR_READ_ONLY
+        WRITE = 1,             // SQL_ATTR_WRITE
+        READWRITE_UNKNOWN = 2  // SQL_ATTR_READWRITE_UNKNOWN
+    ],
+
+    SQL_IDENTIFIER_CASE =
+    [
+        UPPER = 1,    // SQL_IC_UPPER
+        LOWER = 2,    // SQL_IC_LOWER
+        SENSITIVE = 3,    // SQL_IC_SENSITIVE
+        MIXED = 4    // SQL_IC_MIXED
+    ],
+
+    // Uniqueness parameter in the SQLStatistics function
+    SQL_INDEX =
+    [
+        UNIQUE = 0,
+        ALL = 1
+    ],
+
+    // Reserved parameter in the SQLStatistics function
+    SQL_STATISTICS_RESERVED =
+    [
+        QUICK = 0,                // SQL_QUICK
+        ENSURE = 1                // SQL_ENSURE
+    ],
+
+    // Identifier type parameter in the SQLSpecialColumns function
+    SQL_SPECIALCOLS =
+    [
+        BEST_ROWID = 1,            // SQL_BEST_ROWID
+        ROWVER = 2            // SQL_ROWVER
+    ],
+
+    // Scope parameter in the SQLSpecialColumns function
+    SQL_SCOPE =
+    [
+        CURROW = 0,            // SQL_SCOPE_CURROW
+        TRANSACTION = 1,           // SQL_SCOPE_TRANSACTION
+        SESSION = 2           // SQL_SCOPE_SESSION
+    ],
+
+    SQL_NULLABILITY =
+    [
+        NO_NULLS = 0,                // SQL_NO_NULLS
+        NULLABLE = 1,                // SQL_NULLABLE
+        UNKNOWN = 2                 // SQL_NULLABLE_UNKNOWN
+    ],
+
+    SQL_SEARCHABLE =
+    [
+        UNSEARCHABLE = 0,        // SQL_UNSEARCHABLE
+        LIKE_ONLY = 1,        // SQL_LIKE_ONLY
+        ALL_EXCEPT_LIKE = 2,        // SQL_ALL_EXCEPT_LIKE
+        SEARCHABLE = 3        // SQL_SEARCHABLE
+    ],
+
+    SQL_UNNAMED =
+    [
+        NAMED = 0,                   // SQL_NAMED
+        UNNAMED = 1                  // SQL_UNNAMED
+    ],
+    // todo:move
+    // internal constants
+    // not odbc specific
+    //
+    HANDLER =
+    [
+        IGNORE = 0x00000000,
+        THROW = 0x00000001
+    ],
+
+    // values for SQLStatistics TYPE column
+    SQL_STATISTICSTYPE =
+    [
+        TABLE_STAT = 0,                    // TABLE Statistics
+        INDEX_CLUSTERED = 1,               // CLUSTERED index statistics
+        INDEX_HASHED = 2,                  // HASHED index statistics
+        INDEX_OTHER = 3                    // OTHER index statistics
+    ],
+
+    // values for SQLProcedures PROCEDURE_TYPE column
+    SQL_PROCEDURETYPE =
+    [
+        UNKNOWN = 0,                    // procedure is of unknow type
+        PROCEDURE = 1,                    // procedure is a procedure
+        FUNCTION = 2                     // procedure is a function
+    ],
+
+    // private constants
+    // to define data types (see below)
+    //
+    SIGNED_OFFSET = -20,      // SQL_SIGNED_OFFSET
+    UNSIGNED_OFFSET = -22,    // SQL_UNSIGNED_OFFSET
+
+    // C Data Types
+    SQL_C =
+    [
+        CHAR            = 1,
+        WCHAR           = -8,
+        SLONG           = 4     + SIGNED_OFFSET,
+        ULONG           = 4     + UNSIGNED_OFFSET,
+        SSHORT          = 5     + SIGNED_OFFSET,
+        USHORT          = 5     + UNSIGNED_OFFSET,
+        FLOAT           = 7,
+        DOUBLE          = 8,
+        BIT             = -7,
+        STINYINT        = -6    + SIGNED_OFFSET,
+        UTINYINT        = -6    + UNSIGNED_OFFSET,
+        SBIGINT         = -5    + SIGNED_OFFSET,
+        UBIGINT         = -5    + UNSIGNED_OFFSET,
+        BINARY          = -2,
+        TIMESTAMP       = 11,
+
+        TYPE_DATE       = 91,
+        TYPE_TIME       = 92,
+        TYPE_TIMESTAMP  = 93,
+
+        NUMERIC         = 2,
+        GUID            = -11,
+        DEFAULT         = 99,
+        ARD_TYPE        = -99
+    ],
+
+    // SQL Data Types
+    SQL_TYPE =
+    [
+        // Base data types (sql.h)
+        UNKNOWN             = 0,
+        NULL                = 0,
+        CHAR                = 1,
+        NUMERIC             = 2,
+        DECIMAL             = 3,
+        INTEGER             = 4,
+        SMALLINT            = 5,
+        FLOAT               = 6,
+        REAL                = 7,
+        DOUBLE              = 8,
+        DATETIME            = 9,      // V3 Only
+        VARCHAR             = 12,
+
+        // Unicode types (sqlucode.h)
+        WCHAR               = -8,
+        WVARCHAR            = -9,
+        WLONGVARCHAR        = -10,
+
+        // Extended data types (sqlext.h)
+        INTERVAL            = 10,    // V3 Only
+        TIME                = 10,
+        TIMESTAMP           = 11,
+        LONGVARCHAR         = -1,
+        BINARY              = -2,
+        VARBINARY           = -3,
+        LONGVARBINARY       = -4,
+        BIGINT              = -5,
+        TINYINT             = -6,
+        BIT                 = -7,
+        GUID                = -11,   // V3 Only
+
+        // One-parameter shortcuts for date/time data types.
+        TYPE_DATE           = 91,
+        TYPE_TIME           = 92,
+        TYPE_TIMESTAMP      = 93,
+
+        // SQL Server Types -150 to -159 (sqlncli.h)
+        SS_VARIANT          = -150,
+        SS_UDT              = -151,
+        SS_XML              = -152,
+        SS_TABLE            = -153,
+        SS_TIME2            = -154,
+        SS_TIMESTAMPOFFSET  = -155
+    ],
+
+    //SQL_ALL_TYPES = 0,
+    //static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
+
+    SQL_LENGTH = 
+    [
+        SQL_IGNORE = -6,
+        SQL_DEFAULT_PARAM = -5,
+        SQL_NO_TOTAL = -4,
+        SQL_NTS = -3,
+        SQL_DATA_AT_EXEC = -2,
+        SQL_NULL_DATA = -1
+    ],
+
+    SQL_DEFAULT_PARAM = -5,        
+
+    // column ordinals for SQLProcedureColumns result set
+    // this column ordinals are not defined in any c/c++ header but in the ODBC Programmer's Reference under SQLProcedureColumns
+    //
+    COLUMN_NAME = 4,
+    COLUMN_TYPE = 5,
+    DATA_TYPE = 6,
+    COLUMN_SIZE = 8,
+    DECIMAL_DIGITS = 10,
+    NUM_PREC_RADIX = 11,
+
+    SQL_ATTR = 
+    [
+        ODBC_VERSION = 200,
+        CONNECTION_POOLING = 201,
+        AUTOCOMMIT = 102,
+        TXN_ISOLATION = 108,
+        CURRENT_CATALOG = 109,
+        LOGIN_TIMEOUT = 103,
+        QUERY_TIMEOUT = 0,
+        CONNECTION_DEAD = 1209,
+
+        SQL_COPT_SS_BASE = 1200,
+        SQL_COPT_SS_ENLIST_IN_DTC = (1200 + 7),
+        SQL_COPT_SS_TXN_ISOLATION = (1200 + 27),
+
+        MAX_LENGTH = 3,
+        ROW_BIND_TYPE = 5,
+        CURSOR_TYPE = 6,
+        RETRIEVE_DATA = 11,
+        ROW_STATUS_PTR = 25, 
+        ROWS_FETCHED_PTR = 26,
+        ROW_ARRAY_SIZE = 27,
+
+        // ODBC 3.0
+        APP_ROW_DESC = 10010,
+        APP_PARAM_DESC = 10011,
+        IMP_ROW_DESC = 10012,
+        IMP_PARAM_DESC = 10013,
+        METADATA_ID = 10014,
+
+        // ODBC 4.0
+        PRIVATE_DRIVER_LOCATION = 204
+    ],
+
+    SQL_RD = 
+    [
+        OFF = 0,
+        ON = 1
+    ],
+
+    SQL_GD = 
+    [
+        //None =  0,
+        ANY_COLUMN = 1,
+        ANY_ORDER = 2,
+        BLOCK = 4,
+        BOUND = 8,
+        OUTPUT_PARAMS = 16
+    ],
+
+    //SQLGetInfo
+/*
+    SQL_INFO =
+    [
+        SQL_ACTIVE_CONNECTIONS = 0,        
+        SQL_MAX_DRIVER_CONNECTIONS = 0,
+        SQL_MAX_CONCURRENT_ACTIVITIES = 1,
+        SQL_ACTIVE_STATEMENTS = 1,         
+        SQL_DATA_SOURCE_NAME = 2,          
+        SQL_DRIVER_HDBC,                   
+        SQL_DRIVER_HENV,                   
+        SQL_DRIVER_HSTMT,                  
+        SQL_DRIVER_NAME,                   
+        SQL_DRIVER_VER,                    
+        SQL_FETCH_DIRECTION,               
+        SQL_ODBC_API_CONFORMANCE,          
+        SQL_ODBC_VER,                      
+        SQL_ROW_UPDATES,                   
+        SQL_ODBC_SAG_CLI_CONFORMANCE,      
+        SQL_SERVER_NAME,                   
+        SQL_SEARCH_PATTERN_ESCAPE,         
+        SQL_ODBC_SQL_CONFORMANCE,          
+
+        SQL_DATABASE_NAME,                 
+        SQL_DBMS_NAME,                     
+        SQL_DBMS_VER,                      
+
+        SQL_ACCESSIBLE_TABLES,             
+        SQL_ACCESSIBLE_PROCEDURES,         
+        SQL_PROCEDURES,                    
+        SQL_CONCAT_NULL_BEHAVIOR,          
+        SQL_CURSOR_COMMIT_BEHAVIOR,        
+        SQL_CURSOR_ROLLBACK_BEHAVIOR,      
+        SQL_DATA_SOURCE_READ_ONLY,         
+        SQL_DEFAULT_TXN_ISOLATION,         
+        SQL_EXPRESSIONS_IN_ORDERBY,        
+        SQL_IDENTIFIER_CASE,               
+        SQL_IDENTIFIER_QUOTE_CHAR,         
+        SQL_MAX_COLUMN_NAME_LEN,           
+        SQL_MAX_CURSOR_NAME_LEN,           
+        SQL_MAX_OWNER_NAME_LEN,            
+        SQL_MAX_SCHEMA_NAME_LEN = 32,
+        SQL_MAX_PROCEDURE_NAME_LEN,        
+        SQL_MAX_QUALIFIER_NAME_LEN,        
+        SQL_MAX_CATALOG_NAME_LEN = 34,
+        SQL_MAX_TABLE_NAME_LEN,            
+        SQL_MULT_RESULT_SETS,              
+        SQL_MULTIPLE_ACTIVE_TXN,           
+        SQL_OUTER_JOINS,                   
+        SQL_SCHEMA_TERM,                   
+        SQL_PROCEDURE_TERM,                
+        SQL_CATALOG_NAME_SEPARATOR,        
+        SQL_CATALOG_TERM,                  
+        SQL_SCROLL_CONCURRENCY,            
+        SQL_SCROLL_OPTIONS,                
+        SQL_TABLE_TERM,                    
+        SQL_TXN_CAPABLE,                   
+        SQL_USER_NAME,                     
+
+        SQL_CONVERT_FUNCTIONS,             
+        SQL_NUMERIC_FUNCTIONS,             
+        SQL_STRING_FUNCTIONS,              
+        SQL_SYSTEM_FUNCTIONS,              
+        SQL_TIMEDATE_FUNCTIONS,            
+
+        SQL_CONVERT_BIGINT,
+        SQL_CONVERT_BINARY,
+        SQL_CONVERT_BIT,
+        SQL_CONVERT_CHAR,
+        SQL_CONVERT_DATE,
+        SQL_CONVERT_DECIMAL,
+        SQL_CONVERT_DOUBLE,
+        SQL_CONVERT_FLOAT,            
+        SQL_CONVERT_INTEGER,
+        SQL_CONVERT_LONGVARCHAR,
+        SQL_CONVERT_NUMERIC,
+        SQL_CONVERT_REAL,
+        SQL_CONVERT_SMALLINT,
+        SQL_CONVERT_TIME,
+        SQL_CONVERT_TIMESTAMP,
+        SQL_CONVERT_TINYINT,
+        SQL_CONVERT_VARBINARY,
+        SQL_CONVERT_VARCHAR,          
+        SQL_CONVERT_LONGVARBINARY,
+
+        SQL_TXN_ISOLATION_OPTION,     
+        SQL_ODBC_SQL_OPT_IEF,
+        SQL_INTEGRITY = 73,
+        SQL_CORRELATION_NAME,
+        SQL_NON_NULLABLE_COLUMNS,
+        SQL_DRIVER_HLIB,
+        SQL_DRIVER_ODBC_VER,
+        SQL_LOCK_TYPES,
+        SQL_POS_OPERATIONS,
+        SQL_POSITIONED_STATEMENTS,        
+        SQL_GETDATA_EXTENSIONS,
+        SQL_BOOKMARK_PERSISTENCE,
+        SQL_STATIC_SENSITIVITY,
+        SQL_FILE_USAGE,
+        SQL_NULL_COLLATION,
+        SQL_ALTER_TABLE,
+        SQL_COLUMN_ALIAS,
+        SQL_GROUP_BY,
+        SQL_KEYWORDS,
+        SQL_ORDER_BY_COLUMNS_IN_SELECT,   
+        SQL_SCHEMA_USAGE,
+        SQL_CATALOG_USAGE,
+        SQL_QUOTED_IDENTIFIER_CASE,
+        SQL_SPECIAL_CHARACTERS,
+        SQL_SUBQUERIES,
+        SQL_UNION_STATEMENT,
+        SQL_MAX_COLUMNS_IN_GROUP_BY,
+        SQL_MAX_COLUMNS_IN_INDEX,
+        SQL_MAX_COLUMNS_IN_ORDER_BY,
+        SQL_MAX_COLUMNS_IN_SELECT,        
+        SQL_MAX_COLUMNS_IN_TABLE,
+        SQL_MAX_INDEX_SIZE,
+        SQL_MAX_ROW_SIZE_INCLUDES_LONG,
+        SQL_MAX_ROW_SIZE,
+        SQL_MAX_STATEMENT_LEN,
+        SQL_MAX_TABLES_IN_SELECT,
+        SQL_MAX_USER_NAME_LEN,
+        SQL_MAX_CHAR_LITERAL_LEN,
+        SQL_TIMEDATE_ADD_INTERVALS,
+        SQL_TIMEDATE_DIFF_INTERVALS,      
+        SQL_NEED_LONG_DATA_LEN,
+        SQL_MAX_BINARY_LITERAL_LEN,
+        SQL_LIKE_ESCAPE_CLAUSE,
+        SQL_CATALOG_LOCATION,
+        SQL_OJ_CAPABILITIES,
+
+        SQL_ACTIVE_ENVIRONMENTS,
+        SQL_ALTER_DOMAIN,
+        SQL_SQL_CONFORMANCE,
+        SQL_DATETIME_LITERALS,
+        SQL_BATCH_ROW_COUNT,              
+        SQL_BATCH_SUPPORT,
+        SQL_CONVERT_WCHAR,
+        SQL_CONVERT_INTERVAL_DAY_TIME,
+        SQL_CONVERT_INTERVAL_YEAR_MONTH,
+        SQL_CONVERT_WLONGVARCHAR,
+        SQL_CONVERT_WVARCHAR,
+        SQL_CREATE_ASSERTION,
+        SQL_CREATE_CHARACTER_SET,
+        SQL_CREATE_COLLATION,
+        SQL_CREATE_DOMAIN,                  
+        SQL_CREATE_SCHEMA,
+        SQL_CREATE_TABLE,
+        SQL_CREATE_TRANSLATION,
+        SQL_CREATE_VIEW,
+        SQL_DRIVER_HDESC,
+        SQL_DROP_ASSERTION,
+        SQL_DROP_CHARACTER_SET,
+        SQL_DROP_COLLATION,
+        SQL_DROP_DOMAIN,
+        SQL_DROP_SCHEMA,                    
+        SQL_DROP_TABLE,
+        SQL_DROP_TRANSLATION,
+        SQL_DROP_VIEW,
+        SQL_DYNAMIC_CURSOR_ATTRIBUTES1,
+        SQL_DYNAMIC_CURSOR_ATTRIBUTES2,
+        SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1,
+        SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2,
+        SQL_INDEX_KEYWORDS,
+        SQL_INFO_SCHEMA_VIEWS,
+        SQL_KEYSET_CURSOR_ATTRIBUTES1,    
+        SQL_KEYSET_CURSOR_ATTRIBUTES2,
+        SQL_ODBC_INTERFACE_CONFORMANCE,
+        SQL_PARAM_ARRAY_ROW_COUNTS,
+        SQL_PARAM_ARRAY_SELECTS,
+        SQL_SQL92_DATETIME_FUNCTIONS,
+        SQL_SQL92_FOREIGN_KEY_DELETE_RULE,
+        SQL_SQL92_FOREIGN_KEY_UPDATE_RULE,
+        SQL_SQL92_GRANT,
+        SQL_SQL92_NUMERIC_VALUE_FUNCTIONS,
+        SQL_SQL92_PREDICATES,              
+        SQL_SQL92_RELATIONAL_JOIN_OPERATORS,
+        SQL_SQL92_REVOKE,
+        SQL_SQL92_ROW_VALUE_CONSTRUCTOR,
+        SQL_SQL92_STRING_FUNCTIONS,
+        SQL_SQL92_VALUE_EXPRESSIONS,
+        SQL_STANDARD_CLI_CONFORMANCE,
+        SQL_STATIC_CURSOR_ATTRIBUTES1,
+        SQL_STATIC_CURSOR_ATTRIBUTES2,
+        SQL_AGGREGATE_FUNCTIONS,
+        SQL_DDL_INDEX,                   
+        SQL_DM_VER,
+        SQL_INSERT_STATEMENT,
+        SQL_CONVERT_GUID,
+
+        SQL_XOPEN_CLI_YEAR = 10000,      
+        SQL_CURSOR_SENSITIVITY,
+        SQL_DESCRIBE_PARAMETER,
+        SQL_CATALOG_NAME,
+        SQL_COLLATION_SEQ,
+        SQL_MAX_IDENTIFIER_LEN,
+        SQL_ASYNC_MODE = 10021,          
+        SQL_MAX_ASYNC_CONCURRENT_STATEMENTS,
+
+        SQL_DTC_TRANSITION_COST = 1750,
+    ],
+*/
+    SQL_OAC = 
+    [
+        SQL_OAC_None = 0x0000,
+        SQL_OAC_LEVEL1 = 0x0001,
+        SQL_OAC_LEVEL2 = 0x0002
+    ],
+
+    SQL_OSC = 
+    [
+        SQL_OSC_MINIMUM = 0x0000,
+        SQL_OSC_CORE = 0x0001,
+        SQL_OSC_EXTENDED = 0x0002
+    ],
+
+    SQL_SCC = 
+    [
+        SQL_SCC_XOPEN_CLI_VERSION1 = 0x00000001,
+        SQL_SCC_ISO92_CLI = 0x00000002
+    ],
+
+    SQL_SVE = 
+    [
+        SQL_SVE_CASE = 0x00000001,
+        SQL_SVE_CAST = 0x00000002,
+        SQL_SVE_COALESCE = 0x00000004,
+        SQL_SVE_NULLIF = 0x00000008
+    ],
+
+    SQL_SSF = 
+    [
+        SQL_SSF_CONVERT = 0x00000001,
+        SQL_SSF_LOWER = 0x00000002,
+        SQL_SSF_UPPER = 0x00000004,
+        SQL_SSF_SUBSTRING = 0x00000008,
+        SQL_SSF_TRANSLATE = 0x00000010,
+        SQL_SSF_TRIM_BOTH = 0x00000020,
+        SQL_SSF_TRIM_LEADING = 0x00000040,
+        SQL_SSF_TRIM_TRAILING = 0x00000080
+    ],
+
+    SQL_SP = 
+    [
+        //None = 0,
+
+        SQL_SP_EXISTS = 0x00000001,
+        SQL_SP_ISNOTNULL = 0x00000002,
+        SQL_SP_ISNULL = 0x00000004,
+        SQL_SP_MATCH_FULL = 0x00000008,
+        SQL_SP_MATCH_PARTIAL = 0x00000010,
+        SQL_SP_MATCH_UNIQUE_FULL = 0x00000020,
+        SQL_SP_MATCH_UNIQUE_PARTIAL = 0x00000040,
+        SQL_SP_OVERLAPS = 0x00000080,
+        SQL_SP_UNIQUE = 0x00000100,
+        SQL_SP_LIKE = 0x00000200,
+        SQL_SP_IN = 0x00000400,
+        SQL_SP_BETWEEN = 0x00000800,
+        SQL_SP_COMPARISON = 0x00001000,
+        SQL_SP_QUANTIFIED_COMPARISON = 0x00002000,
+
+        All = 0x0000FFFF
+    ],
+
+    SQL_OIC =
+    [
+        SQL_OIC_CORE = 1,
+        SQL_OIC_LEVEL1 = 2,
+        SQL_OIC_LEVEL2 = 3
+    ],
+
+    SQL_USAGE = 
+    [
+        SQL_U_DML_STATEMENTS = 0x00000001,
+        SQL_U_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_U_TABLE_DEFINITION = 0x00000004,
+        SQL_U_INDEX_DEFINITION = 0x00000008,
+        SQL_U_PRIVILEGE_DEFINITION = 0x00000010
+    ],
+
+    SQL_GB = 
+    [
+            
+        SQL_GB_NOT_SUPPORTED = 0,
+        SQL_GB_GROUP_BY_EQUALS_SELECT = 1,
+        SQL_GB_GROUP_BY_CONTAINS_SELECT = 2,
+        SQL_GB_NO_RELATION = 3,
+        SQL_GB_COLLATE = 4
+    ],
+
+    SQL_NC =
+    [
+        SQL_NC_END = 0,
+        SQL_NC_HIGH = 1,
+        SQL_NC_LOW = 2,
+        SQL_NC_START = 3
+    ],
+
+    SQL_CN =
+    [
+        SQL_CN_None = 0,
+        SQL_CN_DIFFERENT = 1,
+        SQL_CN_ANY = 2
+    ],
+
+    SQL_NNC = 
+    [
+        SQL_NNC_NULL = 0,
+        SQL_NNC_NON_NULL = 1
+    ],
+
+    SQL_CB = 
+    [
+        SQL_CB_NULL = 0,
+        SQL_CB_NON_NULL = 1
+    ],
+
+    SQL_FD_FETCH = 
+    [
+        SQL_FD_FETCH_NEXT = 0x00000001,
+        SQL_FD_FETCH_FIRST = 0x00000002,
+        SQL_FD_FETCH_LAST = 0x00000004,
+        SQL_FD_FETCH_PRIOR = 0x00000008,
+        SQL_FD_FETCH_ABSOLUTE = 0x00000010,
+        SQL_FD_FETCH_RELATIVE = 0x00000020,
+        SQL_FD_FETCH_BOOKMARK = 0x00000080
+    ],
+
+    SQL_SQ = 
+    [
+        SQL_SQ_COMPARISON = 0x00000001,
+        SQL_SQ_EXISTS = 0x00000002,
+        SQL_SQ_IN = 0x00000004,
+        SQL_SQ_QUANTIFIED = 0x00000008,
+        SQL_SQ_CORRELATED_SUBQUERIES = 0x00000010
+    ],
+
+    SQL_U = 
+    [
+        SQL_U_UNION = 0x00000001,
+        SQL_U_UNION_ALL = 0x00000002
+    ],
+
+    SQL_BP = 
+    [
+        SQL_BP_CLOSE = 0x00000001,
+        SQL_BP_DELETE = 0x00000002,
+        SQL_BP_DROP = 0x00000004,
+        SQL_BP_TRANSACTION = 0x00000008,
+        SQL_BP_UPDATE = 0x00000010,
+        SQL_BP_OTHER_HSTMT = 0x00000020,
+        SQL_BP_SCROLL = 0x00000040
+    ],
+
+    SQL_QL = 
+    [
+        SQL_QL_START = 0x0001,
+        SQL_QL_END = 0x0002
+    ],
+
+    SQL_OJ = 
+    [
+        SQL_OJ_LEFT = 0x00000001,
+        SQL_OJ_RIGHT = 0x00000002,
+        SQL_OJ_FULL = 0x00000004,
+        SQL_OJ_NESTED = 0x00000008,
+        SQL_OJ_NOT_ORDERED = 0x00000010,
+        SQL_OJ_INNER = 0x00000020,
+        SQL_OJ_ALL_COMPARISON_OPS = 0x00000040
+    ],
+
+    SQL_FN_CVT = 
+    [
+        //None = 0,
+
+        SQL_FN_CVT_CONVERT        = 0x00000001,
+        SQL_FN_CVT_CAST        = 0x00000002
+    ],
+
+    SQL_FN_NUM = 
+    [
+        //None = 0,
+
+        SQL_FN_NUM_ABS        = 0x00000001,
+        SQL_FN_NUM_ACOS        = 0x00000002,
+        SQL_FN_NUM_ASIN        = 0x00000004,
+        SQL_FN_NUM_ATAN        = 0x00000008,
+        SQL_FN_NUM_ATAN2    = 0x00000010,
+        SQL_FN_NUM_CEILING    = 0x00000020,
+        SQL_FN_NUM_COS        = 0x00000040,
+        SQL_FN_NUM_COT        = 0x00000080,
+        SQL_FN_NUM_EXP        = 0x00000100,
+        SQL_FN_NUM_FLOOR    = 0x00000200,
+        SQL_FN_NUM_LOG        = 0x00000400,
+        SQL_FN_NUM_MOD        = 0x00000800,
+        SQL_FN_NUM_SIGN        = 0x00001000,
+        SQL_FN_NUM_SIN        = 0x00002000,
+        SQL_FN_NUM_SQRT        = 0x00004000,
+        SQL_FN_NUM_TAN      = 0x00008000,
+        SQL_FN_NUM_PI       = 0x00010000,
+        SQL_FN_NUM_RAND     = 0x00020000,
+        SQL_FN_NUM_DEGREES    = 0x00040000,
+        SQL_FN_NUM_LOG10    = 0x00080000,
+        SQL_FN_NUM_POWER    = 0x00100000,
+        SQL_FN_NUM_RADIANS    = 0x00200000,
+        SQL_FN_NUM_ROUND    = 0x00400000,
+        SQL_FN_NUM_TRUNCATE = 0x00800000
+    ],
+
+    SQL_SNVF = 
+    [
+        SQL_SNVF_BIT_LENGTH = 0x00000001,
+        SQL_SNVF_CHAR_LENGTH = 0x00000002,
+        SQL_SNVF_CHARACTER_LENGTH = 0x00000004,
+        SQL_SNVF_EXTRACT = 0x00000008,
+        SQL_SNVF_OCTET_LENGTH = 0x00000010,
+        SQL_SNVF_POSITION = 0x00000020
+    ],
+
+    SQL_FN_STR =
+    [
+        //None = 0,
+
+        SQL_FN_STR_CONCAT            = 0x00000001,
+        SQL_FN_STR_INSERT            = 0x00000002,
+        SQL_FN_STR_LEFT            = 0x00000004,
+        SQL_FN_STR_LTRIM            = 0x00000008,
+        SQL_FN_STR_LENGTH            = 0x00000010,
+        SQL_FN_STR_LOCATE            = 0x00000020,
+        SQL_FN_STR_LCASE            = 0x00000040,
+        SQL_FN_STR_REPEAT            = 0x00000080,
+        SQL_FN_STR_REPLACE            = 0x00000100,
+        SQL_FN_STR_RIGHT            = 0x00000200,
+        SQL_FN_STR_RTRIM            = 0x00000400,
+        SQL_FN_STR_SUBSTRING        = 0x00000800,
+        SQL_FN_STR_UCASE            = 0x00001000,
+        SQL_FN_STR_ASCII            = 0x00002000,
+        SQL_FN_STR_CHAR            = 0x00004000,
+        SQL_FN_STR_DIFFERENCE = 0x00008000,
+        SQL_FN_STR_LOCATE_2          = 0x00010000,
+        SQL_FN_STR_SOUNDEX          = 0x00020000,
+        SQL_FN_STR_SPACE          = 0x00040000,
+        SQL_FN_STR_BIT_LENGTH      = 0x00080000,
+        SQL_FN_STR_CHAR_LENGTH      = 0x00100000,
+        SQL_FN_STR_CHARACTER_LENGTH      = 0x00200000,
+        SQL_FN_STR_OCTET_LENGTH = 0x00400000,
+        SQL_FN_STR_POSITION = 0x00800000
+    ],
+
+    SQL_FN_SYSTEM = 
+    [
+        //None = 0,
+
+        SQL_FN_SYS_USERNAME = 0x00000001,
+        SQL_FN_SYS_DBNAME = 0x00000002,
+        SQL_FN_SYS_IFNULL = 0x00000004
+    ],
+
+    SQL_FN_TD = 
+    [
+        //None = 0,
+
+        SQL_FN_TD_NOW            = 0x00000001,
+        SQL_FN_TD_CURDATE            = 0x00000002,
+        SQL_FN_TD_DAYOFMONTH        = 0x00000004,
+        SQL_FN_TD_DAYOFWEEK            = 0x00000008,
+        SQL_FN_TD_DAYOFYEAR            = 0x00000010,
+        SQL_FN_TD_MONTH            = 0x00000020,
+        SQL_FN_TD_QUARTER            = 0x00000040,
+        SQL_FN_TD_WEEK            = 0x00000080,
+        SQL_FN_TD_YEAR            = 0x00000100,
+        SQL_FN_TD_CURTIME            = 0x00000200,
+        SQL_FN_TD_HOUR            = 0x00000400,
+        SQL_FN_TD_MINUTE            = 0x00000800,
+        SQL_FN_TD_SECOND            = 0x00001000,
+        SQL_FN_TD_TIMESTAMPADD        = 0x00002000,
+        SQL_FN_TD_TIMESTAMPDIFF        = 0x00004000,
+        SQL_FN_TD_DAYNAME          = 0x00008000,
+        SQL_FN_TD_MONTHNAME          = 0x00010000,
+        SQL_FN_TD_CURRENT_DATE      = 0x00020000,
+        SQL_FN_TD_CURRENT_TIME      = 0x00040000,
+        SQL_FN_TD_CURRENT_TIMESTAMP      = 0x00080000,
+        SQL_FN_TD_EXTRACT = 0x00100000
+    ],
+
+    SQL_SDF = 
+    [
+        SQL_SDF_CURRENT_DATE = 0x00000001,
+        SQL_SDF_CURRENT_TIME = 0x00000002,
+        SQL_SDF_CURRENT_TIMESTAMP = 0x00000004
+    ],
+
+    SQL_TSI =
+    [
+        //None = 0,
+
+        SQL_TSI_FRAC_SECOND = 0x00000001,
+        SQL_TSI_SECOND = 0x00000002,
+        SQL_TSI_MINUTE = 0x00000004,
+        SQL_TSI_HOUR = 0x00000008,
+        SQL_TSI_DAY = 0x00000010,
+        SQL_TSI_WEEK = 0x00000020,
+        SQL_TSI_MONTH = 0x00000040,
+        SQL_TSI_QUARTER = 0x00000080,
+        SQL_TSI_YEAR = 0x00000100
+    ],
+
+    SQL_AF = 
+    [
+        //None = 0,
+
+        SQL_AF_AVG        = 0x00000001,
+        SQL_AF_COUNT    = 0x00000002,
+        SQL_AF_MAX        = 0x00000004,
+        SQL_AF_MIN        = 0x00000008,
+        SQL_AF_SUM        = 0x00000010,
+        SQL_AF_DISTINCT    = 0x00000020,
+        SQL_AF_ALL        = 0x00000040,
+
+        All = 0xFF
+    ],
+
+    SQL_SC = 
+    [
+        //None = 0,
+
+        SQL_SC_SQL92_ENTRY            = 0x00000001,
+        SQL_SC_FIPS127_2_TRANSITIONAL    = 0x00000002,
+        SQL_SC_SQL92_INTERMEDIATE        = 0x00000004,
+        SQL_SC_SQL92_FULL            = 0x00000008
+    ],
+
+    SQL_DL_SQL92 = 
+    [
+        SQL_DL_SQL92_DATE                    = 0x00000001,
+        SQL_DL_SQL92_TIME                    = 0x00000002,
+        SQL_DL_SQL92_TIMESTAMP                = 0x00000004,
+        SQL_DL_SQL92_INTERVAL_YEAR                = 0x00000008,
+        SQL_DL_SQL92_INTERVAL_MONTH                = 0x00000010,
+        SQL_DL_SQL92_INTERVAL_DAY                = 0x00000020,
+        SQL_DL_SQL92_INTERVAL_HOUR                = 0x00000040,
+        SQL_DL_SQL92_INTERVAL_MINUTE            = 0x00000080,
+        SQL_DL_SQL92_INTERVAL_SECOND            = 0x00000100,
+        SQL_DL_SQL92_INTERVAL_YEAR_TO_MONTH            = 0x00000200,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_HOUR            = 0x00000400,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_MINUTE            = 0x00000800,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_SECOND            = 0x00001000,
+        SQL_DL_SQL92_INTERVAL_HOUR_TO_MINUTE        = 0x00002000,
+        SQL_DL_SQL92_INTERVAL_HOUR_TO_SECOND        = 0x00004000,
+        SQL_DL_SQL92_INTERVAL_MINUTE_TO_SECOND     = 0x00008000
+    ],
+
+    SQL_IK = 
+    [
+        SQL_IK_NONE        = 0x00000000,
+        SQL_IK_ASC        = 0x00000001,
+        SQL_IK_DESC        = 0x00000002,
+        SQL_IK_ALL = 0x00000003 //SQL_IK_ASC | SQL_IK_DESC
+    ],
+
+    SQL_ISV = 
+    [
+        SQL_ISV_ASSERTIONS            = 0x00000001,
+        SQL_ISV_CHARACTER_SETS        = 0x00000002,
+        SQL_ISV_CHECK_CONSTRAINTS        = 0x00000004,
+        SQL_ISV_COLLATIONS            = 0x00000008,
+        SQL_ISV_COLUMN_DOMAIN_USAGE        = 0x00000010,
+        SQL_ISV_COLUMN_PRIVILEGES        = 0x00000020,
+        SQL_ISV_COLUMNS            = 0x00000040,
+        SQL_ISV_CONSTRAINT_COLUMN_USAGE    = 0x00000080,
+        SQL_ISV_CONSTRAINT_TABLE_USAGE    = 0x00000100,
+        SQL_ISV_DOMAIN_CONSTRAINTS        = 0x00000200,
+        SQL_ISV_DOMAINS            = 0x00000400,
+        SQL_ISV_KEY_COLUMN_USAGE        = 0x00000800,
+        SQL_ISV_REFERENTIAL_CONSTRAINTS    = 0x00001000,
+        SQL_ISV_SCHEMATA            = 0x00002000,
+        SQL_ISV_SQL_LANGUAGES        = 0x00004000,
+        SQL_ISV_TABLE_CONSTRAINTS      = 0x00008000,
+        SQL_ISV_TABLE_PRIVILEGES      = 0x00010000,
+        SQL_ISV_TABLES          = 0x00020000,
+        SQL_ISV_TRANSLATIONS      = 0x00040000,
+        SQL_ISV_USAGE_PRIVILEGES      = 0x00080000,
+        SQL_ISV_VIEW_COLUMN_USAGE      = 0x00100000,
+        SQL_ISV_VIEW_TABLE_USAGE = 0x00200000,
+        SQL_ISV_VIEWS          = 0x00400000
+    ],
+
+    SQL_SRJO = 
+    [
+        //None = 0,
+
+        SQL_SRJO_CORRESPONDING_CLAUSE = 0x00000001,
+        SQL_SRJO_CROSS_JOIN = 0x00000002,
+        SQL_SRJO_EXCEPT_JOIN = 0x00000004,
+        SQL_SRJO_FULL_OUTER_JOIN = 0x00000008,
+        SQL_SRJO_INNER_JOIN = 0x00000010,
+        SQL_SRJO_INTERSECT_JOIN = 0x00000020,
+        SQL_SRJO_LEFT_OUTER_JOIN = 0x00000040,
+        SQL_SRJO_NATURAL_JOIN = 0x00000080,
+        SQL_SRJO_RIGHT_OUTER_JOIN = 0x00000100,
+        SQL_SRJO_UNION_JOIN = 0x00000200
+    ],
+
+    SQL_SRVC = 
+    [
+        SQL_SRVC_VALUE_EXPRESSION = 0x00000001,
+        SQL_SRVC_NULL = 0x00000002,
+        SQL_SRVC_DEFAULT = 0x00000004,
+        SQL_SRVC_ROW_SUBQUERY = 0x00000008
+    ],
+
+    //public static readonly int SQL_OV_ODBC3 = 3;
+    //public const Int32 SQL_NTS = -3;       //flags for null-terminated string
+
+    //Pooling
+    SQL_CP = 
+    [
+        OFF = 0,
+        ONE_PER_DRIVER = 1,
+        ONE_PER_HENV = 2
+    ],
+
+/*
+    public const Int32 SQL_CD_TRUE = 1;
+    public const Int32 SQL_CD_FALSE = 0;
+
+    public const Int32 SQL_DTC_DONE = 0;
+    public const Int32 SQL_IS_POINTER = -4;
+    public const Int32 SQL_IS_PTR = 1;
+*/
+    SQL_DRIVER =
+    [
+        NOPROMPT = 0,
+        COMPLETE = 1,
+        PROMPT = 2,
+        COMPLETE_REQUIRED = 3
+    ],
+
+    // Column set for SQLPrimaryKeys
+    SQL_PRIMARYKEYS =
+    [
+        /*
+                    CATALOGNAME         = 1,                    // TABLE_CAT
+                    SCHEMANAME          = 2,                    // TABLE_SCHEM
+                    TABLENAME           = 3,                    // TABLE_NAME
+        */
+        COLUMNNAME = 4                    // COLUMN_NAME
+        /*
+                    KEY_SEQ             = 5,                    // KEY_SEQ
+                    PKNAME              = 6,                    // PK_NAME
+        */
+    ],
+
+    // Column set for SQLStatistics
+    SQL_STATISTICS =
+    [
+        /*
+                    CATALOGNAME         = 1,                    // TABLE_CAT
+                    SCHEMANAME          = 2,                    // TABLE_SCHEM
+                    TABLENAME           = 3,                    // TABLE_NAME
+                    NONUNIQUE           = 4,                    // NON_UNIQUE
+                    INDEXQUALIFIER      = 5,                    // INDEX_QUALIFIER
+        */
+        INDEXNAME = 6,                    // INDEX_NAME
+        /*
+                    TYPE                = 7,                    // TYPE
+        */
+        ORDINAL_POSITION = 8,                    // ORDINAL_POSITION
+        COLUMN_NAME = 9                    // COLUMN_NAME
+        /*
+                    ASC_OR_DESC         = 10,                   // ASC_OR_DESC
+                    CARDINALITY         = 11,                   // CARDINALITY
+                    PAGES               = 12,                   // PAGES
+                    FILTER_CONDITION    = 13,                   // FILTER_CONDITION
+        */
+    ],
+
+    // Column set for SQLSpecialColumns
+    SQL_SPECIALCOLUMNSET =
+    [
+        /*
+                    SCOPE               = 1,                    // SCOPE
+        */
+        COLUMN_NAME = 2                    // COLUMN_NAME
+        /*
+                    DATA_TYPE           = 3,                    // DATA_TYPE
+                    TYPE_NAME           = 4,                    // TYPE_NAME
+                    COLUMN_SIZE         = 5,                    // COLUMN_SIZE
+                    BUFFER_LENGTH       = 6,                    // BUFFER_LENGTH
+                    DECIMAL_DIGITS      = 7,                    // DECIMAL_DIGITS
+                    PSEUDO_COLUMN       = 8,                    // PSEUDO_COLUMN
+        */
+    ],
+
+    SQL_DIAG =
+    [
+        CURSOR_ROW_COUNT= -1249,
+        ROW_NUMBER = -1248,
+        COLUMN_NUMBER = -1247,
+        RETURNCODE = 1,
+        NUMBER = 2,
+        ROW_COUNT = 3,
+        SQLSTATE = 4,
+        NATIVE = 5,
+        MESSAGE_TEXT = 6,
+        DYNAMIC_FUNCTION = 7,
+        CLASS_ORIGIN = 8,
+        SUBCLASS_ORIGIN = 9,
+        CONNECTION_NAME = 10,
+        SERVER_NAME = 11,
+        DYNAMIC_FUNCTION_CODE = 12
+    ],
+
+    SQL_SU =
+    [
+        SQL_SU_DML_STATEMENTS       = 0x00000001,
+        SQL_SU_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_SU_TABLE_DEFINITION     = 0x00000004,
+        SQL_SU_INDEX_DEFINITION     = 0x00000008,
+        SQL_SU_PRIVILEGE_DEFINITION = 0x00000010
+    ]
+]

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/SnowflakeODBC/SnowflakeODBC.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/SnowflakeODBC/SnowflakeODBC.pq
@@ -1,0 +1,275 @@
+﻿section SnowflakeODBC;
+
+// When set to true, additional trace information will be written out to the User log. 
+// This should be set to false before release. Tracing is done through a call to 
+// Diagnostics.LogValue(). When EnableTraceOutput is set to false, the call becomes a 
+// no-op and simply returns the original value.
+EnableTraceOutput = false;
+
+[DataSource.Kind="SnowflakeODBC", Publish="SnowflakeODBC.UI"]
+shared SnowflakeODBC.Databases = (server as text, warehouse as text, optional options as nullable record) as table =>
+    let
+        Host = GetHost(server),
+        ConnectionTimeoutOption = GetTimeoutOption(options, "ConnectionTimeout"),
+        QueryTimeoutOption = GetTimeoutOption(options, "CommandTimeout"),
+        BaseConnectionString =
+            if options <> null and List.Count(List.Difference(Record.FieldNames(options), ValidOptions)) > 0 then
+                error Error.Record("Expression.Error", "InvalidOptionsKey")
+            else
+                [
+                    driver = "SnowflakeDSIIDriver",
+                    server = Host,
+                    warehouse = warehouse
+                ],
+        WithLoginTimeoutOption = AddConnectionStringOption(BaseConnectionString, "login_timeout", ConnectionTimeoutOption),
+        WithNetworkTimeoutOption = AddConnectionStringOption(WithLoginTimeoutOption, "network_timeout", ConnectionTimeoutOption),
+        ConnectionString = AddConnectionStringOption(WithNetworkTimeoutOption, "query_timeout", QueryTimeoutOption),
+        Options = [
+            AstVisitor = [
+                LimitClause = (skip, take) =>
+                    if skip = 0 and take = null then
+                        ...
+                    else
+                        let
+                            // While supported in the documented grammar, using OFFSET without LIMIT produces a synax error.
+                            take = if take = null then 4611686018427387903 else take
+                        in
+                            [
+                                Text = Text.Format("LIMIT #{0} OFFSET #{1}", { take, skip }),
+                                Location = "AfterQuerySpecification"
+                            ],
+                Constant =
+                    let
+                        Quote = each Text.Format("'#{0}'", { _ }),
+                        Cast = (value, typeName) => [
+                            Text = Text.Format("CAST(#{0} as #{1})", { value, typeName })
+                        ],
+                        Visitor = [
+                            // This is to work around parameters being converted to VARCHAR
+                            // and to work around driver crash when using TYPE_TIME parameters.
+                            NUMERIC = each Cast(_, "NUMERIC"),
+                            DECIMAL = each Cast(_, "DECIMAL"),
+                            INTEGER = each Cast(_, "INTEGER"),
+                            FLOAT = each Cast(_, "FLOAT"),
+                            REAL = each Cast(_, "REAL"),
+                            DOUBLE = each Cast(_, "DOUBLE"),
+                            DATE = each Cast(Quote(Date.ToText(_, "yyyy-MM-dd")), "DATE"),
+                            TIMESTAMP = each Cast(Quote(DateTime.ToText(_, "yyyy-MM-dd HH:mm:ss.sssssss")), "TIMESTAMP"),
+                            TIME = each Cast(Quote(Time.ToText(_, "HH:mm:ss.sssssss")), "TIME")
+                        ]
+                    in
+                        (typeInfo, ast) => Record.FieldOrDefault(Visitor, typeInfo[TYPE_NAME], each null)(ast[Value])
+            ],
+            ClientConnectionPooling = true,
+            SqlCapabilities = [
+                Sql92Conformance = 8, /* SQL_SC_SQL92_FULL */
+                FractionalSecondsScale = 3,
+                MaxParameters = 50
+            ],
+            OnError = (errorRecord as record) =>
+                if errorRecord[Reason] = DataSourceMissingClientLibrary then
+                    error Error.Record(
+                        DataSourceMissingClientLibrary, Text.Format(
+                        "Missing client library", { DriverDownloadUrl }),
+                        DriverDownloadUrl)
+                else if errorRecord[Reason] = DataSourceError and not Table.IsEmpty(Table.SelectRows(errorRecord[Detail][OdbcErrors], each [SQLState] = "57P03")) then
+                    error Error.Record(
+                        DataSourceError,
+                        Text.Format("warehouse suspended", { warehouse }),
+                        errorRecord[Detail])
+                else
+                    error errorRecord,
+
+            // SQLGetTypeInfo can be specified in two ways:
+            // 1. A #table() value that returns the same type information as an ODBC
+            //    call to SQLGetTypeInfo.
+            // 2. A function that accepts a table argument, and returns a table. The 
+            //    argument will contain the original results of the ODBC call to SQLGetTypeInfo.
+            //    Your function implementation can modify/add to this table.
+            //
+            // For details of the format of the types table parameter and expected return value,
+            // please see: https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgettypeinfo-function
+            //
+            // The sample implementation provided here will simply output the original table
+            // to the user trace log, without any modification. 
+            SQLGetTypeInfo = (types) => 
+                if (EnableTraceOutput <> true) then types else
+                let
+                    // Outputting the entire table might be too large, and result in the value being truncated.
+                    // We can output a row at a time instead with Table.TransformRows()
+                    rows = Table.TransformRows(types, each Diagnostics.LogValue("SQLGetTypeInfo " & _[TYPE_NAME], _)),
+                    toTable = Table.FromRecords(rows)
+                in
+                    Value.ReplaceType(toTable, Value.Type(types)),         
+
+            // This is to work around the driver returning the deprecated
+            // TIMESTAMP, DATE and TIME instead of TYPE_TIMESTAMP, TYPE_DATE and TYPE_TIME
+            // for column metadata returned by SQLColumns. The column types also don't
+            // match the types that are returned by SQLGetTypeInfo.
+            SQLColumns = (catalogName, schemaName, tableName, columnName, source) =>
+                let
+                    OdbcSqlType.DATETIME = 9,
+                    OdbcSqlType.TYPE_DATE = 91,
+                    OdbcSqlType.TIME = 10,
+                    OdbcSqlType.TYPE_TIME = 92,
+                    OdbcSqlType.TIMESTAMP = 11,
+                    OdbcSqlType.TYPE_TIMESTAMP = 93,
+
+                    FixDataType = (dataType) =>
+                        if dataType = OdbcSqlType.DATETIME then
+                            OdbcSqlType.TYPE_DATE
+                        else if dataType = OdbcSqlType.TIME then
+                            OdbcSqlType.TYPE_TIME
+                        else if dataType = OdbcSqlType.TIMESTAMP then
+                            OdbcSqlType.TYPE_TIMESTAMP
+                        else
+                            dataType,
+                    Transform = Table.TransformColumns(source, { { "DATA_TYPE", FixDataType } })
+                in
+                    if (EnableTraceOutput <> true) then Transform else
+                    // the if statement conditions will force the values to evaluated/written to diagnostics
+                    if (Diagnostics.LogValue("SQLColumns.TableName", tableName) <> "***" and Diagnostics.LogValue("SQLColumns.ColumnName", columnName) <> "***") then
+                        let
+                            // Outputting the entire table might be too large, and result in the value being truncated.
+                            // We can output a row at a time instead with Table.TransformRows()
+                            rows = Table.TransformRows(Transform, each Diagnostics.LogValue("SQLColumns", _)),
+                            toTable = Table.FromRecords(rows)
+                        in
+                            Value.ReplaceType(toTable, Value.Type(Transform))
+                    else
+                        Transform,
+
+            HierarchicalNavigation = true,
+            HideNativeQuery = true,
+            SoftNumbers = true
+        ],
+        Databases = Odbc.DataSource(ConnectionString, Options),
+        Metadata = Value.Metadata(Value.Type(Databases)),
+        RemovedInformationSchema = 
+            let
+                RemoveInformationSchema = (data) => Table.SelectRows(data, each [Name] <> "INFORMATION_SCHEMA"),
+                TransformColumns = Table.TransformColumns(Databases, { "Data", RemoveInformationSchema })
+            in
+                TransformColumns,
+        TransformComplexColumns = 
+            let
+                TransformComplexColumns = (table) => 
+                    let
+                        TableType = Value.Type(table),
+                        Schema = Table.Schema(table),
+                        ComplexColumns = Table.ToRecords(Table.SelectRows(Schema, 
+                            each [NativeTypeName]  = "STRUCT" or [NativeTypeName] = "ARRAY")),
+                        TransformOperations = List.Accumulate(ComplexColumns, table, (state, column) =>
+                            let
+                                ColumnType = Type.TableColumn(TableType, column[Name]),
+                                PreservedFacetFields = { "NativeTypeName", "NativeDefaultExpression", "NativeExpression" },
+                                Facets = Record.SelectFields(Type.Facets(ColumnType), PreservedFacetFields),
+                                ComplexType = if column[NativeTypeName] = "STRUCT" then type record else type list,
+                                AddNullable = if Type.IsNullable(ComplexType) then type nullable ComplexType else ComplexType,
+                                TypeWithFacets = Type.ReplaceFacets(AddNullable, Facets),
+                                ToNullableJson = (value) => if value = null then null else Json.Document(value),
+                                TransformColumn = Table.TransformColumns(state, { column[Name], ToNullableJson, TypeWithFacets })
+                            in
+                                TransformColumn)
+                    in
+                        TransformOperations,
+
+                TransformColumnKeepType = (table, columnName, operation) =>
+                    let
+                        TableType = Value.Type(table),
+                        TransformColumn = Table.TransformColumns(table, { columnName, operation, Type.TableColumn(table, columnName) }),
+                        ReplaceType = Value.ReplaceType(TransformColumn, TableType)
+                    in
+                        ReplaceType,
+
+                TransformColumns =  TransformColumnKeepType(RemovedInformationSchema, "Data", 
+                    (schemas) => TransformColumnKeepType(schemas, "Data",
+                        (tables) => TransformColumnKeepType(tables, "Data",
+                            TransformComplexColumns)))
+            in
+                TransformColumns,
+        WithMetadata = Value.ReplaceType(TransformComplexColumns, Value.ReplaceMetadata(Value.Type(RemovedInformationSchema), Metadata))
+    in
+        WithMetadata;
+
+GetOption = (options as nullable record, name as text) =>
+    if options <> null and Record.HasFields(options, name) then
+        Record.Field(options, name)
+    else
+        null;
+
+GetTimeoutOption = (options as nullable record, name as text) =>
+    let
+        option = GetOption(options, name)
+    in
+        if option <> null then
+            if option is number and option >= 0 and NumberIsInteger(option) then
+                option
+            else
+                error Error.Record("Expression.Error", Text.Format("InvalidTimeoutOptionError: #{0}"), { name })
+        else
+            null;
+
+GetHost = (server as text) as text =>
+    let
+        Address = Uri.Parts("http://" & server)
+    in
+        if Address[Host] = "" 
+            or Address[Scheme] <> "http" 
+            or Address[Path] <> "/" 
+            or Address[Query] <> [] 
+            or Address[Fragment] <> ""
+            or Address[UserName] <> "" 
+            or Address[Password] <> "" 
+            or (Address[Port] <> 80 and Address[Port] <> 443) 
+            or Text.EndsWith(server, ":80") 
+        then 
+            error "Invalid server name"
+        else 
+            Address[Host];
+
+AddConnectionStringOption = (options as record, name as text, value as any) as record =>
+    if value = null then
+        options
+    else
+        Record.AddField(options, name, value);
+
+NumberIsInteger = (x as number) => Number.RoundDown(x) = x;
+DriverDownloadUrl = "http://go.microsoft.com/fwlink/?LinkID=823762";
+ValidOptions = {
+    "ConnectionTimeout",
+    "CommandTimeout"
+};
+DataSourceMissingClientLibrary = "DataSource.MissingClientLibrary";
+DataSourceError = "DataSource.Error";
+
+SnowflakeODBC = [
+    Authentication = [
+        UsernamePassword = []
+    ]
+];
+
+SnowflakeODBC.UI = [
+    ButtonText = { "SnowflakeODBC Sample", "SnowflakeODBC Sample" },
+    Category = "Database",
+    SupportsDirectQuery = true
+];
+
+// 
+// Load common library functions
+// 
+Extension.LoadFunction = (name as text) =>
+    let
+        binary = Extension.Contents(name),
+        asText = Text.FromBinary(binary)
+    in
+        Expression.Evaluate(asText, #shared);
+
+// Diagnostics module contains multiple functions. We can take the ones we need.
+Diagnostics = Extension.LoadFunction("Diagnostics.pqm");
+Diagnostics.LogValue = if (EnableTraceOutput) then Diagnostics[LogValue] else (prefix, value) => value;
+
+// OdbcConstants contains numeric constants from the ODBC header files, and a 
+// helper function to create bitfield values.
+ODBC = Extension.LoadFunction("OdbcConstants.pqm");
+Odbc.Flags = ODBC[Flags];

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/SnowflakeODBC/SnowflakeODBC.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/SnowflakeODBC/SnowflakeODBC.query.pq
@@ -1,0 +1,5 @@
+﻿// Use this file to write queries to test your data connector
+let
+    result = SnowflakeODBC.Databases("server", "warehouse")
+in
+    result

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/SqlODBC/Diagnostics.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/SqlODBC/Diagnostics.pqm
@@ -1,0 +1,275 @@
+﻿let
+    Diagnostics.LogValue = (prefix, value) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogFailure = (text, function) =>
+        let
+            result = try function()
+        in
+            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
+
+    Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
+        Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
+
+    Diagnostics.WrapHandlers = (handlers as record) as record =>
+        Record.FromList(
+            List.Transform(
+                Record.FieldNames(handlers),
+                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
+            Record.FieldNames(handlers)),
+
+    Diagnostics.ValueToText = (value) =>
+        let
+            _canBeIdentifier = (x) =>
+                                            let
+                                                keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                                charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                                charDigit = (c as number) => c>= 48 and c <= 57
+                                            in
+                                                try
+                                                    charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                    and
+                                                        List.MatchesAll(
+                                                            Text.ToList(x),
+                                                            (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                        )
+                                                    and not 
+                                                        List.MatchesAny( keywords, (li)=> li=x )
+                                                otherwise 
+                                                    false,
+    
+            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+            Serialize.Date =        (x) => "#date(" & 
+                                           Text.From(Date.Year(x))  & ", " & 
+                                           Text.From(Date.Month(x)) & ", " & 
+                                           Text.From(Date.Day(x))   & ") ",
+
+            Serialize.Datetime =    (x) => "#datetime(" &
+                                           Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                           Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                           Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                           Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                           Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                           Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+            Serialize.Datetimezone =(x) => let 
+                                              dtz = DateTimeZone.ToRecord(x) 
+                                           in
+                                              "#datetimezone(" & 
+                                              Text.From(dtz[Year])        & ", " &
+                                              Text.From(dtz[Month])       & ", " &
+                                              Text.From(dtz[Day])         & ", " &
+                                              Text.From(dtz[Hour])        & ", " &
+                                              Text.From(dtz[Minute])      & ", " &
+                                              Text.From(dtz[Second])      & ", " &
+                                              Text.From(dtz[ZoneHours])   & ", " &
+                                              Text.From(dtz[ZoneMinutes]) & ") ",
+
+            Serialize.Duration =    (x) => let
+                                              dur = Duration.ToRecord(x)
+                                           in
+                                              "#duration(" &
+                                              Text.From(dur[Days])    & ", " &
+                                              Text.From(dur[Hours])   & ", " &
+                                              Text.From(dur[Minutes]) & ", " &
+                                              Text.From(dur[Seconds]) & ") ",
+
+            Serialize.Function =    (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(Value.Type(x)),
+                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                           " as " &
+                                           _serialize_function_return_type(Value.Type(x)) &
+                                           " => (...) ",
+
+            Serialize.List =        (x) => "{" & 
+                                           List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                           "} ",
+
+            Serialize.Logical =     (x) => Text.From(x),
+
+            Serialize.Null =        (x) => "null",
+
+            Serialize.Number =      (x) => 
+                                        let Text.From = (i as number) as text => 
+                                            if Number.IsNaN(i) then "#nan" else
+                                            if i=Number.PositiveInfinity then "#infinity" else
+                                            if i=Number.NegativeInfinity then "-#infinity" else
+                                            Text.From(i)
+                                        in
+                                            Text.From(x),
+
+            Serialize.Record =      (x) => "[ " &
+                                           List.Accumulate(
+                                                Record.FieldNames(x), 
+                                                "", 
+                                                (seed,item) => 
+                                                    (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                           ) &
+                                           " ] ",
+
+            Serialize.Table =       (x) => "#table( type " &
+                                            _serialize_table_type(Value.Type(x)) &
+                                            ", " &
+                                            Serialize(Table.ToRows(x)) &
+                                            ") ",
+                                    
+            Serialize.Text =        (x) => """" & 
+                                           _serialize_text_content(x) & 
+                                           """",
+
+            _serialize_text_content =  (x) => let 
+                                                escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                            in
+                                            List.Accumulate(
+                                               List.Transform(
+                                                   Text.ToList(x),
+                                                   (c) => let n=Character.ToNumber(c) in 
+                                                            if n = 9   then "#(#)(tab)" else
+                                                            if n = 10  then "#(#)(lf)"  else
+                                                            if n = 13  then "#(#)(cr)"  else
+                                                            if n = 34  then """"""      else
+                                                            if n = 35  then "#(#)(#)"   else
+                                                            if n < 32  then escapeText(n) else 
+                                                            if n < 127 then Character.FromNumber(n) else 
+                                                            escapeText(n) 
+                                                ),
+                                                "",
+                                                (s,i)=>s&i
+                                            ),
+        
+            Serialize.Identifier =   (x) => 
+                                            if _canBeIdentifier(x) then 
+                                                x 
+                                            else 
+                                                "#""" &
+                                                _serialize_text_content(x) &
+                                                """",
+
+            Serialize.Time =        (x) => "#time(" &
+                                           Text.From(Time.Hour(x))   & ", " & 
+                                           Text.From(Time.Minute(x)) & ", " & 
+                                           Text.From(Time.Second(x)) & ") ",
+                                
+            Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                        let
+                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                        in
+                                
+                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                            if x = type any then "any" else
+                                            let base = Type.NonNullable(x) in
+                                              (if Type.IsNullable(x) then "nullable " else "") &       
+                                              (if base = type anynonnull then "anynonnull" else                
+                                              if base = type binary then "binary" else                
+                                              if base = type date   then "date"   else
+                                              if base = type datetime then "datetime" else
+                                              if base = type datetimezone then "datetimezone" else
+                                              if base = type duration then "duration" else
+                                              if base = type logical then "logical" else
+                                              if base = type none then "none" else
+                                              if base = type null then "null" else
+                                              if base = type number then "number" else
+                                              if base = type text then "text" else 
+                                              if base = type time then "time" else 
+                                              if base = type type then "type" else 
+                                      
+                                              /* Abstract types: */
+                                              if base = type function then "function" else
+                                              if base = type table then "table" else
+                                              if base = type record then "record" else
+                                              if base = type list then "list" else
+                                      
+                                              "any /*Actually unknown type*/"),
+
+            _serialize_table_type =     (x) => 
+                                               let 
+                                                 schema = Type.TableSchema(x)
+                                               in
+                                                 "table " &
+                                                 (if Table.IsEmpty(schema) then "" else 
+                                                     "[" & List.Accumulate(
+                                                        List.Transform(
+                                                            Table.ToRecords(Table.Sort(schema,"Position")),
+                                                            each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                        "",
+                                                        (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                    ) & "] " ),
+
+            _serialize_record_type =    (x) => 
+                                                let flds = Type.RecordFields(x)
+                                                in
+                                                    if Record.FieldCount(flds)=0 then "record" else
+                                                        "[" & List.Accumulate(
+                                                            Record.FieldNames(flds),
+                                                            "",
+                                                            (seed,item) => 
+                                                                seed &
+                                                                (if seed<>"" then ", " else "") &
+                                                                (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                        ) & 
+                                                        (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                        "]",
+
+            _serialize_function_type =  (x) => _serialize_function_param_type(
+                                                  Type.FunctionParameters(x),
+                                                  Type.FunctionRequiredParameters(x) ) &
+                                                " as " &
+                                                _serialize_function_return_type(x),
+    
+            _serialize_function_param_type = (t,n) => 
+                                    let
+                                        funsig = Table.ToRecords(
+                                            Table.TransformColumns(
+                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                                { "isOptional", (x)=> x>n } ) )
+                                    in
+                                        "(" & 
+                                        List.Accumulate(
+                                            funsig,
+                                            "",
+                                            (seed,item)=>
+                                                (if seed="" then "" else seed & ", ") &
+                                                (if item[isOptional] then "optional " else "") &
+                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                         & ")",
+
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+            Serialize = (x) as text => 
+                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                               if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                               if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                               if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                               if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                               if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                               if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                               if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                               if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                               if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                               "[#_unable_to_serialize_#]"                     
+        in
+            try Serialize(value) otherwise "<serialization failed>"
+in
+    [ 
+        LogValue = Diagnostics.LogValue,
+        LogValue2 = Diagnostics.LogValue2,
+        LogFailure = Diagnostics.LogFailure,
+        WrapFunctionResult = Diagnostics.WrapFunctionResult,
+        WrapHandlers = Diagnostics.WrapHandlers,
+        ValueToText = Diagnostics.ValueToText
+    ]

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/SqlODBC/OdbcConstants.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/SqlODBC/OdbcConstants.pqm
@@ -1,0 +1,1253 @@
+// values from https://github.com/Microsoft/ODBC-Specification/blob/master/Windows/inc/sqlext.h
+[
+    Flags = (flags as list) => 
+        if (List.IsEmpty(flags)) then 0 else
+        let
+            Loop = List.Generate(()=> [i = 0, Combined = flags{0}],
+                                    each [i] < List.Count(flags),
+                                    each [Combined = Number.BitwiseOr([Combined], flags{i}), i = [i]+1],
+                                    each [Combined]),
+            Result = List.Last(Loop)
+        in
+            Result,
+
+    SQL_HANDLE =
+    [
+        ENV = 1,
+        DBC = 2,
+        STMT = 3,
+        DESC = 4
+    ],
+
+    RetCode =
+    [
+        SUCCESS = 0,
+        SUCCESS_WITH_INFO = 1,
+        ERROR = -1,
+        INVALID_HANDLE = -2,
+        NO_DATA = 100
+    ],
+
+    SQL_CONVERT =
+    [
+        BIGINT = 53,
+        BINARY = 54,
+        BIT = 55,
+        CHAR = 56,
+        DATE = 57,
+        DECIMAL = 58,
+        DOUBLE = 59,
+        FLOAT = 60,
+        INTEGER = 61,
+        LONGVARCHAR = 62,
+        NUMERIC = 63,
+        REAL = 64,
+        SMALLINT = 65,
+        TIME = 66,
+        TIMESTAMP = 67,
+        TINYINT = 68,
+        VARBINARY = 69,
+        VARCHAR = 70,
+        LONGVARBINARY = 71
+    ],
+
+    SQL_ROW =
+    [
+        PROCEED = 0,
+        IGNORE = 1,
+        SUCCESS = 0,
+        DELETED = 1,
+        UPDATED = 2,
+        NOROW = 3,
+        ADDED = 4,
+        ERROR = 5,
+        SUCCESS_WITH_INFO = 6
+    ],
+
+SQL_CVT =
+[
+    //None = 0,
+
+    CHAR = 0x00000001,
+    NUMERIC = 0x00000002,
+    DECIMAL = 0x00000004,
+    INTEGER = 0x00000008,
+    SMALLINT = 0x00000010,
+    FLOAT = 0x00000020,
+    REAL = 0x00000040,
+    DOUBLE = 0x00000080,
+    VARCHAR = 0x00000100,
+    LONGVARCHAR = 0x00000200,
+    BINARY = 0x00000400,
+    VARBINARY = 0x00000800,
+    BIT = 0x00001000,
+    TINYINT = 0x00002000,
+    BIGINT = 0x00004000,
+    DATE = 0x00008000,
+    TIME = 0x00010000,
+    TIMESTAMP = 0x00020000,
+    LONGVARBINARY = 0x00040000,
+    INTERVAL_YEAR_MONTH = 0x00080000,
+    INTERVAL_DAY_TIME = 0x00100000,
+    WCHAR = 0x00200000,
+    WLONGVARCHAR = 0x00400000,
+    WVARCHAR = 0x00800000,
+    GUID = 0x01000000
+],
+
+    STMT =
+    [
+        CLOSE = 0,
+        DROP = 1,
+        UNBIND = 2,
+        RESET_PARAMS = 3
+    ],
+
+    SQL_MAX =
+    [
+        NUMERIC_LEN = 16
+    ],
+
+    SQL_IS =
+    [
+        POINTER = -4,
+        INTEGER = -6,
+        UINTEGER = -5,
+        SMALLINT = -8
+    ],
+
+    //SQL Server specific defines
+    //
+    SQL_HC =                        // from Odbcss.h
+    [
+        OFF = 0,                //  FOR BROWSE columns are hidden
+        ON = 1                //  FOR BROWSE columns are exposed
+    ],
+
+    SQL_NB =                         // from Odbcss.h
+    [
+        OFF = 0,                //  NO_BROWSETABLE is off
+        ON = 1                //  NO_BROWSETABLE is on
+    ],
+
+    //  SQLColAttributes driver specific defines.
+    //  SQLSet/GetDescField driver specific defines.
+    //  Microsoft has 1200 thru 1249 reserved for Microsoft SQL Server driver usage.
+    //
+    SQL_CA_SS =                      // from Odbcss.h
+    [
+        BASE = 1200,           // SQL_CA_SS_BASE
+
+        COLUMN_HIDDEN = 1200 + 11,      //  Column is hidden (FOR BROWSE)
+        COLUMN_KEY = 1200 + 12,      //  Column is key column (FOR BROWSE)
+        VARIANT_TYPE = 1200 + 15,
+        VARIANT_SQL_TYPE = 1200 + 16,
+        VARIANT_SERVER_TYPE = 1200 + 17
+
+    ],
+
+    SQL_SOPT_SS =                    // from Odbcss.h
+    [
+        BASE = 1225,                // SQL_SOPT_SS_BASE
+        HIDDEN_COLUMNS = 1225 + 2,  // Expose FOR BROWSE hidden columns
+        NOBROWSETABLE = 1225 + 3    // Set NOBROWSETABLE option
+    ],
+
+    SQL_COMMIT = 0,      //Commit
+    SQL_ROLLBACK = 1,      //Abort
+
+    //static public readonly IntPtr SQL_AUTOCOMMIT_OFF = IntPtr.Zero;
+    //static public readonly IntPtr SQL_AUTOCOMMIT_ON = new IntPtr(1);
+
+    SQL_TRANSACTION =
+    [
+        READ_UNCOMMITTED = 0x00000001,
+        READ_COMMITTED = 0x00000002,
+        REPEATABLE_READ = 0x00000004,
+        SERIALIZABLE = 0x00000008,
+        SNAPSHOT = 0x00000020 // VSDD 414121: SQL_TXN_SS_SNAPSHOT == 0x20 (sqlncli.h)
+    ],
+
+    SQL_PARAM =
+    [
+        TYPE_UNKNOWN = 0,          // SQL_PARAM_TYPE_UNKNOWN
+        INPUT = 1,                 // SQL_PARAM_INPUT
+        INPUT_OUTPUT = 2,          // SQL_PARAM_INPUT_OUTPUT
+        RESULT_COL =   3,          // SQL_RESULT_COL
+        OUTPUT = 4,                // SQL_PARAM_OUTPUT
+        RETURN_VALUE = 5           // SQL_RETURN_VALUE
+    ],
+
+    SQL_DESC =
+    [
+        // from sql.h (ODBCVER >= 3.0)
+        //
+        COUNT = 1001,
+        TYPE = 1002,
+        LENGTH = 1003,
+        OCTET_LENGTH_PTR = 1004,
+        PRECISION = 1005,
+        SCALE = 1006,
+        DATETIME_INTERVAL_CODE = 1007,
+        NULLABLE = 1008,
+        INDICATOR_PTR = 1009,
+        DATA_PTR = 1010,
+        NAME = 1011,
+        UNNAMED = 1012,
+        OCTET_LENGTH = 1013,
+        ALLOC_TYPE = 1099,
+
+        // from sqlext.h (ODBCVER >= 3.0)
+        //
+        CONCISE_TYPE = SQL_COLUMN[TYPE],
+        DISPLAY_SIZE = SQL_COLUMN[DISPLAY_SIZE],
+        UNSIGNED = SQL_COLUMN[UNSIGNED],
+        UPDATABLE = SQL_COLUMN[UPDATABLE],
+        AUTO_UNIQUE_VALUE = SQL_COLUMN[AUTO_INCREMENT],
+
+        TYPE_NAME = SQL_COLUMN[TYPE_NAME],
+        TABLE_NAME = SQL_COLUMN[TABLE_NAME],
+        SCHEMA_NAME = SQL_COLUMN[OWNER_NAME],
+        CATALOG_NAME = SQL_COLUMN[QUALIFIER_NAME],
+
+        BASE_COLUMN_NAME = 22,
+        BASE_TABLE_NAME = 23,
+
+        NUM_PREC_RADIX = 32
+    ],
+
+    // ODBC version 2.0 style attributes
+    // All IdentifierValues are ODBC 1.0 unless marked differently
+    //
+    SQL_COLUMN =
+    [
+        COUNT = 0,
+        NAME = 1,
+        TYPE = 2,
+        LENGTH = 3,
+        PRECISION = 4,
+        SCALE = 5,
+        DISPLAY_SIZE = 6,
+        NULLABLE = 7,
+        UNSIGNED = 8,
+        MONEY = 9,
+        UPDATABLE = 10,
+        AUTO_INCREMENT = 11,
+        CASE_SENSITIVE = 12,
+        SEARCHABLE = 13,
+        TYPE_NAME = 14,
+        TABLE_NAME = 15,    // (ODBC 2.0)
+        OWNER_NAME = 16,    // (ODBC 2.0)
+        QUALIFIER_NAME = 17,    // (ODBC 2.0)
+        LABEL = 18
+    ],
+
+    // values from sqlext.h
+    SQL_SQL92_RELATIONAL_JOIN_OPERATORS =
+    [
+        CORRESPONDING_CLAUSE = 0x00000001,    // SQL_SRJO_CORRESPONDING_CLAUSE
+        CROSS_JOIN = 0x00000002,    // SQL_SRJO_CROSS_JOIN
+        EXCEPT_JOIN = 0x00000004,    // SQL_SRJO_EXCEPT_JOIN
+        FULL_OUTER_JOIN = 0x00000008,    // SQL_SRJO_FULL_OUTER_JOIN
+        INNER_JOIN = 0x00000010,    // SQL_SRJO_INNER_JOIN
+        INTERSECT_JOIN = 0x00000020,    // SQL_SRJO_INTERSECT_JOIN
+        LEFT_OUTER_JOIN = 0x00000040,    // SQL_SRJO_LEFT_OUTER_JOIN
+        NATURAL_JOIN = 0x00000080,    // SQL_SRJO_NATURAL_JOIN
+        RIGHT_OUTER_JOIN = 0x00000100,  // SQL_SRJO_RIGHT_OUTER_JOIN
+        UNION_JOIN = 0x00000200         // SQL_SRJO_UNION_JOIN
+    ],
+
+    // values from sqlext.h
+    SQL_QU = 
+    [
+        SQL_QU_DML_STATEMENTS = 0x00000001,
+        SQL_QU_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_QU_TABLE_DEFINITION     = 0x00000004,
+        SQL_QU_INDEX_DEFINITION     = 0x00000008,
+        SQL_QU_PRIVILEGE_DEFINITION = 0x00000010
+    ],
+
+    // values from sql.h
+    SQL_OJ_CAPABILITIES =
+    [
+        LEFT = 0x00000001,    // SQL_OJ_LEFT
+        RIGHT = 0x00000002,    // SQL_OJ_RIGHT
+        FULL = 0x00000004,    // SQL_OJ_FULL
+        NESTED = 0x00000008,    // SQL_OJ_NESTED
+        NOT_ORDERED = 0x00000010,    // SQL_OJ_NOT_ORDERED
+        INNER = 0x00000020,    // SQL_OJ_INNER
+        ALL_COMPARISON_OPS = 0x00000040  //SQL_OJ_ALLCOMPARISION+OPS
+    ],
+
+    SQL_UPDATABLE =
+    [
+        READONLY = 0,          // SQL_ATTR_READ_ONLY
+        WRITE = 1,             // SQL_ATTR_WRITE
+        READWRITE_UNKNOWN = 2  // SQL_ATTR_READWRITE_UNKNOWN
+    ],
+
+    SQL_IDENTIFIER_CASE =
+    [
+        UPPER = 1,    // SQL_IC_UPPER
+        LOWER = 2,    // SQL_IC_LOWER
+        SENSITIVE = 3,    // SQL_IC_SENSITIVE
+        MIXED = 4    // SQL_IC_MIXED
+    ],
+
+    // Uniqueness parameter in the SQLStatistics function
+    SQL_INDEX =
+    [
+        UNIQUE = 0,
+        ALL = 1
+    ],
+
+    // Reserved parameter in the SQLStatistics function
+    SQL_STATISTICS_RESERVED =
+    [
+        QUICK = 0,                // SQL_QUICK
+        ENSURE = 1                // SQL_ENSURE
+    ],
+
+    // Identifier type parameter in the SQLSpecialColumns function
+    SQL_SPECIALCOLS =
+    [
+        BEST_ROWID = 1,            // SQL_BEST_ROWID
+        ROWVER = 2            // SQL_ROWVER
+    ],
+
+    // Scope parameter in the SQLSpecialColumns function
+    SQL_SCOPE =
+    [
+        CURROW = 0,            // SQL_SCOPE_CURROW
+        TRANSACTION = 1,           // SQL_SCOPE_TRANSACTION
+        SESSION = 2           // SQL_SCOPE_SESSION
+    ],
+
+    SQL_NULLABILITY =
+    [
+        NO_NULLS = 0,                // SQL_NO_NULLS
+        NULLABLE = 1,                // SQL_NULLABLE
+        UNKNOWN = 2                 // SQL_NULLABLE_UNKNOWN
+    ],
+
+    SQL_SEARCHABLE =
+    [
+        UNSEARCHABLE = 0,        // SQL_UNSEARCHABLE
+        LIKE_ONLY = 1,        // SQL_LIKE_ONLY
+        ALL_EXCEPT_LIKE = 2,        // SQL_ALL_EXCEPT_LIKE
+        SEARCHABLE = 3        // SQL_SEARCHABLE
+    ],
+
+    SQL_UNNAMED =
+    [
+        NAMED = 0,                   // SQL_NAMED
+        UNNAMED = 1                  // SQL_UNNAMED
+    ],
+    // todo:move
+    // internal constants
+    // not odbc specific
+    //
+    HANDLER =
+    [
+        IGNORE = 0x00000000,
+        THROW = 0x00000001
+    ],
+
+    // values for SQLStatistics TYPE column
+    SQL_STATISTICSTYPE =
+    [
+        TABLE_STAT = 0,                    // TABLE Statistics
+        INDEX_CLUSTERED = 1,               // CLUSTERED index statistics
+        INDEX_HASHED = 2,                  // HASHED index statistics
+        INDEX_OTHER = 3                    // OTHER index statistics
+    ],
+
+    // values for SQLProcedures PROCEDURE_TYPE column
+    SQL_PROCEDURETYPE =
+    [
+        UNKNOWN = 0,                    // procedure is of unknow type
+        PROCEDURE = 1,                    // procedure is a procedure
+        FUNCTION = 2                     // procedure is a function
+    ],
+
+    // private constants
+    // to define data types (see below)
+    //
+    SIGNED_OFFSET = -20,      // SQL_SIGNED_OFFSET
+    UNSIGNED_OFFSET = -22,    // SQL_UNSIGNED_OFFSET
+
+    // C Data Types
+    SQL_C =
+    [
+        CHAR            = 1,
+        WCHAR           = -8,
+        SLONG           = 4     + SIGNED_OFFSET,
+        ULONG           = 4     + UNSIGNED_OFFSET,
+        SSHORT          = 5     + SIGNED_OFFSET,
+        USHORT          = 5     + UNSIGNED_OFFSET,
+        FLOAT           = 7,
+        DOUBLE          = 8,
+        BIT             = -7,
+        STINYINT        = -6    + SIGNED_OFFSET,
+        UTINYINT        = -6    + UNSIGNED_OFFSET,
+        SBIGINT         = -5    + SIGNED_OFFSET,
+        UBIGINT         = -5    + UNSIGNED_OFFSET,
+        BINARY          = -2,
+        TIMESTAMP       = 11,
+
+        TYPE_DATE       = 91,
+        TYPE_TIME       = 92,
+        TYPE_TIMESTAMP  = 93,
+
+        NUMERIC         = 2,
+        GUID            = -11,
+        DEFAULT         = 99,
+        ARD_TYPE        = -99
+    ],
+
+    // SQL Data Types
+    SQL_TYPE =
+    [
+        // Base data types (sql.h)
+        UNKNOWN             = 0,
+        NULL                = 0,
+        CHAR                = 1,
+        NUMERIC             = 2,
+        DECIMAL             = 3,
+        INTEGER             = 4,
+        SMALLINT            = 5,
+        FLOAT               = 6,
+        REAL                = 7,
+        DOUBLE              = 8,
+        DATETIME            = 9,      // V3 Only
+        VARCHAR             = 12,
+
+        // Unicode types (sqlucode.h)
+        WCHAR               = -8,
+        WVARCHAR            = -9,
+        WLONGVARCHAR        = -10,
+
+        // Extended data types (sqlext.h)
+        INTERVAL            = 10,    // V3 Only
+        TIME                = 10,
+        TIMESTAMP           = 11,
+        LONGVARCHAR         = -1,
+        BINARY              = -2,
+        VARBINARY           = -3,
+        LONGVARBINARY       = -4,
+        BIGINT              = -5,
+        TINYINT             = -6,
+        BIT                 = -7,
+        GUID                = -11,   // V3 Only
+
+        // One-parameter shortcuts for date/time data types.
+        TYPE_DATE           = 91,
+        TYPE_TIME           = 92,
+        TYPE_TIMESTAMP      = 93,
+
+        // SQL Server Types -150 to -159 (sqlncli.h)
+        SS_VARIANT          = -150,
+        SS_UDT              = -151,
+        SS_XML              = -152,
+        SS_TABLE            = -153,
+        SS_TIME2            = -154,
+        SS_TIMESTAMPOFFSET  = -155
+    ],
+
+    //SQL_ALL_TYPES = 0,
+    //static public readonly IntPtr SQL_HANDLE_NULL = IntPtr.Zero;
+
+    SQL_LENGTH = 
+    [
+        SQL_IGNORE = -6,
+        SQL_DEFAULT_PARAM = -5,
+        SQL_NO_TOTAL = -4,
+        SQL_NTS = -3,
+        SQL_DATA_AT_EXEC = -2,
+        SQL_NULL_DATA = -1
+    ],
+
+    SQL_DEFAULT_PARAM = -5,        
+
+    // column ordinals for SQLProcedureColumns result set
+    // this column ordinals are not defined in any c/c++ header but in the ODBC Programmer's Reference under SQLProcedureColumns
+    //
+    COLUMN_NAME = 4,
+    COLUMN_TYPE = 5,
+    DATA_TYPE = 6,
+    COLUMN_SIZE = 8,
+    DECIMAL_DIGITS = 10,
+    NUM_PREC_RADIX = 11,
+
+    SQL_ATTR = 
+    [
+        ODBC_VERSION = 200,
+        CONNECTION_POOLING = 201,
+        AUTOCOMMIT = 102,
+        TXN_ISOLATION = 108,
+        CURRENT_CATALOG = 109,
+        LOGIN_TIMEOUT = 103,
+        QUERY_TIMEOUT = 0,
+        CONNECTION_DEAD = 1209,
+
+        SQL_COPT_SS_BASE = 1200,
+        SQL_COPT_SS_ENLIST_IN_DTC = (1200 + 7),
+        SQL_COPT_SS_TXN_ISOLATION = (1200 + 27),
+
+        MAX_LENGTH = 3,
+        ROW_BIND_TYPE = 5,
+        CURSOR_TYPE = 6,
+        RETRIEVE_DATA = 11,
+        ROW_STATUS_PTR = 25, 
+        ROWS_FETCHED_PTR = 26,
+        ROW_ARRAY_SIZE = 27,
+
+        // ODBC 3.0
+        APP_ROW_DESC = 10010,
+        APP_PARAM_DESC = 10011,
+        IMP_ROW_DESC = 10012,
+        IMP_PARAM_DESC = 10013,
+        METADATA_ID = 10014,
+
+        // ODBC 4.0
+        PRIVATE_DRIVER_LOCATION = 204
+    ],
+
+    SQL_RD = 
+    [
+        OFF = 0,
+        ON = 1
+    ],
+
+    SQL_GD = 
+    [
+        //None =  0,
+        ANY_COLUMN = 1,
+        ANY_ORDER = 2,
+        BLOCK = 4,
+        BOUND = 8,
+        OUTPUT_PARAMS = 16
+    ],
+
+    //SQLGetInfo
+/*
+    SQL_INFO =
+    [
+        SQL_ACTIVE_CONNECTIONS = 0,        
+        SQL_MAX_DRIVER_CONNECTIONS = 0,
+        SQL_MAX_CONCURRENT_ACTIVITIES = 1,
+        SQL_ACTIVE_STATEMENTS = 1,         
+        SQL_DATA_SOURCE_NAME = 2,          
+        SQL_DRIVER_HDBC,                   
+        SQL_DRIVER_HENV,                   
+        SQL_DRIVER_HSTMT,                  
+        SQL_DRIVER_NAME,                   
+        SQL_DRIVER_VER,                    
+        SQL_FETCH_DIRECTION,               
+        SQL_ODBC_API_CONFORMANCE,          
+        SQL_ODBC_VER,                      
+        SQL_ROW_UPDATES,                   
+        SQL_ODBC_SAG_CLI_CONFORMANCE,      
+        SQL_SERVER_NAME,                   
+        SQL_SEARCH_PATTERN_ESCAPE,         
+        SQL_ODBC_SQL_CONFORMANCE,          
+
+        SQL_DATABASE_NAME,                 
+        SQL_DBMS_NAME,                     
+        SQL_DBMS_VER,                      
+
+        SQL_ACCESSIBLE_TABLES,             
+        SQL_ACCESSIBLE_PROCEDURES,         
+        SQL_PROCEDURES,                    
+        SQL_CONCAT_NULL_BEHAVIOR,          
+        SQL_CURSOR_COMMIT_BEHAVIOR,        
+        SQL_CURSOR_ROLLBACK_BEHAVIOR,      
+        SQL_DATA_SOURCE_READ_ONLY,         
+        SQL_DEFAULT_TXN_ISOLATION,         
+        SQL_EXPRESSIONS_IN_ORDERBY,        
+        SQL_IDENTIFIER_CASE,               
+        SQL_IDENTIFIER_QUOTE_CHAR,         
+        SQL_MAX_COLUMN_NAME_LEN,           
+        SQL_MAX_CURSOR_NAME_LEN,           
+        SQL_MAX_OWNER_NAME_LEN,            
+        SQL_MAX_SCHEMA_NAME_LEN = 32,
+        SQL_MAX_PROCEDURE_NAME_LEN,        
+        SQL_MAX_QUALIFIER_NAME_LEN,        
+        SQL_MAX_CATALOG_NAME_LEN = 34,
+        SQL_MAX_TABLE_NAME_LEN,            
+        SQL_MULT_RESULT_SETS,              
+        SQL_MULTIPLE_ACTIVE_TXN,           
+        SQL_OUTER_JOINS,                   
+        SQL_SCHEMA_TERM,                   
+        SQL_PROCEDURE_TERM,                
+        SQL_CATALOG_NAME_SEPARATOR,        
+        SQL_CATALOG_TERM,                  
+        SQL_SCROLL_CONCURRENCY,            
+        SQL_SCROLL_OPTIONS,                
+        SQL_TABLE_TERM,                    
+        SQL_TXN_CAPABLE,                   
+        SQL_USER_NAME,                     
+
+        SQL_CONVERT_FUNCTIONS,             
+        SQL_NUMERIC_FUNCTIONS,             
+        SQL_STRING_FUNCTIONS,              
+        SQL_SYSTEM_FUNCTIONS,              
+        SQL_TIMEDATE_FUNCTIONS,            
+
+        SQL_CONVERT_BIGINT,
+        SQL_CONVERT_BINARY,
+        SQL_CONVERT_BIT,
+        SQL_CONVERT_CHAR,
+        SQL_CONVERT_DATE,
+        SQL_CONVERT_DECIMAL,
+        SQL_CONVERT_DOUBLE,
+        SQL_CONVERT_FLOAT,            
+        SQL_CONVERT_INTEGER,
+        SQL_CONVERT_LONGVARCHAR,
+        SQL_CONVERT_NUMERIC,
+        SQL_CONVERT_REAL,
+        SQL_CONVERT_SMALLINT,
+        SQL_CONVERT_TIME,
+        SQL_CONVERT_TIMESTAMP,
+        SQL_CONVERT_TINYINT,
+        SQL_CONVERT_VARBINARY,
+        SQL_CONVERT_VARCHAR,          
+        SQL_CONVERT_LONGVARBINARY,
+
+        SQL_TXN_ISOLATION_OPTION,     
+        SQL_ODBC_SQL_OPT_IEF,
+        SQL_INTEGRITY = 73,
+        SQL_CORRELATION_NAME,
+        SQL_NON_NULLABLE_COLUMNS,
+        SQL_DRIVER_HLIB,
+        SQL_DRIVER_ODBC_VER,
+        SQL_LOCK_TYPES,
+        SQL_POS_OPERATIONS,
+        SQL_POSITIONED_STATEMENTS,        
+        SQL_GETDATA_EXTENSIONS,
+        SQL_BOOKMARK_PERSISTENCE,
+        SQL_STATIC_SENSITIVITY,
+        SQL_FILE_USAGE,
+        SQL_NULL_COLLATION,
+        SQL_ALTER_TABLE,
+        SQL_COLUMN_ALIAS,
+        SQL_GROUP_BY,
+        SQL_KEYWORDS,
+        SQL_ORDER_BY_COLUMNS_IN_SELECT,   
+        SQL_SCHEMA_USAGE,
+        SQL_CATALOG_USAGE,
+        SQL_QUOTED_IDENTIFIER_CASE,
+        SQL_SPECIAL_CHARACTERS,
+        SQL_SUBQUERIES,
+        SQL_UNION_STATEMENT,
+        SQL_MAX_COLUMNS_IN_GROUP_BY,
+        SQL_MAX_COLUMNS_IN_INDEX,
+        SQL_MAX_COLUMNS_IN_ORDER_BY,
+        SQL_MAX_COLUMNS_IN_SELECT,        
+        SQL_MAX_COLUMNS_IN_TABLE,
+        SQL_MAX_INDEX_SIZE,
+        SQL_MAX_ROW_SIZE_INCLUDES_LONG,
+        SQL_MAX_ROW_SIZE,
+        SQL_MAX_STATEMENT_LEN,
+        SQL_MAX_TABLES_IN_SELECT,
+        SQL_MAX_USER_NAME_LEN,
+        SQL_MAX_CHAR_LITERAL_LEN,
+        SQL_TIMEDATE_ADD_INTERVALS,
+        SQL_TIMEDATE_DIFF_INTERVALS,      
+        SQL_NEED_LONG_DATA_LEN,
+        SQL_MAX_BINARY_LITERAL_LEN,
+        SQL_LIKE_ESCAPE_CLAUSE,
+        SQL_CATALOG_LOCATION,
+        SQL_OJ_CAPABILITIES,
+
+        SQL_ACTIVE_ENVIRONMENTS,
+        SQL_ALTER_DOMAIN,
+        SQL_SQL_CONFORMANCE,
+        SQL_DATETIME_LITERALS,
+        SQL_BATCH_ROW_COUNT,              
+        SQL_BATCH_SUPPORT,
+        SQL_CONVERT_WCHAR,
+        SQL_CONVERT_INTERVAL_DAY_TIME,
+        SQL_CONVERT_INTERVAL_YEAR_MONTH,
+        SQL_CONVERT_WLONGVARCHAR,
+        SQL_CONVERT_WVARCHAR,
+        SQL_CREATE_ASSERTION,
+        SQL_CREATE_CHARACTER_SET,
+        SQL_CREATE_COLLATION,
+        SQL_CREATE_DOMAIN,                  
+        SQL_CREATE_SCHEMA,
+        SQL_CREATE_TABLE,
+        SQL_CREATE_TRANSLATION,
+        SQL_CREATE_VIEW,
+        SQL_DRIVER_HDESC,
+        SQL_DROP_ASSERTION,
+        SQL_DROP_CHARACTER_SET,
+        SQL_DROP_COLLATION,
+        SQL_DROP_DOMAIN,
+        SQL_DROP_SCHEMA,                    
+        SQL_DROP_TABLE,
+        SQL_DROP_TRANSLATION,
+        SQL_DROP_VIEW,
+        SQL_DYNAMIC_CURSOR_ATTRIBUTES1,
+        SQL_DYNAMIC_CURSOR_ATTRIBUTES2,
+        SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1,
+        SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2,
+        SQL_INDEX_KEYWORDS,
+        SQL_INFO_SCHEMA_VIEWS,
+        SQL_KEYSET_CURSOR_ATTRIBUTES1,    
+        SQL_KEYSET_CURSOR_ATTRIBUTES2,
+        SQL_ODBC_INTERFACE_CONFORMANCE,
+        SQL_PARAM_ARRAY_ROW_COUNTS,
+        SQL_PARAM_ARRAY_SELECTS,
+        SQL_SQL92_DATETIME_FUNCTIONS,
+        SQL_SQL92_FOREIGN_KEY_DELETE_RULE,
+        SQL_SQL92_FOREIGN_KEY_UPDATE_RULE,
+        SQL_SQL92_GRANT,
+        SQL_SQL92_NUMERIC_VALUE_FUNCTIONS,
+        SQL_SQL92_PREDICATES,              
+        SQL_SQL92_RELATIONAL_JOIN_OPERATORS,
+        SQL_SQL92_REVOKE,
+        SQL_SQL92_ROW_VALUE_CONSTRUCTOR,
+        SQL_SQL92_STRING_FUNCTIONS,
+        SQL_SQL92_VALUE_EXPRESSIONS,
+        SQL_STANDARD_CLI_CONFORMANCE,
+        SQL_STATIC_CURSOR_ATTRIBUTES1,
+        SQL_STATIC_CURSOR_ATTRIBUTES2,
+        SQL_AGGREGATE_FUNCTIONS,
+        SQL_DDL_INDEX,                   
+        SQL_DM_VER,
+        SQL_INSERT_STATEMENT,
+        SQL_CONVERT_GUID,
+
+        SQL_XOPEN_CLI_YEAR = 10000,      
+        SQL_CURSOR_SENSITIVITY,
+        SQL_DESCRIBE_PARAMETER,
+        SQL_CATALOG_NAME,
+        SQL_COLLATION_SEQ,
+        SQL_MAX_IDENTIFIER_LEN,
+        SQL_ASYNC_MODE = 10021,          
+        SQL_MAX_ASYNC_CONCURRENT_STATEMENTS,
+
+        SQL_DTC_TRANSITION_COST = 1750,
+    ],
+*/
+    SQL_OAC = 
+    [
+        SQL_OAC_None = 0x0000,
+        SQL_OAC_LEVEL1 = 0x0001,
+        SQL_OAC_LEVEL2 = 0x0002
+    ],
+
+    SQL_OSC = 
+    [
+        SQL_OSC_MINIMUM = 0x0000,
+        SQL_OSC_CORE = 0x0001,
+        SQL_OSC_EXTENDED = 0x0002
+    ],
+
+    SQL_SCC = 
+    [
+        SQL_SCC_XOPEN_CLI_VERSION1 = 0x00000001,
+        SQL_SCC_ISO92_CLI = 0x00000002
+    ],
+
+    SQL_SVE = 
+    [
+        SQL_SVE_CASE = 0x00000001,
+        SQL_SVE_CAST = 0x00000002,
+        SQL_SVE_COALESCE = 0x00000004,
+        SQL_SVE_NULLIF = 0x00000008
+    ],
+
+    SQL_SSF = 
+    [
+        SQL_SSF_CONVERT = 0x00000001,
+        SQL_SSF_LOWER = 0x00000002,
+        SQL_SSF_UPPER = 0x00000004,
+        SQL_SSF_SUBSTRING = 0x00000008,
+        SQL_SSF_TRANSLATE = 0x00000010,
+        SQL_SSF_TRIM_BOTH = 0x00000020,
+        SQL_SSF_TRIM_LEADING = 0x00000040,
+        SQL_SSF_TRIM_TRAILING = 0x00000080
+    ],
+
+    SQL_SP = 
+    [
+        //None = 0,
+
+        SQL_SP_EXISTS = 0x00000001,
+        SQL_SP_ISNOTNULL = 0x00000002,
+        SQL_SP_ISNULL = 0x00000004,
+        SQL_SP_MATCH_FULL = 0x00000008,
+        SQL_SP_MATCH_PARTIAL = 0x00000010,
+        SQL_SP_MATCH_UNIQUE_FULL = 0x00000020,
+        SQL_SP_MATCH_UNIQUE_PARTIAL = 0x00000040,
+        SQL_SP_OVERLAPS = 0x00000080,
+        SQL_SP_UNIQUE = 0x00000100,
+        SQL_SP_LIKE = 0x00000200,
+        SQL_SP_IN = 0x00000400,
+        SQL_SP_BETWEEN = 0x00000800,
+        SQL_SP_COMPARISON = 0x00001000,
+        SQL_SP_QUANTIFIED_COMPARISON = 0x00002000,
+
+        All = 0x0000FFFF
+    ],
+
+    SQL_OIC =
+    [
+        SQL_OIC_CORE = 1,
+        SQL_OIC_LEVEL1 = 2,
+        SQL_OIC_LEVEL2 = 3
+    ],
+
+    SQL_USAGE = 
+    [
+        SQL_U_DML_STATEMENTS = 0x00000001,
+        SQL_U_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_U_TABLE_DEFINITION = 0x00000004,
+        SQL_U_INDEX_DEFINITION = 0x00000008,
+        SQL_U_PRIVILEGE_DEFINITION = 0x00000010
+    ],
+
+    SQL_GB = 
+    [
+            
+        SQL_GB_NOT_SUPPORTED = 0,
+        SQL_GB_GROUP_BY_EQUALS_SELECT = 1,
+        SQL_GB_GROUP_BY_CONTAINS_SELECT = 2,
+        SQL_GB_NO_RELATION = 3,
+        SQL_GB_COLLATE = 4
+    ],
+
+    SQL_NC =
+    [
+        SQL_NC_END = 0,
+        SQL_NC_HIGH = 1,
+        SQL_NC_LOW = 2,
+        SQL_NC_START = 3
+    ],
+
+    SQL_CN =
+    [
+        SQL_CN_None = 0,
+        SQL_CN_DIFFERENT = 1,
+        SQL_CN_ANY = 2
+    ],
+
+    SQL_NNC = 
+    [
+        SQL_NNC_NULL = 0,
+        SQL_NNC_NON_NULL = 1
+    ],
+
+    SQL_CB = 
+    [
+        SQL_CB_NULL = 0,
+        SQL_CB_NON_NULL = 1
+    ],
+
+    SQL_FD_FETCH = 
+    [
+        SQL_FD_FETCH_NEXT = 0x00000001,
+        SQL_FD_FETCH_FIRST = 0x00000002,
+        SQL_FD_FETCH_LAST = 0x00000004,
+        SQL_FD_FETCH_PRIOR = 0x00000008,
+        SQL_FD_FETCH_ABSOLUTE = 0x00000010,
+        SQL_FD_FETCH_RELATIVE = 0x00000020,
+        SQL_FD_FETCH_BOOKMARK = 0x00000080
+    ],
+
+    SQL_SQ = 
+    [
+        SQL_SQ_COMPARISON = 0x00000001,
+        SQL_SQ_EXISTS = 0x00000002,
+        SQL_SQ_IN = 0x00000004,
+        SQL_SQ_QUANTIFIED = 0x00000008,
+        SQL_SQ_CORRELATED_SUBQUERIES = 0x00000010
+    ],
+
+    SQL_U = 
+    [
+        SQL_U_UNION = 0x00000001,
+        SQL_U_UNION_ALL = 0x00000002
+    ],
+
+    SQL_BP = 
+    [
+        SQL_BP_CLOSE = 0x00000001,
+        SQL_BP_DELETE = 0x00000002,
+        SQL_BP_DROP = 0x00000004,
+        SQL_BP_TRANSACTION = 0x00000008,
+        SQL_BP_UPDATE = 0x00000010,
+        SQL_BP_OTHER_HSTMT = 0x00000020,
+        SQL_BP_SCROLL = 0x00000040
+    ],
+
+    SQL_QL = 
+    [
+        SQL_QL_START = 0x0001,
+        SQL_QL_END = 0x0002
+    ],
+
+    SQL_OJ = 
+    [
+        SQL_OJ_LEFT = 0x00000001,
+        SQL_OJ_RIGHT = 0x00000002,
+        SQL_OJ_FULL = 0x00000004,
+        SQL_OJ_NESTED = 0x00000008,
+        SQL_OJ_NOT_ORDERED = 0x00000010,
+        SQL_OJ_INNER = 0x00000020,
+        SQL_OJ_ALL_COMPARISON_OPS = 0x00000040
+    ],
+
+    SQL_FN_CVT = 
+    [
+        //None = 0,
+
+        SQL_FN_CVT_CONVERT        = 0x00000001,
+        SQL_FN_CVT_CAST        = 0x00000002
+    ],
+
+    SQL_FN_NUM = 
+    [
+        //None = 0,
+
+        SQL_FN_NUM_ABS        = 0x00000001,
+        SQL_FN_NUM_ACOS        = 0x00000002,
+        SQL_FN_NUM_ASIN        = 0x00000004,
+        SQL_FN_NUM_ATAN        = 0x00000008,
+        SQL_FN_NUM_ATAN2    = 0x00000010,
+        SQL_FN_NUM_CEILING    = 0x00000020,
+        SQL_FN_NUM_COS        = 0x00000040,
+        SQL_FN_NUM_COT        = 0x00000080,
+        SQL_FN_NUM_EXP        = 0x00000100,
+        SQL_FN_NUM_FLOOR    = 0x00000200,
+        SQL_FN_NUM_LOG        = 0x00000400,
+        SQL_FN_NUM_MOD        = 0x00000800,
+        SQL_FN_NUM_SIGN        = 0x00001000,
+        SQL_FN_NUM_SIN        = 0x00002000,
+        SQL_FN_NUM_SQRT        = 0x00004000,
+        SQL_FN_NUM_TAN      = 0x00008000,
+        SQL_FN_NUM_PI       = 0x00010000,
+        SQL_FN_NUM_RAND     = 0x00020000,
+        SQL_FN_NUM_DEGREES    = 0x00040000,
+        SQL_FN_NUM_LOG10    = 0x00080000,
+        SQL_FN_NUM_POWER    = 0x00100000,
+        SQL_FN_NUM_RADIANS    = 0x00200000,
+        SQL_FN_NUM_ROUND    = 0x00400000,
+        SQL_FN_NUM_TRUNCATE = 0x00800000
+    ],
+
+    SQL_SNVF = 
+    [
+        SQL_SNVF_BIT_LENGTH = 0x00000001,
+        SQL_SNVF_CHAR_LENGTH = 0x00000002,
+        SQL_SNVF_CHARACTER_LENGTH = 0x00000004,
+        SQL_SNVF_EXTRACT = 0x00000008,
+        SQL_SNVF_OCTET_LENGTH = 0x00000010,
+        SQL_SNVF_POSITION = 0x00000020
+    ],
+
+    SQL_FN_STR =
+    [
+        //None = 0,
+
+        SQL_FN_STR_CONCAT            = 0x00000001,
+        SQL_FN_STR_INSERT            = 0x00000002,
+        SQL_FN_STR_LEFT            = 0x00000004,
+        SQL_FN_STR_LTRIM            = 0x00000008,
+        SQL_FN_STR_LENGTH            = 0x00000010,
+        SQL_FN_STR_LOCATE            = 0x00000020,
+        SQL_FN_STR_LCASE            = 0x00000040,
+        SQL_FN_STR_REPEAT            = 0x00000080,
+        SQL_FN_STR_REPLACE            = 0x00000100,
+        SQL_FN_STR_RIGHT            = 0x00000200,
+        SQL_FN_STR_RTRIM            = 0x00000400,
+        SQL_FN_STR_SUBSTRING        = 0x00000800,
+        SQL_FN_STR_UCASE            = 0x00001000,
+        SQL_FN_STR_ASCII            = 0x00002000,
+        SQL_FN_STR_CHAR            = 0x00004000,
+        SQL_FN_STR_DIFFERENCE = 0x00008000,
+        SQL_FN_STR_LOCATE_2          = 0x00010000,
+        SQL_FN_STR_SOUNDEX          = 0x00020000,
+        SQL_FN_STR_SPACE          = 0x00040000,
+        SQL_FN_STR_BIT_LENGTH      = 0x00080000,
+        SQL_FN_STR_CHAR_LENGTH      = 0x00100000,
+        SQL_FN_STR_CHARACTER_LENGTH      = 0x00200000,
+        SQL_FN_STR_OCTET_LENGTH = 0x00400000,
+        SQL_FN_STR_POSITION = 0x00800000
+    ],
+
+    SQL_FN_SYSTEM = 
+    [
+        //None = 0,
+
+        SQL_FN_SYS_USERNAME = 0x00000001,
+        SQL_FN_SYS_DBNAME = 0x00000002,
+        SQL_FN_SYS_IFNULL = 0x00000004
+    ],
+
+    SQL_FN_TD = 
+    [
+        //None = 0,
+
+        SQL_FN_TD_NOW            = 0x00000001,
+        SQL_FN_TD_CURDATE            = 0x00000002,
+        SQL_FN_TD_DAYOFMONTH        = 0x00000004,
+        SQL_FN_TD_DAYOFWEEK            = 0x00000008,
+        SQL_FN_TD_DAYOFYEAR            = 0x00000010,
+        SQL_FN_TD_MONTH            = 0x00000020,
+        SQL_FN_TD_QUARTER            = 0x00000040,
+        SQL_FN_TD_WEEK            = 0x00000080,
+        SQL_FN_TD_YEAR            = 0x00000100,
+        SQL_FN_TD_CURTIME            = 0x00000200,
+        SQL_FN_TD_HOUR            = 0x00000400,
+        SQL_FN_TD_MINUTE            = 0x00000800,
+        SQL_FN_TD_SECOND            = 0x00001000,
+        SQL_FN_TD_TIMESTAMPADD        = 0x00002000,
+        SQL_FN_TD_TIMESTAMPDIFF        = 0x00004000,
+        SQL_FN_TD_DAYNAME          = 0x00008000,
+        SQL_FN_TD_MONTHNAME          = 0x00010000,
+        SQL_FN_TD_CURRENT_DATE      = 0x00020000,
+        SQL_FN_TD_CURRENT_TIME      = 0x00040000,
+        SQL_FN_TD_CURRENT_TIMESTAMP      = 0x00080000,
+        SQL_FN_TD_EXTRACT = 0x00100000
+    ],
+
+    SQL_SDF = 
+    [
+        SQL_SDF_CURRENT_DATE = 0x00000001,
+        SQL_SDF_CURRENT_TIME = 0x00000002,
+        SQL_SDF_CURRENT_TIMESTAMP = 0x00000004
+    ],
+
+    SQL_TSI =
+    [
+        //None = 0,
+
+        SQL_TSI_FRAC_SECOND = 0x00000001,
+        SQL_TSI_SECOND = 0x00000002,
+        SQL_TSI_MINUTE = 0x00000004,
+        SQL_TSI_HOUR = 0x00000008,
+        SQL_TSI_DAY = 0x00000010,
+        SQL_TSI_WEEK = 0x00000020,
+        SQL_TSI_MONTH = 0x00000040,
+        SQL_TSI_QUARTER = 0x00000080,
+        SQL_TSI_YEAR = 0x00000100
+    ],
+
+    SQL_AF = 
+    [
+        //None = 0,
+
+        SQL_AF_AVG        = 0x00000001,
+        SQL_AF_COUNT    = 0x00000002,
+        SQL_AF_MAX        = 0x00000004,
+        SQL_AF_MIN        = 0x00000008,
+        SQL_AF_SUM        = 0x00000010,
+        SQL_AF_DISTINCT    = 0x00000020,
+        SQL_AF_ALL        = 0x00000040,
+
+        All = 0xFF
+    ],
+
+    SQL_SC = 
+    [
+        //None = 0,
+
+        SQL_SC_SQL92_ENTRY            = 0x00000001,
+        SQL_SC_FIPS127_2_TRANSITIONAL    = 0x00000002,
+        SQL_SC_SQL92_INTERMEDIATE        = 0x00000004,
+        SQL_SC_SQL92_FULL            = 0x00000008
+    ],
+
+    SQL_DL_SQL92 = 
+    [
+        SQL_DL_SQL92_DATE                    = 0x00000001,
+        SQL_DL_SQL92_TIME                    = 0x00000002,
+        SQL_DL_SQL92_TIMESTAMP                = 0x00000004,
+        SQL_DL_SQL92_INTERVAL_YEAR                = 0x00000008,
+        SQL_DL_SQL92_INTERVAL_MONTH                = 0x00000010,
+        SQL_DL_SQL92_INTERVAL_DAY                = 0x00000020,
+        SQL_DL_SQL92_INTERVAL_HOUR                = 0x00000040,
+        SQL_DL_SQL92_INTERVAL_MINUTE            = 0x00000080,
+        SQL_DL_SQL92_INTERVAL_SECOND            = 0x00000100,
+        SQL_DL_SQL92_INTERVAL_YEAR_TO_MONTH            = 0x00000200,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_HOUR            = 0x00000400,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_MINUTE            = 0x00000800,
+        SQL_DL_SQL92_INTERVAL_DAY_TO_SECOND            = 0x00001000,
+        SQL_DL_SQL92_INTERVAL_HOUR_TO_MINUTE        = 0x00002000,
+        SQL_DL_SQL92_INTERVAL_HOUR_TO_SECOND        = 0x00004000,
+        SQL_DL_SQL92_INTERVAL_MINUTE_TO_SECOND     = 0x00008000
+    ],
+
+    SQL_IK = 
+    [
+        SQL_IK_NONE        = 0x00000000,
+        SQL_IK_ASC        = 0x00000001,
+        SQL_IK_DESC        = 0x00000002,
+        SQL_IK_ALL = 0x00000003 //SQL_IK_ASC | SQL_IK_DESC
+    ],
+
+    SQL_ISV = 
+    [
+        SQL_ISV_ASSERTIONS            = 0x00000001,
+        SQL_ISV_CHARACTER_SETS        = 0x00000002,
+        SQL_ISV_CHECK_CONSTRAINTS        = 0x00000004,
+        SQL_ISV_COLLATIONS            = 0x00000008,
+        SQL_ISV_COLUMN_DOMAIN_USAGE        = 0x00000010,
+        SQL_ISV_COLUMN_PRIVILEGES        = 0x00000020,
+        SQL_ISV_COLUMNS            = 0x00000040,
+        SQL_ISV_CONSTRAINT_COLUMN_USAGE    = 0x00000080,
+        SQL_ISV_CONSTRAINT_TABLE_USAGE    = 0x00000100,
+        SQL_ISV_DOMAIN_CONSTRAINTS        = 0x00000200,
+        SQL_ISV_DOMAINS            = 0x00000400,
+        SQL_ISV_KEY_COLUMN_USAGE        = 0x00000800,
+        SQL_ISV_REFERENTIAL_CONSTRAINTS    = 0x00001000,
+        SQL_ISV_SCHEMATA            = 0x00002000,
+        SQL_ISV_SQL_LANGUAGES        = 0x00004000,
+        SQL_ISV_TABLE_CONSTRAINTS      = 0x00008000,
+        SQL_ISV_TABLE_PRIVILEGES      = 0x00010000,
+        SQL_ISV_TABLES          = 0x00020000,
+        SQL_ISV_TRANSLATIONS      = 0x00040000,
+        SQL_ISV_USAGE_PRIVILEGES      = 0x00080000,
+        SQL_ISV_VIEW_COLUMN_USAGE      = 0x00100000,
+        SQL_ISV_VIEW_TABLE_USAGE = 0x00200000,
+        SQL_ISV_VIEWS          = 0x00400000
+    ],
+
+    SQL_SRJO = 
+    [
+        //None = 0,
+
+        SQL_SRJO_CORRESPONDING_CLAUSE = 0x00000001,
+        SQL_SRJO_CROSS_JOIN = 0x00000002,
+        SQL_SRJO_EXCEPT_JOIN = 0x00000004,
+        SQL_SRJO_FULL_OUTER_JOIN = 0x00000008,
+        SQL_SRJO_INNER_JOIN = 0x00000010,
+        SQL_SRJO_INTERSECT_JOIN = 0x00000020,
+        SQL_SRJO_LEFT_OUTER_JOIN = 0x00000040,
+        SQL_SRJO_NATURAL_JOIN = 0x00000080,
+        SQL_SRJO_RIGHT_OUTER_JOIN = 0x00000100,
+        SQL_SRJO_UNION_JOIN = 0x00000200
+    ],
+
+    SQL_SRVC = 
+    [
+        SQL_SRVC_VALUE_EXPRESSION = 0x00000001,
+        SQL_SRVC_NULL = 0x00000002,
+        SQL_SRVC_DEFAULT = 0x00000004,
+        SQL_SRVC_ROW_SUBQUERY = 0x00000008
+    ],
+
+    //public static readonly int SQL_OV_ODBC3 = 3;
+    //public const Int32 SQL_NTS = -3;       //flags for null-terminated string
+
+    //Pooling
+    SQL_CP = 
+    [
+        OFF = 0,
+        ONE_PER_DRIVER = 1,
+        ONE_PER_HENV = 2
+    ],
+
+/*
+    public const Int32 SQL_CD_TRUE = 1;
+    public const Int32 SQL_CD_FALSE = 0;
+
+    public const Int32 SQL_DTC_DONE = 0;
+    public const Int32 SQL_IS_POINTER = -4;
+    public const Int32 SQL_IS_PTR = 1;
+*/
+    SQL_DRIVER =
+    [
+        NOPROMPT = 0,
+        COMPLETE = 1,
+        PROMPT = 2,
+        COMPLETE_REQUIRED = 3
+    ],
+
+    // Column set for SQLPrimaryKeys
+    SQL_PRIMARYKEYS =
+    [
+        /*
+                    CATALOGNAME         = 1,                    // TABLE_CAT
+                    SCHEMANAME          = 2,                    // TABLE_SCHEM
+                    TABLENAME           = 3,                    // TABLE_NAME
+        */
+        COLUMNNAME = 4                    // COLUMN_NAME
+        /*
+                    KEY_SEQ             = 5,                    // KEY_SEQ
+                    PKNAME              = 6,                    // PK_NAME
+        */
+    ],
+
+    // Column set for SQLStatistics
+    SQL_STATISTICS =
+    [
+        /*
+                    CATALOGNAME         = 1,                    // TABLE_CAT
+                    SCHEMANAME          = 2,                    // TABLE_SCHEM
+                    TABLENAME           = 3,                    // TABLE_NAME
+                    NONUNIQUE           = 4,                    // NON_UNIQUE
+                    INDEXQUALIFIER      = 5,                    // INDEX_QUALIFIER
+        */
+        INDEXNAME = 6,                    // INDEX_NAME
+        /*
+                    TYPE                = 7,                    // TYPE
+        */
+        ORDINAL_POSITION = 8,                    // ORDINAL_POSITION
+        COLUMN_NAME = 9                    // COLUMN_NAME
+        /*
+                    ASC_OR_DESC         = 10,                   // ASC_OR_DESC
+                    CARDINALITY         = 11,                   // CARDINALITY
+                    PAGES               = 12,                   // PAGES
+                    FILTER_CONDITION    = 13,                   // FILTER_CONDITION
+        */
+    ],
+
+    // Column set for SQLSpecialColumns
+    SQL_SPECIALCOLUMNSET =
+    [
+        /*
+                    SCOPE               = 1,                    // SCOPE
+        */
+        COLUMN_NAME = 2                    // COLUMN_NAME
+        /*
+                    DATA_TYPE           = 3,                    // DATA_TYPE
+                    TYPE_NAME           = 4,                    // TYPE_NAME
+                    COLUMN_SIZE         = 5,                    // COLUMN_SIZE
+                    BUFFER_LENGTH       = 6,                    // BUFFER_LENGTH
+                    DECIMAL_DIGITS      = 7,                    // DECIMAL_DIGITS
+                    PSEUDO_COLUMN       = 8,                    // PSEUDO_COLUMN
+        */
+    ],
+
+    SQL_DIAG =
+    [
+        CURSOR_ROW_COUNT= -1249,
+        ROW_NUMBER = -1248,
+        COLUMN_NUMBER = -1247,
+        RETURNCODE = 1,
+        NUMBER = 2,
+        ROW_COUNT = 3,
+        SQLSTATE = 4,
+        NATIVE = 5,
+        MESSAGE_TEXT = 6,
+        DYNAMIC_FUNCTION = 7,
+        CLASS_ORIGIN = 8,
+        SUBCLASS_ORIGIN = 9,
+        CONNECTION_NAME = 10,
+        SERVER_NAME = 11,
+        DYNAMIC_FUNCTION_CODE = 12
+    ],
+
+    SQL_SU =
+    [
+        SQL_SU_DML_STATEMENTS       = 0x00000001,
+        SQL_SU_PROCEDURE_INVOCATION = 0x00000002,
+        SQL_SU_TABLE_DEFINITION     = 0x00000004,
+        SQL_SU_INDEX_DEFINITION     = 0x00000008,
+        SQL_SU_PRIVILEGE_DEFINITION = 0x00000010
+    ]
+]

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/SqlODBC/SqlODBC.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/SqlODBC/SqlODBC.pq
@@ -1,0 +1,364 @@
+﻿// This connector provides a sample Direct Query enabled connector 
+// based on an ODBC driver. It is meant as a template for other 
+// ODBC based connectors that require similar functionality.
+// 
+section SqlODBC;
+
+// When set to true, additional trace information will be written out to the User log. 
+// This should be set to false before release. Tracing is done through a call to 
+// Diagnostics.LogValue(). When EnableTraceOutput is set to false, the call becomes a 
+// no-op and simply returns the original value.
+EnableTraceOutput = true;
+
+// TODO
+// add and handle common options record properties
+// add handling for LIMIT/OFFSET vs. TOP 
+// add handling for SSL
+
+/****************************
+ * ODBC Driver Configuration
+ ****************************/
+
+// The name of your ODBC driver.
+//
+Config_DriverName = "SQL Server Native Client 11.0";
+
+// If your driver under-reports its SQL conformance level because it does not
+// support the full range of CRUD operations, but does support the ANSI SQL required
+// to support the SELECT operations performed by Power Query, you can override 
+// this value to report a higher conformance level. Please use one of the numeric 
+// values below (i.e. 8 for SQL_SC_SQL92_FULL).
+// 
+// SQL_SC = 
+// [
+//     SQL_SC_SQL92_ENTRY            = 1,
+//     SQL_SC_FIPS127_2_TRANSITIONAL = 2,
+//     SQL_SC_SQL92_INTERMEDIATE     = 4,
+//     SQL_SC_SQL92_FULL             = 8
+// ]
+//
+// Set to null to determine the value from the driver.
+// 
+Config_SqlConformance = ODBC[SQL_SC][SQL_SC_SQL92_FULL];  // null, 1, 2, 4, 8
+
+// Set this option to true if your ODBC supports the standard username/password 
+// handling through the UN and PWD connection string parameters. If the user 
+// selects UsernamePassword auth, the supplied values will be automatically
+// added to the CredentialConnectionString. 
+//
+// If you wish to set these values yourself, or your driver requires additional
+// parameters to be set, please set this option to 'false'
+//
+Config_DefaultUsernamePasswordHandling = true;  // true, false
+
+// Some drivers have problems will parameter bindings and certain data types. 
+// If the driver supports parameter bindings, then set this to true. 
+// When set to false, parameter values will be inlined as literals into the generated SQL.
+// To enable inlining for a limited number of data types, set this value
+// to null and set individual flags through the SqlCapabilities record.
+// 
+// Set to null to determine the value from the driver. 
+//
+Config_UseParameterBindings = false;  // true, false, null
+ 
+// Override this setting to force the character escape value. 
+// This is typically done when you have set UseParameterBindings to false.
+//
+// Set to null to determine the value from the driver. 
+//
+Config_StringLiterateEscapeCharacters  = { "\" }; // ex. { "\" }
+
+// Override this if the driver expects the use of CAST instead of CONVERT.
+// By default, the query will be generated using ANSI SQL CONVERT syntax.
+//
+// Set to false or null to leave default behavior. 
+//
+Config_UseCastInsteadOfConvert = null; // true, false, null
+
+// If the driver supports the TOP clause in select statements, set this to true. 
+// If set to false, you MUST implement the AstVisitor for the LimitClause in the 
+// main body of the code below. 
+//
+Config_SupportsTop = true; // true, false
+
+// Set this to true to enable Direct Query in addition to Import mode.
+//
+Config_EnableDirectQuery = true;    // true, false
+
+[DataSource.Kind="SqlODBC", Publish="SqlODBC.Publish"]
+shared SqlODBC.Contents = (server as text) =>
+    let
+        //
+        // Connection string settings
+        //
+        ConnectionString = [
+            Driver = Config_DriverName,
+
+            // set all connection string properties
+            Server = server,
+            ApplicationIntent = "readonly"
+        ],
+
+        //
+        // Handle credentials
+        // Credentials are not persisted with the query and are set through a separate 
+        // record field - CredentialConnectionString. The base Odbc.DataSource function
+        // will handle UsernamePassword authentication automatically, but it is explictly
+        // handled here as an example. 
+        //
+        Credential = Extension.CurrentCredential(),
+		CredentialConnectionString =
+            if Credential[AuthenticationKind]? = "UsernamePassword" then
+                // set connection string parameters used for basic authentication
+                [ UID = Credential[Username], PWD = Credential[Password] ]
+            else if (Credential[AuthenticationKind]? = "Windows") then
+                // set connection string parameters used for windows/kerberos authentication
+                [ Trusted_Connection="Yes" ]
+            else
+                error Error.Record("Error", "Unhandled authentication kind: " & Credential[AuthenticationKind]?),
+        
+        //
+        // Configuration options for the call to Odbc.DataSource
+        //
+        defaultConfig = BuildOdbcConfig(),
+
+        SqlCapabilities = defaultConfig[SqlCapabilities] & [
+            // place custom overrides here
+            FractionalSecondsScale = 3
+        ],
+
+        // Please refer to the ODBC specification for SQLGetInfo properties and values.
+        // https://github.com/Microsoft/ODBC-Specification/blob/master/Windows/inc/sqlext.h
+        SQLGetInfo = defaultConfig[SQLGetInfo] & [
+            // place custom overrides here
+            SQL_SQL92_PREDICATES = ODBC[SQL_SP][All],
+            SQL_AGGREGATE_FUNCTIONS = ODBC[SQL_AF][All]
+        ],
+
+        // SQLGetTypeInfo can be specified in two ways:
+        // 1. A #table() value that returns the same type information as an ODBC
+        //    call to SQLGetTypeInfo.
+        // 2. A function that accepts a table argument, and returns a table. The 
+        //    argument will contain the original results of the ODBC call to SQLGetTypeInfo.
+        //    Your function implementation can modify/add to this table.
+        //
+        // For details of the format of the types table parameter and expected return value,
+        // please see: https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgettypeinfo-function
+        //
+        // The sample implementation provided here will simply output the original table
+        // to the user trace log, without any modification. 
+        SQLGetTypeInfo = (types) => 
+            if (EnableTraceOutput <> true) then types else
+            let
+                // Outputting the entire table might be too large, and result in the value being truncated.
+                // We can output a row at a time instead with Table.TransformRows()
+                rows = Table.TransformRows(types, each Diagnostics.LogValue("SQLGetTypeInfo " & _[TYPE_NAME], _)),
+                toTable = Table.FromRecords(rows)
+            in
+                Value.ReplaceType(toTable, Value.Type(types)),                
+
+        // SQLColumns is a function handler that receives the results of an ODBC call
+        // to SQLColumns(). The source parameter contains a table with the data type 
+        // information. This override is typically used to fix up data type mismatches
+        // between calls to SQLGetTypeInfo and SQLColumns. 
+        //
+        // For details of the format of the source table parameter, please see:
+        // https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlcolumns-function
+        //
+        // The sample implementation provided here will simply output the original table
+        // to the user trace log, without any modification. 
+        SQLColumns = (catalogName, schemaName, tableName, columnName, source) =>
+            if (EnableTraceOutput <> true) then source else
+            // the if statement conditions will force the values to evaluated/written to diagnostics
+            if (Diagnostics.LogValue("SQLColumns.TableName", tableName) <> "***" and Diagnostics.LogValue("SQLColumns.ColumnName", columnName) <> "***") then
+                let
+                    // Outputting the entire table might be too large, and result in the value being truncated.
+                    // We can output a row at a time instead with Table.TransformRows()
+                    rows = Table.TransformRows(source, each Diagnostics.LogValue("SQLColumns", _)),
+                    toTable = Table.FromRecords(rows)
+                in
+                    Value.ReplaceType(toTable, Value.Type(source))
+            else
+                source,
+
+        // This record allows you to customize the generated SQL for certain
+        // operations. The most common usage is to define syntax for LIMIT/OFFSET operators 
+        // when TOP is not supported. 
+        // 
+/*
+        AstVisitor = [
+            LimitClause = (skip, take) =>
+                let
+                    offset = if (skip <> null and skip > 0) then Text.Format("OFFSET #{0} ROWS", {skip}) else "",
+                    limit = if (take <> null) then Text.Format("LIMIT #{0}", {take}) else ""
+                in
+                    [
+                        Text = Text.Format("#{0} #{1}", {offset, limit}),
+                        Location = "AfterQuerySpecification"
+                    ]
+        ],
+*/
+        OdbcDatasource = Odbc.DataSource(ConnectionString, [
+            // A logical (true/false) that sets whether to view the tables grouped by their schema names
+            HierarchicalNavigation = true, 
+            // Prevents execution of native SQL statements. Extensions should set this to true.
+            HideNativeQuery = true,
+            // Allows upconversion of numeric types
+            SoftNumbers = true,
+            // Allow upconversion / resizing of numeric and string types
+            TolerateConcatOverflow = true,
+            // Enables connection pooling via the system ODBC manager
+            ClientConnectionPooling = true,
+
+            // These values should be set by previous steps
+            CredentialConnectionString = CredentialConnectionString,
+            //AstVisitor = AstVisitor,
+            SqlCapabilities = SqlCapabilities,
+            SQLColumns = SQLColumns,
+            SQLGetInfo = SQLGetInfo,
+            SQLGetTypeInfo = SQLGetTypeInfo
+        ])
+    in
+        OdbcDatasource;  
+
+// Data Source Kind description
+SqlODBC = [
+    // Set the TestConnection handler to enable gateway support.
+    // The TestConnection handler will invoke your data source function to 
+    // validate the credentials the user has provider. Ideally, this is not 
+    // an expensive operation to perform. By default, the dataSourcePath value 
+    // will be a json string containing the required parameters of your data  
+    // source function. These should be parsed and parsed as individual parameters
+    // to the specified data source function.
+    TestConnection = (dataSourcePath) => 
+        let
+            json = Json.Document(dataSourcePath),
+            server = json[server]   // name of function parameter
+        in
+            { "SqlODBC.Contents", server },
+    // Set supported types of authentication
+    Authentication = [
+        Windows = [],
+        UsernamePassword = []
+    ],
+    Label = Extension.LoadString("DataSourceLabel")
+];
+
+// Data Source UI publishing description
+SqlODBC.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { Extension.LoadString("ButtonTitle"), Extension.LoadString("ButtonHelp") },
+    LearnMoreUrl = "https://powerbi.microsoft.com/",
+
+    SupportsDirectQuery = Config_EnableDirectQuery,
+
+    SourceImage = SqlODBC.Icons,
+    SourceTypeImage = SqlODBC.Icons
+];
+
+SqlODBC.Icons = [
+    Icon16 = { Extension.Contents("SqlODBC16.png"), Extension.Contents("SqlODBC20.png"), Extension.Contents("SqlODBC24.png"), Extension.Contents("SqlODBC32.png") },
+    Icon32 = { Extension.Contents("SqlODBC32.png"), Extension.Contents("SqlODBC40.png"), Extension.Contents("SqlODBC48.png"), Extension.Contents("SqlODBC64.png") }
+];
+
+// build settings based on configuration variables
+BuildOdbcConfig = () as record =>
+    let        
+        defaultConfig = [
+            SqlCapabilities = [],
+            SQLGetFunctions = [],
+            SQLGetInfo = []
+        ],
+
+        withParams =
+            if (Config_UseParameterBindings = false) then
+                let 
+                    caps = defaultConfig[SqlCapabilities] & [ 
+                        SqlCapabilities = [
+                            SupportsNumericLiterals = true,
+                            SupportsStringLiterals = true,                
+                            SupportsOdbcDateLiterals = true,
+                            SupportsOdbcTimeLiterals = true,
+                            SupportsOdbcTimestampLiterals = true
+                        ]
+                    ],
+                    funcs = defaultConfig[SQLGetFunctions] & [
+                        SQLGetFunctions = [
+                            SQL_API_SQLBINDPARAMETER = false
+                        ]
+                    ]
+                in
+                    defaultConfig & caps & funcs
+            else
+                defaultConfig,
+                
+        withEscape = 
+            if (Config_StringLiterateEscapeCharacters <> null) then 
+                let
+                    caps = withParams[SqlCapabilities] & [ 
+                        SqlCapabilities = [
+                            StringLiteralEscapeCharacters = Config_StringLiterateEscapeCharacters
+                        ]
+                    ]
+                in
+                    withParams & caps
+            else
+                withParams,
+
+        withTop =
+            let
+                caps = withEscape[SqlCapabilities] & [ 
+                    SqlCapabilities = [
+                        SupportsTop = Config_SupportsTop
+                    ]
+                ]
+            in
+                withEscape & caps,
+
+        withCastOrConvert = 
+            if (Config_UseCastInsteadOfConvert = true) then
+                let
+                    caps = withTop[SQLGetFunctions] & [ 
+                        SQLGetFunctions = [
+                            SQL_CONVERT_FUNCTIONS = 0x2 /* SQL_FN_CVT_CAST */
+                        ]
+                    ]
+                in
+                    withTop & caps
+            else
+                withTop,
+
+        withSqlConformance =
+            if (Config_SqlConformance <> null) then
+                let
+                    caps = withCastOrConvert[SQLGetInfo] & [
+                        SQLGetInfo = [
+                            SQL_SQL_CONFORMANCE = Config_SqlConformance
+                        ]
+                    ]
+                in
+                    withCastOrConvert & caps
+            else
+                withCastOrConvert
+    in
+        withSqlConformance;
+
+// 
+// Load common library functions
+// 
+Extension.LoadFunction = (name as text) =>
+    let
+        binary = Extension.Contents(name),
+        asText = Text.FromBinary(binary)
+    in
+        Expression.Evaluate(asText, #shared);
+
+// Diagnostics module contains multiple functions. We can take the ones we need.
+Diagnostics = Extension.LoadFunction("Diagnostics.pqm");
+Diagnostics.LogValue = if (EnableTraceOutput) then Diagnostics[LogValue] else (prefix, value) => value;
+
+// OdbcConstants contains numeric constants from the ODBC header files, and a 
+// helper function to create bitfield values.
+ODBC = Extension.LoadFunction("OdbcConstants.pqm");
+Odbc.Flags = ODBC[Flags];

--- a/src/test/parser/files/microsoft-DataConnectors/ODBC/SqlODBC/SqlODBC.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/ODBC/SqlODBC/SqlODBC.query.pq
@@ -1,0 +1,8 @@
+﻿// Use this file to write queries to test your data connector
+let
+    result = SqlODBC.Contents("localhost"),
+    db = result{[Name="master"]}[Data],
+    schema = db{[Name="sys"]}[Data],
+    allViews = schema{[Name="all_views"]}[Data]
+in
+    Table.FirstN(allViews, 5)

--- a/src/test/parser/files/microsoft-DataConnectors/OData/AnnotationsSample/AnnotationsSample.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/OData/AnnotationsSample/AnnotationsSample.pq
@@ -1,0 +1,83 @@
+﻿section TripPinAnnotations;
+
+// Data Source Kind description
+TripPin = [
+    // TestConnection is required to enable the connector through the Gateway
+    TestConnection = (dataSourcePath) => { "TripPin.Annotations" },
+    Authentication = [
+        Anonymous = []
+    ],
+    Label = "AnnotationsSample"
+];
+
+// Data Source UI publishing description
+TripPin.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "AnnotationsSample", "AnnotationsSample" }
+];
+
+[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+shared TripPin.Annotations = () => let
+    serviceDocument = TripPin.ServiceDocument()
+in
+    #table({ "Location", "Data" }, {
+        { "Entity Container Annotations", GetEntityContainerAnnotations(serviceDocument) },
+        { "Resources", Table.TransformColumns(serviceDocument, { { "Data", (resource) => 
+            if resource is function then #table({ "Location", "Data" }, {
+                { "Function Import Annotations", GetFunctionImportAnnotations(resource) },
+                { "Parameter Annotations", Record.ToTable(GetFunctionParameterAnnotations(Value.Type(resource))) }
+            }) else #table({ "Location", "Data" }, {
+                { "Entity Set or Singleton", GetEntitySetOrSingletonAnnotations(resource) },
+                { "Entity Type", #table({ "Location", "Data" }, {
+                    { "Entity Type Annotations", GetEntityTypeAnnotations(resource) },
+                    { "Property Annotations", Record.ToTable(GetEntityTypePropertyAnnotations(resource)) },
+                    { "Function Annotations", Table.AddColumn(
+                         Table.FromColumns(Table.ColumnsOfType(resource, { Function.Type }), { "Name" }),
+                         "Value",
+                         each GetEntityTypeFunctionAnnotations(resource, [Name])) }
+                }) }
+            })
+    } }) }
+});
+
+GetEntityContainerAnnotations = (serviceDocument) => Value.Metadata(Value.Type(serviceDocument));
+
+GetEntitySetOrSingletonAnnotations = (entitySetOrSingleton) => Value.Metadata(entitySetOrSingleton);
+
+GetFunctionImportAnnotations = (functionImport) => Value.Metadata(Value.Type(functionImport));
+
+GetEntityTypeAnnotations = (entitySetOrSingleton) => let
+    entityCollectionType = Value.Type(entitySetOrSingleton),
+    entityType = Type.TableRow(entityCollectionType),
+    entityTypeAnnotations = Value.Metadata(entityType)[OData.Annotations]
+in
+    entityTypeAnnotations;
+
+GetEntityTypePropertyAnnotations = (entitySetOrSingleton) => let
+    entityCollectionType = Value.Type(entitySetOrSingleton),
+    entityType = if entitySetOrSingleton is record then entityCollectionType else Type.TableRow(entityCollectionType),
+    fieldAnnotations = Value.Metadata(entityType)[OData.FieldAnnotations]
+in
+    fieldAnnotations;
+
+GetEntityTypeFunctionAnnotations = (entitySetOrSingleton, functionName) => let
+    entityCollectionType = Value.Type(entitySetOrSingleton),
+    entityType = if entitySetOrSingleton is record then entityCollectionType else Type.TableRow(entityCollectionType),
+    functionType = Type.TableColumn(entityType, functionName),
+    functionAnnotations = Value.Metadata(functionType)
+in
+    functionAnnotations;
+
+GetFunctionParameterAnnotations = (functionType) => let
+    parameters = Type.FunctionParameters(functionType),
+    parametersTable = Record.ToTable(parameters),
+    parameterAnnotations = Table.TransformColumns(parametersTable, { { "Value", Value.Metadata } })
+in
+    Record.FromTable(parameterAnnotations);
+
+BaseUrl = "http://services.odata.org/v4/TripPinService/";
+
+// Without explicitly setting IncludeAnnotations or IncludeMetadataAnnotations, 
+// annotations will not be made available
+TripPin.ServiceDocument = () => OData.Feed(BaseUrl, null, [ Implementation = "2.0", IncludeAnnotations = "*" ]) as table;

--- a/src/test/parser/files/microsoft-DataConnectors/OData/AnnotationsSample/AnnotationsSample.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/OData/AnnotationsSample/AnnotationsSample.query.pq
@@ -1,0 +1,5 @@
+﻿// Use this file to write queries to test your data connector
+let
+    result = TripPin.Annotations()
+in
+    result

--- a/src/test/parser/files/microsoft-DataConnectors/OpenApiSample/OpenApiSample.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/OpenApiSample/OpenApiSample.pq
@@ -1,0 +1,122 @@
+﻿section OpenApiSample;
+
+DefaultOptions = [ 
+    // The built-in credential handling for OpenApi.Document only works
+    // with Basic (UsernamePassword) auth. All other types should be handled
+    // explicitly using the ManualCredentials option.
+    //
+    // In the this sample, all of the calls we'll make will work anonymously.
+    // We can force anonymous access by setting ManualCredentials to true, and then
+    // not setting any additional request headers/parameters.
+    //
+    ManualCredentials = true,
+    // The returned data will match the schema defined in the swagger file. 
+    // This means that additional fields and object types that don't have explicit
+    // properties defined will be ignored. To see all results, we set the IncludeMoreColumns
+    // option to true. Any fields found in the response that aren't found in the schema will
+    // be grouped under this column in a record value.
+    //
+    IncludeMoreColumns = true,
+    // When IncludeExtensions is set to true, vendor extensions in the swagger ("x-*" fields)
+    // will be included as meta values on the function.
+    //
+    IncludeExtensions = true
+];
+
+[DataSource.Kind="OpenApiSample", Publish="OpenApiSample.Petstore.Publish"]
+shared OpenApiSample.Petstore = () =>
+    let
+        // Pull the latest swagger definition from the site 
+        swaggerUrl = "http://petstore.swagger.io/v2/swagger.json",
+        swagger = Web.Contents(swaggerUrl),
+        // OpenApi.Document will return a navigation table
+        nav = OpenApi.Document(swagger, DefaultOptions)
+    in
+        nav;
+
+[DataSource.Kind="OpenApiSample", Publish="OpenApiSample.ApisGuru.Publish"]
+shared OpenApiSample.ApisGuru = () =>
+    let
+        // load the swagger definition from the bundled resource file
+        Swagger = Extension.Contents("apisGuru.json"),
+
+        // OpenApi.Document returns a navigation table. Each GET operation defined
+        // in the swagger document is becomes a row in the nav table. Each row is a 
+        // function that can be invoked by the user.
+        defaultNav = OpenApi.Document(Swagger, DefaultOptions),
+        // The Apis.Guru swagger has a listAPIs function - we'll get a reference to that
+        listAPIs = defaultNav{[Name="listAPIs"]}[Data],
+        allAPIs = listAPIs(),
+        // format the results as the nav table we will return
+        nav = ApiGuru.FormatApiList(allAPIs)
+    in
+        nav;
+
+// Process the results of the ApisGuru listAPIs function to return a 
+// navigation table with all published APIs.
+ApiGuru.FormatApiList = (results as record) as table =>
+    if (results[MoreColumns]? = null) then error "[MoreColumns] not found in result" else
+    let
+        // expand down to the level that provides us with the swagger URL
+        MoreColumns = results[MoreColumns],
+        toTable = Record.ToTable(MoreColumns),
+        expandAPI = Table.ExpandRecordColumn(toTable, "Value", {"added", "preferred", "versions"}),
+        getPreferredVersion = Table.AddColumn(expandAPI, "api", each try Record.Field([versions], [preferred]) otherwise null),
+        expandSwaggerInfo = Table.ExpandRecordColumn(getPreferredVersion, "api", {"info", "swaggerUrl", "updated"}),
+        // the [Data] column of our navigator will be another call to OpenApi.Document, passing in the swagger for this endpoint
+        withData = Table.AddColumn(expandSwaggerInfo, "Data", each OpenApi.Document(Web.Contents([swaggerUrl]), DefaultOptions), Table.Type),
+        withKind = Table.AddColumn(withData, "ItemKind", each "Feed", Text.Type),
+        withName = Table.AddColumn(withKind, "ItemName", each "Table", Text.Type),
+        withLeaf = Table.AddColumn(withName, "IsLeaf", each false, Logical.Type),
+        asNav = Table.ToNavigationTable(withLeaf, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        asNav;
+
+// Data Source Kind description
+OpenApiSample = [
+    Authentication = [
+        Anonymous = []
+    ]
+];
+
+// Data Source UI publishing description
+OpenApiSample.ApisGuru.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "Swagger sample - APIs Guru", "Swagger sample - APIs Guru" },
+    LearnMoreUrl = "https://powerbi.microsoft.com/"
+];
+
+// Data Source UI publishing description
+OpenApiSample.Petstore.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "Swagger sample - Petstore", "Swagger sample - Petstore" },
+    LearnMoreUrl = "https://powerbi.microsoft.com/"
+];
+
+//
+// Common functions
+//
+Table.ToNavigationTable = (
+    table as table,
+    keyColumns as list,
+    nameColumn as text,
+    dataColumn as text,
+    itemKindColumn as text,
+    itemNameColumn as text,
+    isLeafColumn as text
+) as table =>
+    let
+        tableType = Value.Type(table),
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
+        [
+            NavigationTable.NameColumn = nameColumn, 
+            NavigationTable.DataColumn = dataColumn,
+            NavigationTable.ItemKindColumn = itemKindColumn, 
+            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.IsLeafColumn = isLeafColumn
+        ],
+        navigationTable = Value.ReplaceType(table, newTableType)
+    in
+        navigationTable;

--- a/src/test/parser/files/microsoft-DataConnectors/OpenApiSample/OpenApiSample.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/OpenApiSample/OpenApiSample.query.pq
@@ -1,0 +1,5 @@
+﻿// Use this file to write queries to test your data connector
+let
+    result = OpenApiSample.ApisGuru()
+in
+    result

--- a/src/test/parser/files/microsoft-DataConnectors/Relationships/Relationships.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/Relationships/Relationships.pq
@@ -1,0 +1,156 @@
+﻿// This sample shows how to define relationships between tables that 
+// will be automatically detected in Power BI Desktop.
+section Relationships;
+
+// Base navigation table, no relationships set
+[DataSource.Kind="Relationships", Publish="Relationships.PublishNone"]
+shared Relationships.None = () =>
+    let
+        base = #table(type table [ Name = Text.Type, Data = Table.Type ], {
+            { "Customers", Customers },
+            { "Orders", Orders },
+            { "OrderDetails", OrderDetails }
+        }),
+
+        nav = CreateNavTable(base)
+    in
+        nav;
+
+// Relationships set using Table.NestedJoin.
+// This function leaves the joined columns on the Orders table,
+// which makes it easy for a consumer to expand/merge the tables inline.
+[DataSource.Kind="Relationships", Publish="Relationships.PublishNested"]
+shared Relationships.Nested = () =>
+    let
+        ordersWithDetail = Table.NestedJoin(
+            Orders, {"OrderId"},
+            OrderDetails, {"OrderId"},
+            "OrderDetails",
+            JoinKind.LeftOuter),
+        ordersWithCustomers = Table.NestedJoin(
+            ordersWithDetail, { "CustomerId" },
+            Customers, {"CustomerId" },
+            "Customer",
+            JoinKind.LeftOuter),
+
+        base = #table(type table [ Name = Text.Type, Data = Table.Type ], {
+            { "Customers", Customers },
+            { "Orders", ordersWithCustomers },
+            { "OrderDetails", OrderDetails }
+        }),
+
+        nav = CreateNavTable(base)
+    in
+        nav;
+
+// Relationships set using Table.NestedJoin.
+// This function removes the joined columns, but
+// leaves the relationship metadata in place.
+[DataSource.Kind="Relationships", Publish="Relationships.PublishImplicit"]
+shared Relationships.Implicit = () =>
+    let
+        ordersWithDetail = Table.NestedJoin(
+            Orders, {"OrderId"},
+            OrderDetails, {"OrderId"},
+            "OrderDetails",
+            JoinKind.LeftOuter),
+        ordersWithCustomers = Table.NestedJoin(
+            ordersWithDetail, { "CustomerId" },
+            Customers, {"CustomerId" },
+            "Customer",
+            JoinKind.LeftOuter),
+
+        // remove the join columns
+        removedJoins = Table.RemoveColumns(ordersWithCustomers, {"OrderDetails", "Customer"}),
+
+        base = #table(type table [ Name = Text.Type, Data = Table.Type ], {
+            { "Customers", Customers },
+            { "Orders", removedJoins },
+            { "OrderDetails", OrderDetails }
+        }),
+
+        nav = CreateNavTable(base)
+    in
+        nav;
+
+// common function to generate format the results into a nav table.
+// expects table with columns { "Name", "Data" }
+CreateNavTable = (base as table) as table =>
+    let
+        withItemKind = Table.AddColumn(base, "ItemKind", each "Table", type text),
+        withItemName = Table.AddColumn(withItemKind, "ItemName", each "Table", type text),
+        withIsLeaf = Table.AddColumn(withItemName, "IsLeaf", each true, type logical),
+        navTable = Table.ToNavigationTable(withIsLeaf, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        navTable;
+
+// Static tables for the sample
+Customers = Table.AddKey(#table(type table [CustomerId = Int64.Type, Name = Text.Type], {
+    { 1, "Tom"},
+    { 2, "Bob"},
+    { 3, "Mary"}
+}), {"CustomerId"}, true);
+
+Orders = Table.AddKey(#table(type table [OrderId = Int64.Type, CustomerId = Int64.Type, OrderDate = Date.Type], {
+    { 1, 1, #date(2018, 1, 1) },
+    { 2, 1, #date(2018, 2, 1) },
+    { 3, 1, #date(2018, 3, 1) },
+    { 4, 1, #date(2018, 4, 1) },
+    { 5, 3, #date(2018, 5, 1) },
+    { 6, 3, #date(2018, 6, 1) },
+    { 7, 3, #date(2018, 7, 1) }
+}), {"OrderId"}, true);
+
+OrderDetails = Table.AddKey(#table(type table [OrderId = Int64.Type, LineItem = Int16.Type, Detail = Text.Type, Amount = Currency.Type], {
+    { 1, 1, "Book", 5.30 },
+    { 1, 2, "Book", 3.99 },
+    { 1, 3, "Supplies", 89.99 },
+    { 2, 1, "Book", 5.30 },
+    { 3, 1, "Book", 2.00 },
+    { 3, 2, "Supplies", 1.54 },
+    { 4, 1, "Book", 2.00 },
+    { 5, 1, "Book", 2.00 },
+    { 6, 1, "Book", 2.00 },
+    { 7, 1, "Book", 2.00 }
+}), {"OrderId", "LineItem"}, true);
+
+// Data Source Kind description
+Relationships = [
+    Authentication = [
+        Anonymous = []
+    ]
+];
+
+Relationships.PublishNone= [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "Relationship - None", "Relationship - None" },
+    LearnMoreUrl = "https://powerbi.microsoft.com/"
+];
+
+Relationships.PublishNested = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "Relationship - Nested", "Relationship - Nested" },
+    LearnMoreUrl = "https://powerbi.microsoft.com/"
+];
+
+Relationships.PublishImplicit = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "Relationship - Implicit", "Relationship - Implicit" },
+    LearnMoreUrl = "https://powerbi.microsoft.com/"
+];
+
+// 
+// Load common library functions
+// 
+// TEMPORARY WORKAROUND until we're able to reference other M modules
+Extension.LoadFunction = (name as text) =>
+    let
+        binary = Extension.Contents(name),
+        asText = Text.FromBinary(binary)
+    in
+        Expression.Evaluate(asText, #shared);
+
+Table.ToNavigationTable = Extension.LoadFunction("Table.ToNavigationTable.pqm");

--- a/src/test/parser/files/microsoft-DataConnectors/Relationships/Relationships.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/Relationships/Relationships.query.pq
@@ -1,0 +1,5 @@
+﻿// Use this file to write queries to test your data connector
+let
+    result = Relationships.Implicit()
+in
+    result

--- a/src/test/parser/files/microsoft-DataConnectors/Relationships/Table.ToNavigationTable.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/Relationships/Table.ToNavigationTable.pqm
@@ -1,0 +1,22 @@
+﻿(
+    table as table,
+    keyColumns as list,
+    nameColumn as text,
+    dataColumn as text,
+    itemKindColumn as text,
+    itemNameColumn as text,
+    isLeafColumn as text
+) as table =>
+    let
+        tableType = Value.Type(table),
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
+        [
+            NavigationTable.NameColumn = nameColumn, 
+            NavigationTable.DataColumn = dataColumn,
+            NavigationTable.ItemKindColumn = itemKindColumn, 
+            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.IsLeafColumn = isLeafColumn
+        ],
+        navigationTable = Value.ReplaceType(table, newTableType)
+    in
+        navigationTable

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/1-OData/TripPin.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/1-OData/TripPin.pq
@@ -1,0 +1,30 @@
+﻿section TripPin;
+
+[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+shared TripPin.Feed = Value.ReplaceType(TripPinImpl, type function (url as Uri.Type) as any);
+
+TripPinImpl = (url as text) =>
+    let
+        source = OData.Feed(url)
+    in
+        source;
+
+// Data Source Kind description
+TripPin = [
+    // Declares the supported type(s) of authentication.
+    // In this case, Implicit = Anonymous web access
+    Authentication = [
+        Anonymous = []
+    ],
+    // Assigns a label to the data source credential.
+    // This will be displayed in the "Manage Data Sources" dialog.
+    Label = "TripPin Part 1 - OData"
+];
+
+// Data Source UI publishing description
+TripPin.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "TripPin OData", "TripPin OData" }
+];
+

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/1-OData/TripPin.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/1-OData/TripPin.query.pq
@@ -1,0 +1,5 @@
+﻿// Use this file to write queries to test your data connector
+let
+    result = TripPin.Feed("http://services.odata.org/v4/TripPinService/")
+in
+    result

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/Diagnostics.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/Diagnostics.pqm
@@ -1,0 +1,275 @@
+﻿let
+    Diagnostics.LogValue = (prefix, value) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogFailure = (text, function) =>
+        let
+            result = try function()
+        in
+            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
+
+    Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
+        Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
+
+    Diagnostics.WrapHandlers = (handlers as record) as record =>
+        Record.FromList(
+            List.Transform(
+                Record.FieldNames(handlers),
+                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
+            Record.FieldNames(handlers)),
+
+    Diagnostics.ValueToText = (value) =>
+        let
+            _canBeIdentifier = (x) =>
+                                            let
+                                                keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                                charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                                charDigit = (c as number) => c>= 48 and c <= 57
+                                            in
+                                                try
+                                                    charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                    and
+                                                        List.MatchesAll(
+                                                            Text.ToList(x),
+                                                            (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                        )
+                                                    and not 
+                                                        List.MatchesAny( keywords, (li)=> li=x )
+                                                otherwise 
+                                                    false,
+    
+            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+            Serialize.Date =        (x) => "#date(" & 
+                                           Text.From(Date.Year(x))  & ", " & 
+                                           Text.From(Date.Month(x)) & ", " & 
+                                           Text.From(Date.Day(x))   & ") ",
+
+            Serialize.Datetime =    (x) => "#datetime(" &
+                                           Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                           Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                           Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                           Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                           Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                           Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+            Serialize.Datetimezone =(x) => let 
+                                              dtz = DateTimeZone.ToRecord(x) 
+                                           in
+                                              "#datetimezone(" & 
+                                              Text.From(dtz[Year])        & ", " &
+                                              Text.From(dtz[Month])       & ", " &
+                                              Text.From(dtz[Day])         & ", " &
+                                              Text.From(dtz[Hour])        & ", " &
+                                              Text.From(dtz[Minute])      & ", " &
+                                              Text.From(dtz[Second])      & ", " &
+                                              Text.From(dtz[ZoneHours])   & ", " &
+                                              Text.From(dtz[ZoneMinutes]) & ") ",
+
+            Serialize.Duration =    (x) => let
+                                              dur = Duration.ToRecord(x)
+                                           in
+                                              "#duration(" &
+                                              Text.From(dur[Days])    & ", " &
+                                              Text.From(dur[Hours])   & ", " &
+                                              Text.From(dur[Minutes]) & ", " &
+                                              Text.From(dur[Seconds]) & ") ",
+
+            Serialize.Function =    (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(Value.Type(x)),
+                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                           " as " &
+                                           _serialize_function_return_type(Value.Type(x)) &
+                                           " => (...) ",
+
+            Serialize.List =        (x) => "{" & 
+                                           List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                           "} ",
+
+            Serialize.Logical =     (x) => Text.From(x),
+
+            Serialize.Null =        (x) => "null",
+
+            Serialize.Number =      (x) => 
+                                        let Text.From = (i as number) as text => 
+                                            if Number.IsNaN(i) then "#nan" else
+                                            if i=Number.PositiveInfinity then "#infinity" else
+                                            if i=Number.NegativeInfinity then "-#infinity" else
+                                            Text.From(i)
+                                        in
+                                            Text.From(x),
+
+            Serialize.Record =      (x) => "[ " &
+                                           List.Accumulate(
+                                                Record.FieldNames(x), 
+                                                "", 
+                                                (seed,item) => 
+                                                    (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                           ) &
+                                           " ] ",
+
+            Serialize.Table =       (x) => "#table( type " &
+                                            _serialize_table_type(Value.Type(x)) &
+                                            ", " &
+                                            Serialize(Table.ToRows(x)) &
+                                            ") ",
+                                    
+            Serialize.Text =        (x) => """" & 
+                                           _serialize_text_content(x) & 
+                                           """",
+
+            _serialize_text_content =  (x) => let 
+                                                escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                            in
+                                            List.Accumulate(
+                                               List.Transform(
+                                                   Text.ToList(x),
+                                                   (c) => let n=Character.ToNumber(c) in 
+                                                            if n = 9   then "#(#)(tab)" else
+                                                            if n = 10  then "#(#)(lf)"  else
+                                                            if n = 13  then "#(#)(cr)"  else
+                                                            if n = 34  then """"""      else
+                                                            if n = 35  then "#(#)(#)"   else
+                                                            if n < 32  then escapeText(n) else 
+                                                            if n < 127 then Character.FromNumber(n) else 
+                                                            escapeText(n) 
+                                                ),
+                                                "",
+                                                (s,i)=>s&i
+                                            ),
+        
+            Serialize.Identifier =   (x) => 
+                                            if _canBeIdentifier(x) then 
+                                                x 
+                                            else 
+                                                "#""" &
+                                                _serialize_text_content(x) &
+                                                """",
+
+            Serialize.Time =        (x) => "#time(" &
+                                           Text.From(Time.Hour(x))   & ", " & 
+                                           Text.From(Time.Minute(x)) & ", " & 
+                                           Text.From(Time.Second(x)) & ") ",
+                                
+            Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                        let
+                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                        in
+                                
+                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                            if x = type any then "any" else
+                                            let base = Type.NonNullable(x) in
+                                              (if Type.IsNullable(x) then "nullable " else "") &       
+                                              (if base = type anynonnull then "anynonnull" else                
+                                              if base = type binary then "binary" else                
+                                              if base = type date   then "date"   else
+                                              if base = type datetime then "datetime" else
+                                              if base = type datetimezone then "datetimezone" else
+                                              if base = type duration then "duration" else
+                                              if base = type logical then "logical" else
+                                              if base = type none then "none" else
+                                              if base = type null then "null" else
+                                              if base = type number then "number" else
+                                              if base = type text then "text" else 
+                                              if base = type time then "time" else 
+                                              if base = type type then "type" else 
+                                      
+                                              /* Abstract types: */
+                                              if base = type function then "function" else
+                                              if base = type table then "table" else
+                                              if base = type record then "record" else
+                                              if base = type list then "list" else
+                                      
+                                              "any /*Actually unknown type*/"),
+
+            _serialize_table_type =     (x) => 
+                                               let 
+                                                 schema = Type.TableSchema(x)
+                                               in
+                                                 "table " &
+                                                 (if Table.IsEmpty(schema) then "" else 
+                                                     "[" & List.Accumulate(
+                                                        List.Transform(
+                                                            Table.ToRecords(Table.Sort(schema,"Position")),
+                                                            each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                        "",
+                                                        (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                    ) & "] " ),
+
+            _serialize_record_type =    (x) => 
+                                                let flds = Type.RecordFields(x)
+                                                in
+                                                    if Record.FieldCount(flds)=0 then "record" else
+                                                        "[" & List.Accumulate(
+                                                            Record.FieldNames(flds),
+                                                            "",
+                                                            (seed,item) => 
+                                                                seed &
+                                                                (if seed<>"" then ", " else "") &
+                                                                (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                        ) & 
+                                                        (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                        "]",
+
+            _serialize_function_type =  (x) => _serialize_function_param_type(
+                                                  Type.FunctionParameters(x),
+                                                  Type.FunctionRequiredParameters(x) ) &
+                                                " as " &
+                                                _serialize_function_return_type(x),
+    
+            _serialize_function_param_type = (t,n) => 
+                                    let
+                                        funsig = Table.ToRecords(
+                                            Table.TransformColumns(
+                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                                { "isOptional", (x)=> x>n } ) )
+                                    in
+                                        "(" & 
+                                        List.Accumulate(
+                                            funsig,
+                                            "",
+                                            (seed,item)=>
+                                                (if seed="" then "" else seed & ", ") &
+                                                (if item[isOptional] then "optional " else "") &
+                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                         & ")",
+
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+            Serialize = (x) as text => 
+                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                               if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                               if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                               if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                               if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                               if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                               if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                               if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                               if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                               if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                               "[#_unable_to_serialize_#]"                     
+        in
+            try Serialize(value) otherwise "<serialization failed>"
+in
+    [ 
+        LogValue = Diagnostics.LogValue,
+        LogValue2 = Diagnostics.LogValue2,
+        LogFailure = Diagnostics.LogFailure,
+        WrapFunctionResult = Diagnostics.WrapFunctionResult,
+        WrapHandlers = Diagnostics.WrapHandlers,
+        ValueToText = Diagnostics.ValueToText
+    ]

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/Table.ChangeType.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/Table.ChangeType.pqm
@@ -1,0 +1,138 @@
+﻿let
+    // table should be an actual Table.Type, or a List.Type of Records
+    Table.ChangeType = (table, tableType as type) as nullable table =>
+        // we only operate on table types
+        if (not Type.Is(tableType, type table)) then error "type argument should be a table type" else
+        // if we have a null value, just return it
+        if (table = null) then table else
+        let
+            columnsForType = Type.RecordFields(Type.TableRow(tableType)),
+            columnsAsTable = Record.ToTable(columnsForType),
+            schema = Table.ExpandRecordColumn(columnsAsTable, "Value", {"Type"}, {"Type"}),
+            previousMeta = Value.Metadata(tableType),
+
+            // make sure we have a table
+            parameterType = Value.Type(table),
+            _table =
+                if (Type.Is(parameterType, type table)) then table
+                else if (Type.Is(parameterType, type list)) then
+                    let
+                        asTable = Table.FromList(table, Splitter.SplitByNothing(), {"Column1"}),
+                        firstValueType = Value.Type(Table.FirstValue(asTable, null)),
+                        result =
+                            // if the member is a record (as expected), then expand it. 
+                            if (Type.Is(firstValueType, type record)) then
+                                Table.ExpandRecordColumn(asTable, "Column1", schema[Name])
+                            else
+                                error Error.Record("Error.Parameter", "table argument is a list, but not a list of records", [ ValueType = firstValueType ])
+                    in
+                        if (List.IsEmpty(table)) then
+                            #table({"a"}, {})
+                        else result
+                else
+                    error Error.Record("Error.Parameter", "table argument should be a table or list of records", [ValueType = parameterType]),
+
+            reordered = Table.SelectColumns(_table, schema[Name], MissingField.UseNull),
+
+            // process primitive values - this will call Table.TransformColumnTypes
+            map = (t) => if Type.Is(t, type table) or Type.Is(t, type list) or Type.Is(t, type record) or t = type any then null else t,        
+            mapped = Table.TransformColumns(schema, {"Type", map}),
+            omitted = Table.SelectRows(mapped, each [Type] <> null),
+            existingColumns = Table.ColumnNames(reordered),
+            removeMissing = Table.SelectRows(omitted, each List.Contains(existingColumns, [Name])),
+            primativeTransforms = Table.ToRows(removeMissing),
+            changedPrimatives = Table.TransformColumnTypes(reordered, primativeTransforms),
+        
+            // Get the list of transforms we'll use for Record types
+            recordColumns = Table.SelectRows(schema, each Type.Is([Type], type record)),
+            recordTypeTransformations = Table.AddColumn(recordColumns, "RecordTransformations", each (r) => Record.ChangeType(r, [Type]), type function),
+            recordChanges = Table.ToRows(Table.SelectColumns(recordTypeTransformations, {"Name", "RecordTransformations"})),
+
+            // Get the list of transforms we'll use for List types
+            listColumns = Table.SelectRows(schema, each Type.Is([Type], type list)),
+            listTransforms = Table.AddColumn(listColumns, "ListTransformations", each (t) => List.ChangeType(t, [Type]), Function.Type),
+            listChanges = Table.ToRows(Table.SelectColumns(listTransforms, {"Name", "ListTransformations"})),
+
+            // Get the list of transforms we'll use for Table types
+            tableColumns = Table.SelectRows(schema, each Type.Is([Type], type table)),
+            tableTransforms = Table.AddColumn(tableColumns, "TableTransformations", each (t) => @Table.ChangeType(t, [Type]), Function.Type),
+            tableChanges = Table.ToRows(Table.SelectColumns(tableTransforms, {"Name", "TableTransformations"})),
+
+            // Perform all of our transformations
+            allColumnTransforms = recordChanges & listChanges & tableChanges,
+            changedRecordTypes = if (List.IsEmpty(allColumnTransforms)) then changedPrimatives else Table.TransformColumns(changedPrimatives, allColumnTransforms, null, MissingField.Ignore),
+
+            // set final type
+            withType = Value.ReplaceType(changedRecordTypes, tableType)
+        in
+            if (List.IsEmpty(Record.FieldNames(columnsForType))) then table else withType meta previousMeta,
+
+    // If given a generic record type (no predefined fields), the original record is returned
+    Record.ChangeType = (record as record, recordType as type) =>
+        let
+            // record field format is [ fieldName = [ Type = type, Optional = logical], ... ]
+            fields = try Type.RecordFields(recordType) otherwise error "Record.ChangeType: failed to get record fields. Is this a record type?",
+            fieldNames = Record.FieldNames(fields),
+            fieldTable = Record.ToTable(fields),
+            optionalFields = Table.SelectRows(fieldTable, each [Value][Optional])[Name],
+            requiredFields = List.Difference(fieldNames, optionalFields),
+            // make sure all required fields exist
+            withRequired = Record.SelectFields(record, requiredFields, MissingField.UseNull),
+            // append optional fields
+            withOptional = withRequired & Record.SelectFields(record, optionalFields, MissingField.Ignore),
+            // set types
+            transforms = GetTransformsForType(recordType),
+            withTypes = Record.TransformFields(withOptional, transforms, MissingField.Ignore),
+            // order the same as the record type
+            reorder = Record.ReorderFields(withTypes, fieldNames, MissingField.Ignore)
+        in
+            if (List.IsEmpty(fieldNames)) then record else reorder,
+
+    List.ChangeType = (list as list, listType as type) =>
+        if (not Type.Is(listType, type list)) then error "type argument should be a list type" else
+        let
+            listItemType = Type.ListItem(listType),
+            transform = GetTransformByType(listItemType),
+            modifiedValues = List.Transform(list, transform),
+            typed = Value.ReplaceType(modifiedValues, listType)
+        in
+            typed,
+
+    // Returns a table type for the provided schema table
+    Schema.ToTableType = (schema as table) as type =>
+        let
+            toList = List.Transform(schema[Type], (t) => [Type=t, Optional=false]),
+            toRecord = Record.FromList(toList, schema[Name]),
+            toType = Type.ForRecord(toRecord, false),
+            previousMeta = Value.Metadata(schema)
+        in
+            type table (toType) meta previousMeta,
+
+    // Returns a list of transformations that can be passed to Table.TransformColumns, or Record.TransformFields
+    // Format: {"Column", (f) => ...) .... ex: {"A", Number.From}
+    GetTransformsForType = (_type as type) as list =>
+        let
+            fieldsOrColumns = if (Type.Is(_type, type record)) then Type.RecordFields(_type)
+                            else if (Type.Is(_type, type table)) then Type.RecordFields(Type.TableRow(_type))
+                            else error "GetTransformsForType: record or table type expected",
+            toTable = Record.ToTable(fieldsOrColumns),
+            transformColumn = Table.AddColumn(toTable, "Transform", each GetTransformByType([Value][Type]), Function.Type),
+            transformMap = Table.ToRows(Table.SelectColumns(transformColumn, {"Name", "Transform"}))
+        in
+            transformMap,
+
+    GetTransformByType = (_type as type) as function =>
+                if (Type.Is(_type, type number)) then Number.From
+        else if (Type.Is(_type, type text)) then Text.From
+        else if (Type.Is(_type, type date)) then Date.From
+        else if (Type.Is(_type, type datetime)) then DateTime.From
+        else if (Type.Is(_type, type duration)) then Duration.From
+        else if (Type.Is(_type, type datetimezone)) then DateTimeZone.From
+        else if (Type.Is(_type, type logical)) then Logical.From
+        else if (Type.Is(_type, type time)) then Time.From
+        else if (Type.Is(_type, type record)) then (t) => if (t <> null) then @Record.ChangeType(t, _type) else t
+        else if (Type.Is(_type, type table)) then (t) => if (t <> null) then @Table.ChangeType(t, _type) else t
+        else if (Type.Is(_type, type list)) then (t) => if (t <> null) then @List.ChangeType(t, _type) else t
+        else (t) => t
+in
+    Table.ChangeType

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/Table.GenerateByPage.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/Table.GenerateByPage.pqm
@@ -1,0 +1,23 @@
+﻿(getNextPage as function) as table =>
+    let        
+        listOfPages = List.Generate(
+            () => getNextPage(null),            // get the first page of data
+            (lastPage) => lastPage <> null,     // stop when the function returns null
+            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+        ),
+        // concatenate the pages together
+        tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
+        firstRow = tableOfPages{0}?
+    in
+        // if we didn't get back any pages of data, return an empty table
+        // otherwise set the table type based on the columns of the first page
+        if (firstRow = null) then
+            Table.FromRows({})
+		// check for empty first table
+		else if (Table.IsEmpty(firstRow[Column1])) then
+			firstRow[Column1]
+        else
+            Value.ReplaceType(
+                Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
+                Value.Type(firstRow[Column1])
+            )

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/Table.ToNavigationTable.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/Table.ToNavigationTable.pqm
@@ -1,0 +1,22 @@
+﻿(
+    table as table,
+    keyColumns as list,
+    nameColumn as text,
+    dataColumn as text,
+    itemKindColumn as text,
+    itemNameColumn as text,
+    isLeafColumn as text
+) as table =>
+    let
+        tableType = Value.Type(table),
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
+        [
+            NavigationTable.NameColumn = nameColumn, 
+            NavigationTable.DataColumn = dataColumn,
+            NavigationTable.ItemKindColumn = itemKindColumn, 
+            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.IsLeafColumn = isLeafColumn
+        ],
+        navigationTable = Value.ReplaceType(table, newTableType)
+    in
+        navigationTable

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/TripPin.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/TripPin.pq
@@ -1,0 +1,380 @@
+﻿section TripPin;
+
+// Data Source Kind description
+TripPin = [
+    // TestConnection is required to enable the connector through the Gateway
+    TestConnection = (dataSourcePath) => { "TripPin.Contents" },
+    Authentication = [
+        Anonymous = []
+    ],
+    Label = "TripPin Part 10 - Query Folding part 1"
+];
+
+// Data Source UI publishing description
+TripPin.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "TripPin QueryFolding 1", "TripPin QueryFolding 1" }
+];
+
+//
+// Implementation
+// 
+
+DefaultRequestHeaders = [
+    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
+    #"OData-MaxVersion" = "4.0"                             // we only support v4
+];
+
+BaseUrl = "http://services.odata.org/v4/TripPinService/";
+
+// Define our top level table types
+AirlinesType = type table [ AirlineCode = text, Name = text ];
+
+AirportsType = type table [
+    Name = text,
+    IataCode = text,
+    Location = LocationType
+];
+
+PeopleType = type table [
+    UserName = text,
+    FirstName = text,
+    LastName = text,
+    Emails = {text},
+    AddressInfo = {nullable LocationType},
+    Gender = nullable text,
+    Concurrency = Int64.Type
+];
+
+// remaining structured types
+LocationType = type [
+    Address = text,
+    City = CityType,
+    Loc = LocType
+];
+
+CityType = type [
+    CountryRegion = text,
+    Name = text,
+    Region = text
+];
+
+LocType = type [
+    #"type" = text,
+    coordinates = {number},
+    crs = CrsType
+];
+
+CrsType = type [
+    #"type" = text,
+    properties = record
+];
+
+SchemaTable = #table({"Entity", "Type"}, {
+    {"Airlines", AirlinesType },    
+    {"Airports", AirportsType },
+    {"People", PeopleType}    
+});
+        
+GetSchemaForEntity = (entity as text) as type =>
+    try 
+        SchemaTable{[Entity=entity]}[Type]
+    otherwise
+        let
+            message = Text.Format("Couldn't find entity: '#{0}'", {entity})
+        in
+            Diagnostics.Trace(TraceLevel.Error, message, () => error message, true);
+
+
+[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
+
+TripPinNavTable = (url as text) as table =>
+    let
+        // Use our schema table as the source of top level items in the navigation tree
+        entities = Table.SelectColumns(SchemaTable, {"Entity"}),
+        rename = Table.RenameColumns(entities, {{"Entity", "Name"}}),
+        // Add Data as a calculated column
+        withData = Table.AddColumn(rename, "Data", each TripPin.View(url, [Name]), type table),
+        // Add ItemKind and ItemName as fixed text values
+        withItemKind = Table.AddColumn(withData, "ItemKind", each "Table", type text),
+        withItemName = Table.AddColumn(withItemKind, "ItemName", each "Table", type text),
+        // Indicate that the node should not be expandable
+        withIsLeaf = Table.AddColumn(withItemName, "IsLeaf", each true, type logical),
+        // Generate the nav table
+        navTable = Table.ToNavigationTable(withIsLeaf, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        navTable;
+
+TripPin.View = (baseUrl as text, entity as text) as table =>
+    let
+        // Implementation of Table.View handlers.
+        //
+        // We wrap the record with Diagnostics.WrapHandlers() to get some automatic
+        // tracing if a handler returns an error.
+        //
+        View = (state as record) => Table.View(null, Diagnostics.WrapHandlers([
+
+            // Returns the table type returned by GetRows()
+            GetType = () => CalculateSchema(state),
+
+            // Called last - retrieves the data from the calculated URL
+            GetRows = () => 
+                let
+                    finalSchema = CalculateSchema(state),
+                    finalUrl = CalculateUrl(state),
+                    result = TripPin.Feed(finalUrl, finalSchema),
+                    appliedType = Table.ChangeType(result, finalSchema)
+                in
+                    appliedType,
+
+            // GetRowCount - called when all we want is the total row count.
+            // Most OData services support $count, but it only works if
+            // no other query parameters are sent (i.e. $top, or $filter).
+            // Our implementation will first check for other query state -
+            // if there are any state fields set by other handlers, we
+            // return "..." unimplemented, because we won't be able to fold
+            // the request to the server.
+            GetRowCount = () as number =>
+                if (Record.FieldCount(Record.RemoveFields(state, {"Url", "Entity", "Schema"}, MissingField.Ignore)) > 0) then
+                    ...
+                else
+                    let
+                        newState = state & [ RowCountOnly = true ],
+                        finalUrl = CalculateUrl(newState),
+                        value = TripPin.Scalar(finalUrl),
+                        converted = Number.FromText(value)
+                    in
+                        converted,
+
+            // OnTake - handles the Table.FirstN transform, limiting
+            // the maximum number of rows returned in the result set.
+            // The count value should be >= 0.
+            OnTake = (count as number) =>
+                let
+                    newState = state & [ Top = count ]
+                in
+                    @View(newState),
+
+            // OnSkip - handles the Table.Skip transform.
+            // The count value should be >= 0.
+            OnSkip = (count as number) =>
+                let
+                    newState = state & [ Skip = count ]
+                in
+                    @View(newState),
+
+            // OnSelectColumns - handles column selection
+            OnSelectColumns = (columns as list) =>
+                let
+                    // get the current schema
+                    currentSchema = CalculateSchema(state),
+                    // get the columns from the current schema (which is an M Type value)
+                    rowRecordType = Type.RecordFields(Type.TableRow(currentSchema)),
+                    existingColumns = Record.FieldNames(rowRecordType),
+                    // calculate the new schema
+                    columnsToRemove = List.Difference(existingColumns, columns),
+                    updatedColumns = Record.RemoveFields(rowRecordType, columnsToRemove),
+                    newSchema = type table (Type.ForRecord(updatedColumns, false))
+                in
+                    @View(state & 
+                        [ 
+                            SelectColumns = columns,
+                            Schema = newSchema
+                        ]
+                    ),
+
+            // OnSort - receives a list of records containing two fields: 
+            //    [Name]  - the name of the column to sort on
+            //    [Order] - equal to Order.Ascending or Order.Descending
+            // If there are multiple records, the sort order must be maintained.
+            //
+            // OData allows you to sort on columns that do not appear in the result
+            // set, so we do not have to validate that the sorted columns are in our 
+            // existing schema.
+            OnSort = (order as list) =>
+                let
+                    // This will convert the list of records to a list of text,
+                    // where each entry is "<columnName> <asc|desc>"
+                    sorting = List.Transform(order, (o) => 
+                        let
+                            column = o[Name],
+                            order = o[Order],
+                            orderText = if (order = Order.Ascending) then "asc" else "desc"
+                        in
+                            column & " " & orderText
+                    ),
+                    orderBy = Text.Combine(sorting, ", ")
+                in
+                    @View(state & [ OrderBy = orderBy ]),
+
+            //
+            // Helper functions
+            //
+            // Retrieves the cached schema. If this is the first call
+            // to CalculateSchema, the table type is calculated based on
+            // entity name that was passed into the function.
+            CalculateSchema = (state) as type =>
+                if (state[Schema]? = null) then
+                    GetSchemaForEntity(entity)
+                else
+                    state[Schema],
+
+            // Calculates the final URL based on the current state.
+            CalculateUrl = (state) as text => 
+                let
+                    urlWithEntity = Uri.Combine(state[Url], state[Entity]),
+
+                    // Check for $count. If all we want is a row count,
+                    // then we add /$count to the path value (following the entity name).
+                    urlWithRowCount =
+                        if (state[RowCountOnly]? = true) then
+                            urlWithEntity & "/$count"
+                        else
+                            urlWithEntity,
+
+                    // Uri.BuildQueryString requires that all field values
+                    // are text literals.
+                    defaultQueryString = [],
+
+                    // Check for Top defined in our state
+                    qsWithTop =
+                        if (state[Top]? <> null) then
+                            defaultQueryString & [ #"$top" = Number.ToText(state[Top]) ]
+                        else
+                            defaultQueryString,
+
+                    // Check for Skip defined in our state
+                    qsWithSkip = 
+                        if (state[Skip]? <> null) then
+                            qsWithTop & [ #"$skip" = Number.ToText(state[Skip]) ]
+                        else
+                            qsWithTop,
+
+                    // Check for explicitly selected columns
+                    qsWithSelect =
+                        if (state[SelectColumns]? <> null) then
+                            qsWithSkip & [ #"$select" = Text.Combine(state[SelectColumns], ",") ]
+                        else
+                            qsWithSkip,
+
+                    qsWithOrderBy = 
+                        if (state[OrderBy]? <> null) then
+                            qsWithSelect & [ #"$orderby" = state[OrderBy] ]
+                        else
+                            qsWithSelect,
+
+                    encodedQueryString = Uri.BuildQueryString(qsWithOrderBy),
+                    finalUrl = urlWithRowCount & "?" & encodedQueryString
+                in
+                    finalUrl
+        ]))
+    in
+        View([Url = baseUrl, Entity = entity]);
+
+// Similar to TripPin.Feed, but is expecting back a scalar value.
+// This function returns the value from the service as plain text.
+TripPin.Scalar = (url as text) as text =>
+    let
+        _url = Diagnostics.LogValue("TripPin.Scalar url", url),
+
+        headers = DefaultRequestHeaders & [
+            #"Accept" = "text/plain"
+        ],
+
+        response = Web.Contents(_url, [ Headers = headers ]),
+        toText = Text.FromBinary(response)
+    in
+        toText;
+
+TripPin.Feed = (url as text, optional schema as type) as table =>
+    let
+        _url = Diagnostics.LogValue("Accessing url", url),
+        _schema = Diagnostics.LogValue("Schema type", schema),
+        result = GetAllPagesByNextLink(_url, _schema)
+    in
+        result;
+
+// 
+// ** Replaced by TripPin.View **
+//
+// GetEntity = (url as text, entity as text) as table => 
+//     let
+//         fullUrl = Uri.Combine(url, entity),
+//         schema = GetSchemaForEntity(entity),
+//         result = TripPin.Feed(fullUrl, schema),
+//         appliedSchema = Table.ChangeType(result, schema)
+//     in
+//         appliedSchema;
+// 
+// TripPin.SuperSimpleView = (url as text, entity as text) as table =>
+//     Table.View(null, [
+//         GetType = () => Value.Type(GetRows()),
+//         GetRows = () => GetEntity(url, entity)
+//     ]);
+
+GetPage = (url as text, optional schema as type) as table =>
+    let
+        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        body = Json.Document(response),
+        nextLink = GetNextLink(body),
+        
+        // If we have no schema, use Table.FromRecords() instead
+        // (and hope that our results all have the same fields).
+        // If we have a schema, expand the record using its field names
+        data =
+            if (schema = null) then
+                Diagnostics.LogFailure(
+                    "Error converting response body. Are the records uniform?",
+                    () => Table.FromRecords(body[value])
+                )
+            else
+                let
+                    // convert the list of records into a table (single column of records)
+                    asTable = Table.FromList(body[value], Splitter.SplitByNothing(), {"Column1"}),
+                    fields = Record.FieldNames(Type.RecordFields(Type.TableRow(schema))),
+                    expanded = Table.ExpandRecordColumn(asTable, "Column1", fields)
+                in
+                    expanded
+    in
+        data meta [NextLink = nextLink];
+
+// Read all pages of data.
+// After every page, we check the "NextLink" record on the metadata of the previous request.
+// Table.GenerateByPage will keep asking for more pages until we return null.
+GetAllPagesByNextLink = (url as text, optional schema as type) as nullable table =>
+    Table.GenerateByPage((previous) => 
+        let
+            // if previous is null, then this is our first page of data
+            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+            // if NextLink was set to null by the previous call, we know we have no more data
+            page = if (nextLink <> null) then GetPage(nextLink, schema) else null
+        in
+            page
+    );
+
+// In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
+// We look for the '@odata.nextLink' field and simply return null if it doesn't exist.
+GetNextLink = (response) as nullable text => Record.FieldOrDefault(response, "@odata.nextLink");
+
+// 
+// Load common library functions
+// 
+// TEMPORARY WORKAROUND until we're able to reference other M modules
+Extension.LoadFunction = (name as text) =>
+    let
+        binary = Extension.Contents(name),
+        asText = Text.FromBinary(binary)
+    in
+        Expression.Evaluate(asText, #shared);
+
+Table.ChangeType = Extension.LoadFunction("Table.ChangeType.pqm");
+Table.GenerateByPage = Extension.LoadFunction("Table.GenerateByPage.pqm");
+Table.ToNavigationTable = Extension.LoadFunction("Table.ToNavigationTable.pqm");
+
+// Diagnostics module contains multiple functions. We can take the ones we need.
+Diagnostics = Extension.LoadFunction("Diagnostics.pqm");
+Diagnostics.LogValue = Diagnostics[LogValue];
+Diagnostics.LogFailure = Diagnostics[LogFailure];
+Diagnostics.WrapHandlers = Diagnostics[WrapHandlers];

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/TripPin.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/10-TableView1/TripPin.query.pq
@@ -1,0 +1,375 @@
+﻿section TripPinUnitTests;
+
+shared TripPin.UnitTest =
+[
+    // Put any common variables here if you only want them to be evaluated once
+    RootTable = TripPin.Contents(),
+    Airlines = RootTable{[Name="Airlines"]}[Data],
+    Airports = RootTable{[Name="Airports"]}[Data],
+    People = RootTable{[Name="People"]}[Data],
+
+    // Fact(<Name of the Test>, <Expected Value>, <Actual Value>)
+    // <Expected Value> and <Actual Value> can be a literal or let statement
+    facts =
+    {
+        Fact("Check that we have three entries in our nav table", 3, Table.RowCount(RootTable)),
+        Fact("We have Airline data?", true, not Table.IsEmpty(Airlines)),
+        Fact("We have People data?", true, not Table.IsEmpty(People)),
+        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),        
+        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),        
+        Fact("Airline table has the right fields",
+            {"AirlineCode","Name"},
+            Record.FieldNames(Type.RecordFields(Type.TableRow(Value.Type(Airlines))))
+        ),
+        Fact("Emails is properly typed", type text, Type.ListItem(Value.Type(People{0}[Emails]))),
+
+        //
+        // Query folding tests
+        //
+
+        // OnTake
+        Fact("Fold $top 1 on Airlines", 
+            #table( type table [AirlineCode = text, Name = text] , {{"AA", "American Airlines"}} ), 
+            Table.FirstN(Airlines, 1)
+        ),
+        Fact("Fold $top 0 on Airports", 
+            #table( type table [Name = text, IataCode = text, Location = record] , {} ), 
+            Table.FirstN(Airports, 0)
+        ),
+
+        // OnSkip
+        Fact("Fold $skip 14 on Airlines",
+            #table( type table [AirlineCode = text, Name = text] , {{"EK", "Emirates"}} ), 
+            Table.Skip(Airlines, 14)
+        ),
+        Fact("Fold $skip 0 and $top 1",
+            #table( type table [AirlineCode = text, Name = text] , {{"AA", "American Airlines"}} ),
+            Table.FirstN(Table.Skip(Airlines, 0), 1)
+        ),
+
+        // GetRowCount
+        Fact("Fold $count", 15, Table.RowCount(Airlines)),
+        // test will fail if "Fail on Folding Error" is set to false
+        Fact("Fold $count + $top *error*", true, Test.IsFoldingError(try Table.RowCount(Table.FirstN(Airlines, 3)))),
+
+        // OnSelectColumns
+        Fact("Fold $select single column", 
+            #table( type table [AirlineCode = text] , {{"AA"}} ),
+            Table.FirstN(Table.SelectColumns(Airlines, {"AirlineCode"}), 1)
+        ),
+        Fact("Fold $select multiple column", 
+             #table( type table [UserName = text, FirstName = text, LastName = text],{{"russellwhyte", "Russell", "Whyte"}}), 
+            Table.FirstN(Table.SelectColumns(People, {"UserName", "FirstName", "LastName"}), 1)
+        ),
+        Fact("Fold $select with ignore column", 
+            #table( type table [AirlineCode = text] , {{"AA"}} ),
+            Table.FirstN(Table.SelectColumns(Airlines, {"AirlineCode", "DoesNotExist"}, MissingField.Ignore), 1)
+        ),
+
+        // OnSort
+        Fact("Fold $orderby single column",
+            #table( type table [AirlineCode = text, Name = text], {{"TK", "Turkish Airlines"}}),
+            Table.FirstN(Table.Sort(Airlines, {{"AirlineCode", Order.Descending}}), 1)
+        ),
+        Fact("Fold $orderby multiple column",
+            #table( type table [UserName = text], {{"javieralfred"}}),
+            Table.SelectColumns(Table.FirstN(Table.Sort(People, {{"LastName", Order.Ascending}, {"UserName", Order.Descending}}), 1), {"UserName"})
+        )
+    },
+
+    report = Facts.Summarize(facts)
+][report];
+
+// Returns true if there is a folding error, or the original record (for logging purposes) if not.
+Test.IsFoldingError = (tryResult as record) =>
+    if ( tryResult[HasError]? = true and tryResult[Error][Message] = "We couldn't fold the expression to the data source. Please try a simpler expression.") then
+        true
+    else
+        tryResult;
+
+/// COMMON UNIT TESTING CODE 
+Fact = (_subject as text, _expected, _actual) as record =>
+[   expected = try _expected,
+    safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],
+    actual = try _actual,
+    safeActual = if actual[HasError] then "Actual : "& @ValueToText(actual[Error]) else actual[Value],
+    attempt = try safeExpected = safeActual,
+    result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
+    resultOp = if result = "Success ✓" then " = " else " <> ",
+    addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
+    addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
+    addendumEvalActual = try @ValueToText (safeActual) otherwise "...",
+    fact =
+    [   Result = result &" "& addendumEvalAttempt,
+        Notes =_subject,
+        Details = " ("& addendumEvalExpected & resultOp & addendumEvalActual &")"
+    ]
+][fact];
+
+Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject,_{0},_{1}));
+
+Facts.Summarize = (_facts as list) as table =>
+[   Fact.CountSuccesses = (count, i) =>
+    [   result = try i[Result],
+        sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
+    ][sum],
+    passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
+    total = List.Count(_facts),
+    format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+    result = if passed = total then "Success" else "⛔",
+    rate = Number.IntegerDivide(100*passed, total),
+    header =
+    [   Result = result,
+        Notes = Text.Format(format, {passed, total-passed}),
+        Details = Text.Format("#{0}% success rate", {rate})
+    ],
+    report = Table.FromRecords(List.Combine({{header},_facts}))
+][report];
+
+ValueToText = (value, optional depth) =>
+    let
+        _canBeIdentifier = (x) =>
+                                        let
+                                            keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                            charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                            charDigit = (c as number) => c>= 48 and c <= 57
+                                        in
+                                            try
+                                                charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                and
+                                                    List.MatchesAll(
+                                                        Text.ToList(x),
+                                                        (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                    )
+                                                and not 
+                                                    List.MatchesAny( keywords, (li)=> li=x )
+                                            otherwise 
+                                                false,
+    
+        Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+        Serialize.Date =        (x) => "#date(" & 
+                                       Text.From(Date.Year(x))  & ", " & 
+                                       Text.From(Date.Month(x)) & ", " & 
+                                       Text.From(Date.Day(x))   & ") ",
+
+        Serialize.Datetime =    (x) => "#datetime(" &
+                                       Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                       Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                       Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                       Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                       Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                       Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+        Serialize.Datetimezone =(x) => let 
+                                          dtz = DateTimeZone.ToRecord(x) 
+                                       in
+                                          "#datetimezone(" & 
+                                          Text.From(dtz[Year])        & ", " &
+                                          Text.From(dtz[Month])       & ", " &
+                                          Text.From(dtz[Day])         & ", " &
+                                          Text.From(dtz[Hour])        & ", " &
+                                          Text.From(dtz[Minute])      & ", " &
+                                          Text.From(dtz[Second])      & ", " &
+                                          Text.From(dtz[ZoneHours])   & ", " &
+                                          Text.From(dtz[ZoneMinutes]) & ") ",
+
+        Serialize.Duration =    (x) => let
+                                          dur = Duration.ToRecord(x)
+                                       in
+                                          "#duration(" &
+                                          Text.From(dur[Days])    & ", " &
+                                          Text.From(dur[Hours])   & ", " &
+                                          Text.From(dur[Minutes]) & ", " &
+                                          Text.From(dur[Seconds]) & ") ",
+
+        Serialize.Function =    (x) => _serialize_function_param_type(
+                                          Type.FunctionParameters(Value.Type(x)),
+                                          Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                       " as " &
+                                       _serialize_function_return_type(Value.Type(x)) &
+                                       " => (...) ",
+
+        Serialize.List =        (x) => "{" & 
+                                       List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                       "} ",
+
+        Serialize.Logical =     (x) => Text.From(x),
+
+        Serialize.Null =        (x) => "null",
+
+        Serialize.Number =      (x) => 
+                                    let Text.From = (i as number) as text => 
+                                        if Number.IsNaN(i) then "#nan" else
+                                        if i=Number.PositiveInfinity then "#infinity" else
+                                        if i=Number.NegativeInfinity then "-#infinity" else
+                                        Text.From(i)
+                                    in
+                                        Text.From(x),
+
+        Serialize.Record =      (x) => "[ " &
+                                       List.Accumulate(
+                                            Record.FieldNames(x), 
+                                            "", 
+                                            (seed,item) => 
+                                                (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                       ) &
+                                       " ] ",
+
+        Serialize.Table =       (x) => "#table( type " &
+                                        _serialize_table_type(Value.Type(x)) &
+                                        ", " &
+                                        Serialize(Table.ToRows(x)) &
+                                        ") ",
+                                    
+        Serialize.Text =        (x) => """" & 
+                                       _serialize_text_content(x) & 
+                                       """",
+
+        _serialize_text_content =  (x) => let 
+                                            escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                        in
+                                        List.Accumulate(
+                                           List.Transform(
+                                               Text.ToList(x),
+                                               (c) => let n=Character.ToNumber(c) in 
+                                                        if n = 9   then "#(#)(tab)" else
+                                                        if n = 10  then "#(#)(lf)"  else
+                                                        if n = 13  then "#(#)(cr)"  else
+                                                        if n = 34  then """"""      else
+                                                        if n = 35  then "#(#)(#)"   else
+                                                        if n < 32  then escapeText(n) else 
+                                                        if n < 127 then Character.FromNumber(n) else 
+                                                        escapeText(n) 
+                                            ),
+                                            "",
+                                            (s,i)=>s&i
+                                        ),
+        
+        Serialize.Identifier =   (x) => 
+                                        if _canBeIdentifier(x) then 
+                                            x 
+                                        else 
+                                            "#""" &
+                                            _serialize_text_content(x) &
+                                            """",
+
+        Serialize.Time =        (x) => "#time(" &
+                                       Text.From(Time.Hour(x))   & ", " & 
+                                       Text.From(Time.Minute(x)) & ", " & 
+                                       Text.From(Time.Second(x)) & ") ",
+                                
+        Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+        _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                    let
+                                        isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                        isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                        isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                        isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                    in
+                                
+                                        if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                        if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                        if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                        if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                        if x = type any then "any" else
+                                        let base = Type.NonNullable(x) in
+                                          (if Type.IsNullable(x) then "nullable " else "") &       
+                                          (if base = type anynonnull then "anynonnull" else                
+                                          if base = type binary then "binary" else                
+                                          if base = type date   then "date"   else
+                                          if base = type datetime then "datetime" else
+                                          if base = type datetimezone then "datetimezone" else
+                                          if base = type duration then "duration" else
+                                          if base = type logical then "logical" else
+                                          if base = type none then "none" else
+                                          if base = type null then "null" else
+                                          if base = type number then "number" else
+                                          if base = type text then "text" else 
+                                          if base = type time then "time" else 
+                                          if base = type type then "type" else 
+                                      
+                                          /* Abstract types: */
+                                          if base = type function then "function" else
+                                          if base = type table then "table" else
+                                          if base = type record then "record" else
+                                          if base = type list then "list" else
+                                      
+                                          "any /*Actually unknown type*/"),
+
+        _serialize_table_type =     (x) => 
+                                           let 
+                                             schema = Type.TableSchema(x)
+                                           in
+                                             "table " &
+                                             (if Table.IsEmpty(schema) then "" else 
+                                                 "[" & List.Accumulate(
+                                                    List.Transform(
+                                                        Table.ToRecords(Table.Sort(schema,"Position")),
+                                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                    "",
+                                                    (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                ) & "] " ),
+
+        _serialize_record_type =    (x) => 
+                                            let flds = Type.RecordFields(x)
+                                            in
+                                                if Record.FieldCount(flds)=0 then "record" else
+                                                    "[" & List.Accumulate(
+                                                        Record.FieldNames(flds),
+                                                        "",
+                                                        (seed,item) => 
+                                                            seed &
+                                                            (if seed<>"" then ", " else "") &
+                                                            (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                    ) & 
+                                                    (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                    "]",
+
+        _serialize_function_type =  (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(x),
+                                              Type.FunctionRequiredParameters(x) ) &
+                                            " as " &
+                                            _serialize_function_return_type(x),
+    
+        _serialize_function_param_type = (t,n) => 
+                                let
+                                    funsig = Table.ToRecords(
+                                        Table.TransformColumns(
+                                            Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                            { "isOptional", (x)=> x>n } ) )
+                                in
+                                    "(" & 
+                                    List.Accumulate(
+                                        funsig,
+                                        "",
+                                        (seed,item)=>
+                                            (if seed="" then "" else seed & ", ") &
+                                            (if item[isOptional] then "optional " else "") &
+                                            Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                     & ")",
+
+        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+        Serialize = (x) as text => 
+                           if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                           if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                           if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                           if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                           if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                           if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                           if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                           if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                           if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                           if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                           if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                           if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                           if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                           if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                           if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                           "[#_unable_to_serialize_#]"                     
+    in
+        try Serialize(value) otherwise "<serialization failed>";

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/2-Rest/TripPin.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/2-Rest/TripPin.pq
@@ -1,0 +1,32 @@
+﻿section TripPin;
+
+[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+shared TripPin.Feed = Value.ReplaceType(TripPinImpl, type function (url as Uri.Type) as any);
+
+DefaultRequestHeaders = [
+    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
+    #"OData-MaxVersion" = "4.0"                             // we only support v4
+];
+
+TripPinImpl = (url as text) =>
+    let
+        source = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),
+        json = Json.Document(source)
+    in
+        json;
+
+// Data Source Kind description
+TripPin = [
+    Authentication = [
+        Anonymous = []
+    ],
+    Label = "TripPin Part 2 - REST"
+];
+
+// Data Source UI publishing description
+TripPin.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "TripPin REST", "TripPin REST" }
+];
+

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/2-Rest/TripPin.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/2-Rest/TripPin.query.pq
@@ -1,0 +1,5 @@
+﻿// Use this file to write queries to test your data connector
+let
+    result = TripPin.Feed("http://services.odata.org/v4/TripPinService/Me")
+in
+    result

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/3-NavTables/TripPin.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/3-NavTables/TripPin.pq
@@ -1,0 +1,104 @@
+﻿section TripPin;
+
+//
+// Definition
+//
+
+// Data Source Kind description
+TripPin = [
+    Authentication = [
+        Anonymous = []
+    ],
+    Label = "TripPin Part 3 - Navigator"
+];
+
+// Data Source UI publishing description
+TripPin.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "TripPin Navigator", "TripPin Navigator" }
+];
+
+//
+// Implementation
+// 
+
+[DataSource.Kind="TripPin"]
+shared TripPin.Feed = Value.ReplaceType(TripPinImpl, type function (url as Uri.Type) as any);
+
+[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+shared TripPin.Contents =  Value.ReplaceType(TripPinNavTable, type function (url as Uri.Type) as any);
+
+DefaultRequestHeaders = [
+    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
+    #"OData-MaxVersion" = "4.0"                             // we only support v4
+];
+
+TripPinImpl = (url as text) =>
+    let
+        source = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),
+        json = Json.Document(source)
+    in
+        json;
+
+TripPinNavTable = (url as text) as table =>
+    let
+        source = #table({"Name", "Data", "ItemKind", "ItemName", "IsLeaf"}, {
+            { "Airlines", GetAirlinesTable(url), "Table", "Table", true },
+            { "Airports", GetAirportsTable(url), "Table", "Table", true }
+        }),
+        navTable = Table.ToNavigationTable(source, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        navTable;
+
+GetAirlinesTable = (url as text) as table =>
+    let
+        source = TripPin.Feed(url & "Airlines"),
+        value = source[value],
+        toTable = Table.FromList(value, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
+        expand = Table.ExpandRecordColumn(toTable, "Column1", {"AirlineCode", "Name"}, {"AirlineCode", "Name"})
+    in
+        expand;
+
+GetAirportsTable = (url as text) as table =>
+    let
+        source = TripPin.Feed(url & "Airports"),
+        value = source[value],
+        #"Converted to Table" = Table.FromList(value, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
+        #"Expanded Column1" = Table.ExpandRecordColumn(#"Converted to Table", "Column1", {"Name", "IcaoCode", "IataCode", "Location"}, {"Name", "IcaoCode", "IataCode", "Location"}),
+        #"Expanded Location" = Table.ExpandRecordColumn(#"Expanded Column1", "Location", {"Address", "Loc", "City"}, {"Address", "Loc", "City"}),
+        #"Expanded City" = Table.ExpandRecordColumn(#"Expanded Location", "City", {"Name", "CountryRegion", "Region"}, {"Name.1", "CountryRegion", "Region"}),
+        #"Renamed Columns" = Table.RenameColumns(#"Expanded City",{{"Name.1", "City"}}),
+        #"Expanded Loc" = Table.ExpandRecordColumn(#"Renamed Columns", "Loc", {"coordinates"}, {"coordinates"}),
+        #"Added Custom" = Table.AddColumn(#"Expanded Loc", "Latitude", each [coordinates]{1}),
+        #"Added Custom1" = Table.AddColumn(#"Added Custom", "Longitude", each [coordinates]{0}),
+        #"Removed Columns" = Table.RemoveColumns(#"Added Custom1",{"coordinates"}),
+        #"Changed Type" = Table.TransformColumnTypes(#"Removed Columns",{{"Name", type text}, {"IcaoCode", type text}, {"IataCode", type text}, {"Address", type text}, {"City", type text}, {"CountryRegion", type text}, {"Region", type text}, {"Latitude", type number}, {"Longitude", type number}})
+    in
+        #"Changed Type";
+
+//
+// Common functions
+//
+Table.ToNavigationTable = (
+    table as table,
+    keyColumns as list,
+    nameColumn as text,
+    dataColumn as text,
+    itemKindColumn as text,
+    itemNameColumn as text,
+    isLeafColumn as text
+) as table =>
+    let
+        tableType = Value.Type(table),
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
+        [
+            NavigationTable.NameColumn = nameColumn, 
+            NavigationTable.DataColumn = dataColumn,
+            NavigationTable.ItemKindColumn = itemKindColumn, 
+            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.IsLeafColumn = isLeafColumn
+        ],
+        navigationTable = Value.ReplaceType(table, newTableType)
+    in
+        navigationTable;

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/3-NavTables/TripPin.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/3-NavTables/TripPin.query.pq
@@ -1,0 +1,1 @@
+﻿ TripPin.Contents("http://services.odata.org/v4/TripPinService/")

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/4-Paths/TripPin.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/4-Paths/TripPin.pq
@@ -1,0 +1,98 @@
+﻿section TripPin;
+
+//
+// Definition
+//
+
+// Data Source Kind description
+TripPin = [
+    Authentication = [
+        Anonymous = []
+    ],
+    Label = "TripPin Part 4 - Data Source Paths"
+];
+
+// Data Source UI publishing description
+TripPin.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "TripPin Data Source Paths", "TripPin Data Source Paths" }
+];
+
+//
+// Implementation
+// 
+
+DefaultRequestHeaders = [
+    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
+    #"OData-MaxVersion" = "4.0"                             // we only support v4
+];
+
+BaseUrl = "http://services.odata.org/v4/TripPinService/";
+
+RootEntities = {
+    "Airlines",
+    "Airports",
+    "People"
+};
+
+[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
+
+TripPinNavTable = (url as text) as table =>
+    let
+        entitiesAsTable = Table.FromList(RootEntities, Splitter.SplitByNothing()),
+        rename = Table.RenameColumns(entitiesAsTable, {{"Column1", "Name"}}),
+        // Add Data as a calculated column
+        withData = Table.AddColumn(rename, "Data", each TripPin.Feed(Uri.Combine(url, [Name])), Uri.Type),
+        // Add ItemKind and ItemName as fixed text values
+        withItemKind = Table.AddColumn(withData, "ItemKind", each "Table", type text),
+        withItemName = Table.AddColumn(withItemKind, "ItemName", each "Table", type text),
+        // Indicate that the node should not be expandable
+        withIsLeaf = Table.AddColumn(withItemName, "IsLeaf", each true, type logical),
+        // Generate the nav table
+        navTable = Table.ToNavigationTable(withIsLeaf, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        navTable;
+
+TripPin.Feed = (url as text) =>
+    let
+        source = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),
+        json = Json.Document(source),
+        // The response is a JSON record - the data we want is a list of records in the "value" field
+        value = json[value],
+        asTable = Table.FromList(value, Splitter.SplitByNothing()),
+        // expand all columns from the record
+        fields = Record.FieldNames(Table.FirstValue(asTable, [Empty = null])),
+        expandAll = Table.ExpandRecordColumn(asTable, "Column1", fields)
+    in
+        expandAll;
+
+//
+// Common functions
+//
+Table.ToNavigationTable = (
+    table as table,
+    keyColumns as list,
+    nameColumn as text,
+    dataColumn as text,
+    itemKindColumn as text,
+    itemNameColumn as text,
+    isLeafColumn as text
+) as table =>
+    let
+        tableType = Value.Type(table),
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
+        [
+            NavigationTable.NameColumn = nameColumn, 
+            NavigationTable.DataColumn = dataColumn,
+            NavigationTable.ItemKindColumn = itemKindColumn, 
+            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.IsLeafColumn = isLeafColumn
+        ],
+        navigationTable = Value.ReplaceType(table, newTableType)
+    in
+        navigationTable;
+
+
+

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/4-Paths/TripPin.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/4-Paths/TripPin.query.pq
@@ -1,0 +1,1 @@
+﻿TripPin.Contents()

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/5-Paging/TripPin.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/5-Paging/TripPin.pq
@@ -1,0 +1,133 @@
+﻿section TripPin;
+
+//
+// Definition
+//
+
+// Data Source Kind description
+TripPin = [
+    Authentication = [
+        Anonymous = []
+    ],
+    Label = "TripPin Part 5 - Paging"
+];
+
+// Data Source UI publishing description
+TripPin.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "TripPin Paging", "TripPin Paging" }
+];
+
+//
+// Implementation
+// 
+
+DefaultRequestHeaders = [
+    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
+    #"OData-MaxVersion" = "4.0"                             // we only support v4
+];
+
+BaseUrl = "http://services.odata.org/v4/TripPinService/";
+
+RootEntities = {
+    "Airlines",
+    "Airports",
+    "People"
+};
+
+[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
+
+TripPinNavTable = (url as text) as table =>
+    let
+        entitiesAsTable = Table.FromList(RootEntities, Splitter.SplitByNothing()),
+        rename = Table.RenameColumns(entitiesAsTable, {{"Column1", "Name"}}),
+        // Add Data as a calculated column
+        withData = Table.AddColumn(rename, "Data", each TripPin.Feed(Uri.Combine(url, [Name])), type table),
+        // Add ItemKind and ItemName as fixed text values
+        withItemKind = Table.AddColumn(withData, "ItemKind", each "Table", type text),
+        withItemName = Table.AddColumn(withItemKind, "ItemName", each "Table", type text),
+        // Indicate that the node should not be expandable
+        withIsLeaf = Table.AddColumn(withItemName, "IsLeaf", each true, type logical),
+        // Generate the nav table
+        navTable = Table.ToNavigationTable(withIsLeaf, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        navTable;
+
+TripPin.Feed = (url as text) as table => GetAllPagesByNextLink(url);
+
+GetPage = (url as text) as table =>
+    let
+        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        body = Json.Document(response),
+        nextLink = GetNextLink(body),
+        data = Table.FromRecords(body[value])
+    in
+        data meta [NextLink = nextLink];
+
+// Read all pages of data.
+// After every page, we check the "NextLink" record on the metadata of the previous request.
+// Table.GenerateByPage will keep asking for more pages until we return null.
+GetAllPagesByNextLink = (url as text) as table =>
+    Table.GenerateByPage((previous) => 
+        let
+            // if previous is null, then this is our first page of data
+            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+            // if NextLink was set to null by the previous call, we know we have no more data
+            page = if (nextLink <> null) then GetPage(nextLink) else null
+        in
+            page
+    );
+
+// In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
+// We look for the '@odata.nextLink' field and simply return null if it doesn't exist.
+GetNextLink = (response) as nullable text => Record.FieldOrDefault(response, "@odata.nextLink");
+
+//
+// Common functions
+//
+Table.ToNavigationTable = (
+    table as table,
+    keyColumns as list,
+    nameColumn as text,
+    dataColumn as text,
+    itemKindColumn as text,
+    itemNameColumn as text,
+    isLeafColumn as text
+) as table =>
+    let
+        tableType = Value.Type(table),
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
+        [
+            NavigationTable.NameColumn = nameColumn, 
+            NavigationTable.DataColumn = dataColumn,
+            NavigationTable.ItemKindColumn = itemKindColumn, 
+            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.IsLeafColumn = isLeafColumn
+        ],
+        navigationTable = Value.ReplaceType(table, newTableType)
+    in
+        navigationTable;
+
+// The getNextPage function takes a single argument and is expected to return a nullable table
+Table.GenerateByPage = (getNextPage as function) as table =>
+    let        
+        listOfPages = List.Generate(
+            () => getNextPage(null),            // get the first page of data
+            (lastPage) => lastPage <> null,     // stop when the function returns null
+            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+        ),
+        // concatenate the pages together
+        tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
+        firstRow = tableOfPages{0}?
+    in
+        // if we didn't get back any pages of data, return an empty table
+        // otherwise set the table type based on the columns of the first page
+        if (firstRow = null) then
+            Table.FromRows({})
+        else        
+            Value.ReplaceType(
+                Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
+                Value.Type(firstRow[Column1])
+            );

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/5-Paging/TripPin.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/5-Paging/TripPin.query.pq
@@ -1,0 +1,6 @@
+﻿let
+    source = TripPin.Contents(),
+    data = source{[Name="People"]}[Data],
+    withRowCount = Table.AddIndexColumn(data, "Index")
+in
+    withRowCount

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/6-Schema/TripPin.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/6-Schema/TripPin.pq
@@ -1,0 +1,230 @@
+﻿section TripPin;
+
+//
+// Definition
+//
+
+// Data Source Kind description
+TripPin = [
+    Authentication = [
+        Anonymous = []
+    ],
+    Label = "TripPin Part 6 - Schema"
+];
+
+// Data Source UI publishing description
+TripPin.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "TripPin Schema", "TripPin Schema" }
+];
+
+//
+// Implementation
+// 
+
+DefaultRequestHeaders = [
+    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
+    #"OData-MaxVersion" = "4.0"                             // we only support v4
+];
+
+BaseUrl = "http://services.odata.org/v4/TripPinService/";
+
+RootEntities = {
+    "Airlines",
+    "Airports",
+    "People"
+};
+
+SchemaTable = #table({"Entity", "SchemaTable"}, {
+    {"Airlines", #table({"Name", "Type"}, {
+        {"AirlineCode", type text},
+        {"Name", type text}
+    })},    
+    
+    {"Airports", #table({"Name", "Type"}, {
+        {"IcaoCode", type text},
+        {"Name", type text},
+        {"IataCode", type text},
+        {"Location", type record}
+    })},
+
+    {"People", #table({"Name", "Type"}, {
+        {"UserName", type text},
+        {"FirstName", type text},
+        {"LastName", type text},
+        {"Emails", type list},
+        {"AddressInfo", type list},
+        {"Gender", type nullable text},
+        {"Concurrency", Int64.Type}
+    })}
+});
+        
+GetSchemaForEntity = (entity as text) as table => try SchemaTable{[Entity=entity]}[SchemaTable] otherwise error "Couldn't find entity: '" & entity &"'";
+
+[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
+
+TripPinNavTable = (url as text) as table =>
+    let
+        entitiesAsTable = Table.FromList(RootEntities, Splitter.SplitByNothing()),
+        rename = Table.RenameColumns(entitiesAsTable, {{"Column1", "Name"}}),
+        // Add Data as a calculated column
+        withData = Table.AddColumn(rename, "Data", each GetEntity(url, [Name]), type table),
+        // Add ItemKind and ItemName as fixed text values
+        withItemKind = Table.AddColumn(withData, "ItemKind", each "Table", type text),
+        withItemName = Table.AddColumn(withItemKind, "ItemName", each "Table", type text),
+        // Indicate that the node should not be expandable
+        withIsLeaf = Table.AddColumn(withItemName, "IsLeaf", each true, type logical),
+        // Generate the nav table
+        navTable = Table.ToNavigationTable(withIsLeaf, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        navTable;
+
+TripPin.Feed = (url as text, optional schema as table) as table => GetAllPagesByNextLink(url, schema);
+
+GetEntity = (url as text, entity as text) as table => 
+    let
+        fullUrl = Uri.Combine(url, entity),
+        schemaTable = GetSchemaForEntity(entity),
+        result = TripPin.Feed(fullUrl, schemaTable)
+    in
+        result;
+
+GetPage = (url as text, optional schema as table) as table =>
+    let
+        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        body = Json.Document(response),
+        nextLink = GetNextLink(body),
+        data = Table.FromRecords(body[value]),
+        // enforce the schema
+        withSchema = if (schema <> null) then SchemaTransformTable(data, schema) else data
+    in
+        withSchema meta [NextLink = nextLink];
+
+// Read all pages of data.
+// After every page, we check the "NextLink" record on the metadata of the previous request.
+// Table.GenerateByPage will keep asking for more pages until we return null.
+GetAllPagesByNextLink = (url as text, optional schema as table) as table =>
+    Table.GenerateByPage((previous) => 
+        let
+            // if previous is null, then this is our first page of data
+            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+            // if NextLink was set to null by the previous call, we know we have no more data
+            page = if (nextLink <> null) then GetPage(nextLink, schema) else null
+        in
+            page
+    );
+
+// In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
+// We look for the '@odata.nextLink' field and simply return null if it doesn't exist.
+GetNextLink = (response) as nullable text => Record.FieldOrDefault(response, "@odata.nextLink");
+
+//
+// Common functions
+//
+Table.ToNavigationTable = (
+    table as table,
+    keyColumns as list,
+    nameColumn as text,
+    dataColumn as text,
+    itemKindColumn as text,
+    itemNameColumn as text,
+    isLeafColumn as text
+) as table =>
+    let
+        tableType = Value.Type(table),
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
+        [
+            NavigationTable.NameColumn = nameColumn, 
+            NavigationTable.DataColumn = dataColumn,
+            NavigationTable.ItemKindColumn = itemKindColumn, 
+            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.IsLeafColumn = isLeafColumn
+        ],
+        navigationTable = Value.ReplaceType(table, newTableType)
+    in
+        navigationTable;
+
+// The getNextPage function takes a single argument and is expected to return a nullable table
+Table.GenerateByPage = (getNextPage as function) as table =>
+    let        
+        listOfPages = List.Generate(
+            () => getNextPage(null),            // get the first page of data
+            (lastPage) => lastPage <> null,     // stop when the function returns null
+            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+        ),
+        // concatenate the pages together
+        tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
+        firstRow = tableOfPages{0}?
+    in
+        // if we didn't get back any pages of data, return an empty table
+        // otherwise set the table type based on the columns of the first page
+        if (firstRow = null) then
+            Table.FromRows({})
+        else        
+            Value.ReplaceType(
+                Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
+                Value.Type(firstRow[Column1])
+            );
+
+//
+// Schema functions
+//
+
+EnforceSchema.Strict = 1;               // Add any missing columns, remove extra columns, set table type
+EnforceSchema.IgnoreExtraColumns = 2;   // Add missing columns, do not remove extra columns
+EnforceSchema.IgnoreMissingColumns = 3; // Do not add or remove columns
+
+SchemaTransformTable = (table as table, schema as table, optional enforceSchema as number) as table =>
+    let
+        // Default to EnforceSchema.Strict
+        _enforceSchema = if (enforceSchema <> null) then enforceSchema else EnforceSchema.Strict,
+
+        // Applies type transforms to a given table
+        EnforceTypes = (table as table, schema as table) as table =>
+            let
+                map = (t) => if Type.Is(t, type list) or Type.Is(t, type record) or t = type any then null else t,
+                mapped = Table.TransformColumns(schema, {"Type", map}),
+                omitted = Table.SelectRows(mapped, each [Type] <> null),
+                existingColumns = Table.ColumnNames(table),
+                removeMissing = Table.SelectRows(omitted, each List.Contains(existingColumns, [Name])),
+                primativeTransforms = Table.ToRows(removeMissing),
+                changedPrimatives = Table.TransformColumnTypes(table, primativeTransforms)
+            in
+                changedPrimatives,
+
+        // Returns the table type for a given schema
+        SchemaToTableType = (schema as table) as type =>
+            let
+                toList = List.Transform(schema[Type], (t) => [Type=t, Optional=false]),
+                toRecord = Record.FromList(toList, schema[Name]),
+                toType = Type.ForRecord(toRecord, false)
+            in
+                type table (toType),
+
+        // Determine if we have extra/missing columns.
+        // The enforceSchema parameter determines what we do about them.
+        schemaNames = schema[Name],
+        foundNames = Table.ColumnNames(table),
+        addNames = List.RemoveItems(schemaNames, foundNames),
+        extraNames = List.RemoveItems(foundNames, schemaNames),
+        tmp = Text.NewGuid(),
+        added = Table.AddColumn(table, tmp, each []),
+        expanded = Table.ExpandRecordColumn(added, tmp, addNames),
+        result = if List.IsEmpty(addNames) then table else expanded,
+        fullList =
+            if (_enforceSchema = EnforceSchema.Strict) then
+                schemaNames
+            else if (_enforceSchema = EnforceSchema.IgnoreMissingColumns) then
+                foundNames
+            else
+                schemaNames & extraNames,
+
+        // Select the final list of columns.
+        // These will be ordered according to the schema table.
+        reordered = Table.SelectColumns(result, fullList, MissingField.Ignore),
+        enforcedTypes = EnforceTypes(reordered, schema),
+        withType = if (_enforceSchema = EnforceSchema.Strict) then Value.ReplaceType(enforcedTypes, SchemaToTableType(schema)) else enforcedTypes
+    in
+        withType;

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/6-Schema/TripPin.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/6-Schema/TripPin.query.pq
@@ -1,0 +1,5 @@
+﻿let
+    source = TripPin.Contents(),
+    data = source{[Name="People"]}[Data]
+in
+    Table.Schema(data)

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/7-AdvancedSchema/Table.ChangeType.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/7-AdvancedSchema/Table.ChangeType.pqm
@@ -1,0 +1,138 @@
+﻿let
+    // table should be an actual Table.Type, or a List.Type of Records
+    Table.ChangeType = (table, tableType as type) as nullable table =>
+        // we only operate on table types
+        if (not Type.Is(tableType, type table)) then error "type argument should be a table type" else
+        // if we have a null value, just return it
+        if (table = null) then table else
+        let
+            columnsForType = Type.RecordFields(Type.TableRow(tableType)),
+            columnsAsTable = Record.ToTable(columnsForType),
+            schema = Table.ExpandRecordColumn(columnsAsTable, "Value", {"Type"}, {"Type"}),
+            previousMeta = Value.Metadata(tableType),
+
+            // make sure we have a table
+            parameterType = Value.Type(table),
+            _table =
+                if (Type.Is(parameterType, type table)) then table
+                else if (Type.Is(parameterType, type list)) then
+                    let
+                        asTable = Table.FromList(table, Splitter.SplitByNothing(), {"Column1"}),
+                        firstValueType = Value.Type(Table.FirstValue(asTable, null)),
+                        result =
+                            // if the member is a record (as expected), then expand it. 
+                            if (Type.Is(firstValueType, type record)) then
+                                Table.ExpandRecordColumn(asTable, "Column1", schema[Name])
+                            else
+                                error Error.Record("Error.Parameter", "table argument is a list, but not a list of records", [ ValueType = firstValueType ])
+                    in
+                        if (List.IsEmpty(table)) then
+                            #table({"a"}, {})
+                        else result
+                else
+                    error Error.Record("Error.Parameter", "table argument should be a table or list of records", [ValueType = parameterType]),
+
+            reordered = Table.SelectColumns(_table, schema[Name], MissingField.UseNull),
+
+            // process primitive values - this will call Table.TransformColumnTypes
+            map = (t) => if Type.Is(t, type table) or Type.Is(t, type list) or Type.Is(t, type record) or t = type any then null else t,        
+            mapped = Table.TransformColumns(schema, {"Type", map}),
+            omitted = Table.SelectRows(mapped, each [Type] <> null),
+            existingColumns = Table.ColumnNames(reordered),
+            removeMissing = Table.SelectRows(omitted, each List.Contains(existingColumns, [Name])),
+            primativeTransforms = Table.ToRows(removeMissing),
+            changedPrimatives = Table.TransformColumnTypes(reordered, primativeTransforms),
+        
+            // Get the list of transforms we'll use for Record types
+            recordColumns = Table.SelectRows(schema, each Type.Is([Type], type record)),
+            recordTypeTransformations = Table.AddColumn(recordColumns, "RecordTransformations", each (r) => Record.ChangeType(r, [Type]), type function),
+            recordChanges = Table.ToRows(Table.SelectColumns(recordTypeTransformations, {"Name", "RecordTransformations"})),
+
+            // Get the list of transforms we'll use for List types
+            listColumns = Table.SelectRows(schema, each Type.Is([Type], type list)),
+            listTransforms = Table.AddColumn(listColumns, "ListTransformations", each (t) => List.ChangeType(t, [Type]), Function.Type),
+            listChanges = Table.ToRows(Table.SelectColumns(listTransforms, {"Name", "ListTransformations"})),
+
+            // Get the list of transforms we'll use for Table types
+            tableColumns = Table.SelectRows(schema, each Type.Is([Type], type table)),
+            tableTransforms = Table.AddColumn(tableColumns, "TableTransformations", each (t) => @Table.ChangeType(t, [Type]), Function.Type),
+            tableChanges = Table.ToRows(Table.SelectColumns(tableTransforms, {"Name", "TableTransformations"})),
+
+            // Perform all of our transformations
+            allColumnTransforms = recordChanges & listChanges & tableChanges,
+            changedRecordTypes = if (List.IsEmpty(allColumnTransforms)) then changedPrimatives else Table.TransformColumns(changedPrimatives, allColumnTransforms, null, MissingField.Ignore),
+
+            // set final type
+            withType = Value.ReplaceType(changedRecordTypes, tableType)
+        in
+            if (List.IsEmpty(Record.FieldNames(columnsForType))) then table else withType meta previousMeta,
+
+    // If given a generic record type (no predefined fields), the original record is returned
+    Record.ChangeType = (record as record, recordType as type) =>
+        let
+            // record field format is [ fieldName = [ Type = type, Optional = logical], ... ]
+            fields = try Type.RecordFields(recordType) otherwise error "Record.ChangeType: failed to get record fields. Is this a record type?",
+            fieldNames = Record.FieldNames(fields),
+            fieldTable = Record.ToTable(fields),
+            optionalFields = Table.SelectRows(fieldTable, each [Value][Optional])[Name],
+            requiredFields = List.Difference(fieldNames, optionalFields),
+            // make sure all required fields exist
+            withRequired = Record.SelectFields(record, requiredFields, MissingField.UseNull),
+            // append optional fields
+            withOptional = withRequired & Record.SelectFields(record, optionalFields, MissingField.Ignore),
+            // set types
+            transforms = GetTransformsForType(recordType),
+            withTypes = Record.TransformFields(withOptional, transforms, MissingField.Ignore),
+            // order the same as the record type
+            reorder = Record.ReorderFields(withTypes, fieldNames, MissingField.Ignore)
+        in
+            if (List.IsEmpty(fieldNames)) then record else reorder,
+
+    List.ChangeType = (list as list, listType as type) =>
+        if (not Type.Is(listType, type list)) then error "type argument should be a list type" else
+        let
+            listItemType = Type.ListItem(listType),
+            transform = GetTransformByType(listItemType),
+            modifiedValues = List.Transform(list, transform),
+            typed = Value.ReplaceType(modifiedValues, listType)
+        in
+            typed,
+
+    // Returns a table type for the provided schema table
+    Schema.ToTableType = (schema as table) as type =>
+        let
+            toList = List.Transform(schema[Type], (t) => [Type=t, Optional=false]),
+            toRecord = Record.FromList(toList, schema[Name]),
+            toType = Type.ForRecord(toRecord, false),
+            previousMeta = Value.Metadata(schema)
+        in
+            type table (toType) meta previousMeta,
+
+    // Returns a list of transformations that can be passed to Table.TransformColumns, or Record.TransformFields
+    // Format: {"Column", (f) => ...) .... ex: {"A", Number.From}
+    GetTransformsForType = (_type as type) as list =>
+        let
+            fieldsOrColumns = if (Type.Is(_type, type record)) then Type.RecordFields(_type)
+                            else if (Type.Is(_type, type table)) then Type.RecordFields(Type.TableRow(_type))
+                            else error "GetTransformsForType: record or table type expected",
+            toTable = Record.ToTable(fieldsOrColumns),
+            transformColumn = Table.AddColumn(toTable, "Transform", each GetTransformByType([Value][Type]), Function.Type),
+            transformMap = Table.ToRows(Table.SelectColumns(transformColumn, {"Name", "Transform"}))
+        in
+            transformMap,
+
+    GetTransformByType = (_type as type) as function =>
+                if (Type.Is(_type, type number)) then Number.From
+        else if (Type.Is(_type, type text)) then Text.From
+        else if (Type.Is(_type, type date)) then Date.From
+        else if (Type.Is(_type, type datetime)) then DateTime.From
+        else if (Type.Is(_type, type duration)) then Duration.From
+        else if (Type.Is(_type, type datetimezone)) then DateTimeZone.From
+        else if (Type.Is(_type, type logical)) then Logical.From
+        else if (Type.Is(_type, type time)) then Time.From
+        else if (Type.Is(_type, type record)) then (t) => if (t <> null) then @Record.ChangeType(t, _type) else t
+        else if (Type.Is(_type, type table)) then (t) => if (t <> null) then @Table.ChangeType(t, _type) else t
+        else if (Type.Is(_type, type list)) then (t) => if (t <> null) then @List.ChangeType(t, _type) else t
+        else (t) => t
+in
+    Table.ChangeType

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/7-AdvancedSchema/Table.GenerateByPage.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/7-AdvancedSchema/Table.GenerateByPage.pqm
@@ -1,0 +1,23 @@
+﻿(getNextPage as function) as table =>
+    let        
+        listOfPages = List.Generate(
+            () => getNextPage(null),            // get the first page of data
+            (lastPage) => lastPage <> null,     // stop when the function returns null
+            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+        ),
+        // concatenate the pages together
+        tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
+        firstRow = tableOfPages{0}?
+    in
+        // if we didn't get back any pages of data, return an empty table
+        // otherwise set the table type based on the columns of the first page
+        if (firstRow = null) then
+            Table.FromRows({})
+		// check for empty first table
+		else if (Table.IsEmpty(firstRow[Column1])) then
+			firstRow[Column1]
+        else
+            Value.ReplaceType(
+                Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
+                Value.Type(firstRow[Column1])
+            )

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/7-AdvancedSchema/Table.ToNavigationTable.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/7-AdvancedSchema/Table.ToNavigationTable.pqm
@@ -1,0 +1,22 @@
+﻿(
+    table as table,
+    keyColumns as list,
+    nameColumn as text,
+    dataColumn as text,
+    itemKindColumn as text,
+    itemNameColumn as text,
+    isLeafColumn as text
+) as table =>
+    let
+        tableType = Value.Type(table),
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
+        [
+            NavigationTable.NameColumn = nameColumn, 
+            NavigationTable.DataColumn = dataColumn,
+            NavigationTable.ItemKindColumn = itemKindColumn, 
+            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.IsLeafColumn = isLeafColumn
+        ],
+        navigationTable = Value.ReplaceType(table, newTableType)
+    in
+        navigationTable

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/7-AdvancedSchema/TripPin.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/7-AdvancedSchema/TripPin.pq
@@ -1,0 +1,165 @@
+﻿section TripPin;
+
+// Data Source Kind description
+TripPin = [
+    Authentication = [
+        Anonymous = []
+    ],
+    Label = "TripPin Part 7 - Advanced Schema"
+];
+
+// Data Source UI publishing description
+TripPin.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "TripPin Advanced Schema", "TripPin Advanced Schema" }
+];
+
+//
+// Implementation
+// 
+
+DefaultRequestHeaders = [
+    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
+    #"OData-MaxVersion" = "4.0"                             // we only support v4
+];
+
+BaseUrl = "http://services.odata.org/v4/TripPinService/";
+
+// Define our top level table types
+AirlinesType = type table [ AirlineCode = text, Name = text ];
+
+AirportsType = type table [
+    Name = text,
+    IataCode = text,
+    Location = LocationType
+];
+
+PeopleType = type table [
+    UserName = text,
+    FirstName = text,
+    LastName = text,
+    Emails = {text},
+    AddressInfo = {nullable LocationType},
+    Gender = nullable text,
+    Concurrency = Int64.Type
+];
+
+// remaining structured types
+LocationType = type [
+    Address = text,
+    City = CityType,
+    Loc = LocType
+];
+
+CityType = type [
+    CountryRegion = text,
+    Name = text,
+    Region = text
+];
+
+LocType = type [
+    #"type" = text,
+    coordinates = {number},
+    crs = CrsType
+];
+
+CrsType = type [
+    #"type" = text,
+    properties = record
+];
+
+SchemaTable = #table({"Entity", "Type"}, {
+    {"Airlines", AirlinesType },    
+    {"Airports", AirportsType },
+    {"People", PeopleType}    
+});
+        
+GetSchemaForEntity = (entity as text) as type => try SchemaTable{[Entity=entity]}[Type] otherwise error "Couldn't find entity: '" & entity &"'";
+
+[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
+
+TripPinNavTable = (url as text) as table =>
+    let
+        // Use our schema table as the source of top level items in the navigation tree
+        entities = Table.SelectColumns(SchemaTable, {"Entity"}),
+        rename = Table.RenameColumns(entities, {{"Entity", "Name"}}),
+        // Add Data as a calculated column
+        withData = Table.AddColumn(rename, "Data", each GetEntity(url, [Name]), type table),
+        // Add ItemKind and ItemName as fixed text values
+        withItemKind = Table.AddColumn(withData, "ItemKind", each "Table", type text),
+        withItemName = Table.AddColumn(withItemKind, "ItemName", each "Table", type text),
+        // Indicate that the node should not be expandable
+        withIsLeaf = Table.AddColumn(withItemName, "IsLeaf", each true, type logical),
+        // Generate the nav table
+        navTable = Table.ToNavigationTable(withIsLeaf, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        navTable;
+
+TripPin.Feed = (url as text, optional schema as type) as table => GetAllPagesByNextLink(url, schema);
+
+GetEntity = (url as text, entity as text) as table => 
+    let
+        fullUrl = Uri.Combine(url, entity),
+        schema = GetSchemaForEntity(entity),
+        result = TripPin.Feed(fullUrl, schema),
+        appliedSchema = Table.ChangeType(result, schema)
+    in
+        appliedSchema;
+
+GetPage = (url as text, optional schema as type) as table =>
+    let
+        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        body = Json.Document(response),
+        nextLink = GetNextLink(body),
+        
+        // If we have no schema, use Table.FromRecords() instead
+        // (and hope that our results all have the same fields).
+        // If we have a schema, expand the record using its field names
+        data =
+            if (schema = null) then
+                Table.FromRecords(body[value])
+            else
+                let
+                    // convert the list of records into a table (single column of records)
+                    asTable = Table.FromList(body[value], Splitter.SplitByNothing(), {"Column1"}),
+                    fields = Record.FieldNames(Type.RecordFields(Type.TableRow(schema))),
+                    expanded = Table.ExpandRecordColumn(asTable, "Column1", fields)
+                in
+                    expanded
+    in
+        data meta [NextLink = nextLink];
+
+// Read all pages of data.
+// After every page, we check the "NextLink" record on the metadata of the previous request.
+// Table.GenerateByPage will keep asking for more pages until we return null.
+GetAllPagesByNextLink = (url as text, optional schema as type) as table =>
+    Table.GenerateByPage((previous) => 
+        let
+            // if previous is null, then this is our first page of data
+            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+            // if NextLink was set to null by the previous call, we know we have no more data
+            page = if (nextLink <> null) then GetPage(nextLink, schema) else null
+        in
+            page
+    );
+
+// In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
+// We look for the '@odata.nextLink' field and simply return null if it doesn't exist.
+GetNextLink = (response) as nullable text => Record.FieldOrDefault(response, "@odata.nextLink");
+
+// 
+// Load common library functions
+// 
+// TEMPORARY WORKAROUND until we're able to reference other M modules
+Extension.LoadFunction = (name as text) =>
+    let
+        binary = Extension.Contents(name),
+        asText = Text.FromBinary(binary)
+    in
+        Expression.Evaluate(asText, #shared);
+
+Table.ChangeType = Extension.LoadFunction("Table.ChangeType.pqm");
+Table.GenerateByPage = Extension.LoadFunction("Table.GenerateByPage.pqm");
+Table.ToNavigationTable = Extension.LoadFunction("Table.ToNavigationTable.pqm");

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/7-AdvancedSchema/TripPin.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/7-AdvancedSchema/TripPin.query.pq
@@ -1,0 +1,315 @@
+﻿section TripPinUnitTests;
+
+shared TripPin.UnitTest =
+[
+    // Put any common variables here if you only want them to be evaluated once
+    RootTable = TripPin.Contents(),
+    Airlines = RootTable{[Name="Airlines"]}[Data],
+    Airports = RootTable{[Name="Airports"]}[Data],
+    People = RootTable{[Name="People"]}[Data],
+
+    // Fact(<Name of the Test>, <Expected Value>, <Actual Value>)
+    // <Expected Value> and <Actual Value> can be a literal or let statement
+    facts =
+    {
+        Fact("Check that we have three entries in our nav table", 3, Table.RowCount(RootTable)),
+        Fact("We have Airline data?", true, not Table.IsEmpty(Airlines)),
+        Fact("We have People data?", true, not Table.IsEmpty(People)),
+        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),        
+        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),        
+        Fact("Airline table has the right fields",
+            {"AirlineCode","Name"},
+            Record.FieldNames(Type.RecordFields(Type.TableRow(Value.Type(Airlines))))
+        ),
+        Fact("Emails is properly typed", type text, Type.ListItem(Value.Type(People{0}[Emails])))
+    },
+
+    report = Facts.Summarize(facts)
+][report];
+
+/// COMMON UNIT TESTING CODE 
+Fact = (_subject as text, _expected, _actual) as record =>
+[   expected = try _expected,
+    safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],
+    actual = try _actual,
+    safeActual = if actual[HasError] then "Actual : "& @ValueToText(actual[Error]) else actual[Value],
+    attempt = try safeExpected = safeActual,
+    result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
+    resultOp = if result = "Success ✓" then " = " else " <> ",
+    addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
+    addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
+    addendumEvalActual = try @ValueToText (safeActual) otherwise "...",
+    fact =
+    [   Result = result &" "& addendumEvalAttempt,
+        Notes =_subject,
+        Details = " ("& addendumEvalExpected & resultOp & addendumEvalActual &")"
+    ]
+][fact];
+
+Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject,_{0},_{1}));
+
+Facts.Summarize = (_facts as list) as table =>
+[   Fact.CountSuccesses = (count, i) =>
+    [   result = try i[Result],
+        sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
+    ][sum],
+    passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
+    total = List.Count(_facts),
+    format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+    result = if passed = total then "Success" else "⛔",
+    rate = Number.IntegerDivide(100*passed, total),
+    header =
+    [   Result = result,
+        Notes = Text.Format(format, {passed, total-passed}),
+        Details = Text.Format("#{0}% success rate", {rate})
+    ],
+    report = Table.FromRecords(List.Combine({{header},_facts}))
+][report];
+
+ValueToText = (value, optional depth) =>
+    let
+        _canBeIdentifier = (x) =>
+                                        let
+                                            keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                            charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                            charDigit = (c as number) => c>= 48 and c <= 57
+                                        in
+                                            try
+                                                charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                and
+                                                    List.MatchesAll(
+                                                        Text.ToList(x),
+                                                        (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                    )
+                                                and not 
+                                                    List.MatchesAny( keywords, (li)=> li=x )
+                                            otherwise 
+                                                false,
+    
+        Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+        Serialize.Date =        (x) => "#date(" & 
+                                       Text.From(Date.Year(x))  & ", " & 
+                                       Text.From(Date.Month(x)) & ", " & 
+                                       Text.From(Date.Day(x))   & ") ",
+
+        Serialize.Datetime =    (x) => "#datetime(" &
+                                       Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                       Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                       Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                       Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                       Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                       Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+        Serialize.Datetimezone =(x) => let 
+                                          dtz = DateTimeZone.ToRecord(x) 
+                                       in
+                                          "#datetimezone(" & 
+                                          Text.From(dtz[Year])        & ", " &
+                                          Text.From(dtz[Month])       & ", " &
+                                          Text.From(dtz[Day])         & ", " &
+                                          Text.From(dtz[Hour])        & ", " &
+                                          Text.From(dtz[Minute])      & ", " &
+                                          Text.From(dtz[Second])      & ", " &
+                                          Text.From(dtz[ZoneHours])   & ", " &
+                                          Text.From(dtz[ZoneMinutes]) & ") ",
+
+        Serialize.Duration =    (x) => let
+                                          dur = Duration.ToRecord(x)
+                                       in
+                                          "#duration(" &
+                                          Text.From(dur[Days])    & ", " &
+                                          Text.From(dur[Hours])   & ", " &
+                                          Text.From(dur[Minutes]) & ", " &
+                                          Text.From(dur[Seconds]) & ") ",
+
+        Serialize.Function =    (x) => _serialize_function_param_type(
+                                          Type.FunctionParameters(Value.Type(x)),
+                                          Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                       " as " &
+                                       _serialize_function_return_type(Value.Type(x)) &
+                                       " => (...) ",
+
+        Serialize.List =        (x) => "{" & 
+                                       List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                       "} ",
+
+        Serialize.Logical =     (x) => Text.From(x),
+
+        Serialize.Null =        (x) => "null",
+
+        Serialize.Number =      (x) => 
+                                    let Text.From = (i as number) as text => 
+                                        if Number.IsNaN(i) then "#nan" else
+                                        if i=Number.PositiveInfinity then "#infinity" else
+                                        if i=Number.NegativeInfinity then "-#infinity" else
+                                        Text.From(i)
+                                    in
+                                        Text.From(x),
+
+        Serialize.Record =      (x) => "[ " &
+                                       List.Accumulate(
+                                            Record.FieldNames(x), 
+                                            "", 
+                                            (seed,item) => 
+                                                (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                       ) &
+                                       " ] ",
+
+        Serialize.Table =       (x) => "#table( type " &
+                                        _serialize_table_type(Value.Type(x)) &
+                                        ", " &
+                                        Serialize(Table.ToRows(x)) &
+                                        ") ",
+                                    
+        Serialize.Text =        (x) => """" & 
+                                       _serialize_text_content(x) & 
+                                       """",
+
+        _serialize_text_content =  (x) => let 
+                                            escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                        in
+                                        List.Accumulate(
+                                           List.Transform(
+                                               Text.ToList(x),
+                                               (c) => let n=Character.ToNumber(c) in 
+                                                        if n = 9   then "#(#)(tab)" else
+                                                        if n = 10  then "#(#)(lf)"  else
+                                                        if n = 13  then "#(#)(cr)"  else
+                                                        if n = 34  then """"""      else
+                                                        if n = 35  then "#(#)(#)"   else
+                                                        if n < 32  then escapeText(n) else 
+                                                        if n < 127 then Character.FromNumber(n) else 
+                                                        escapeText(n) 
+                                            ),
+                                            "",
+                                            (s,i)=>s&i
+                                        ),
+        
+        Serialize.Identifier =   (x) => 
+                                        if _canBeIdentifier(x) then 
+                                            x 
+                                        else 
+                                            "#""" &
+                                            _serialize_text_content(x) &
+                                            """",
+
+        Serialize.Time =        (x) => "#time(" &
+                                       Text.From(Time.Hour(x))   & ", " & 
+                                       Text.From(Time.Minute(x)) & ", " & 
+                                       Text.From(Time.Second(x)) & ") ",
+                                
+        Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+        _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                    let
+                                        isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                        isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                        isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                        isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                    in
+                                
+                                        if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                        if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                        if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                        if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                        if x = type any then "any" else
+                                        let base = Type.NonNullable(x) in
+                                          (if Type.IsNullable(x) then "nullable " else "") &       
+                                          (if base = type anynonnull then "anynonnull" else                
+                                          if base = type binary then "binary" else                
+                                          if base = type date   then "date"   else
+                                          if base = type datetime then "datetime" else
+                                          if base = type datetimezone then "datetimezone" else
+                                          if base = type duration then "duration" else
+                                          if base = type logical then "logical" else
+                                          if base = type none then "none" else
+                                          if base = type null then "null" else
+                                          if base = type number then "number" else
+                                          if base = type text then "text" else 
+                                          if base = type time then "time" else 
+                                          if base = type type then "type" else 
+                                      
+                                          /* Abstract types: */
+                                          if base = type function then "function" else
+                                          if base = type table then "table" else
+                                          if base = type record then "record" else
+                                          if base = type list then "list" else
+                                      
+                                          "any /*Actually unknown type*/"),
+
+        _serialize_table_type =     (x) => 
+                                           let 
+                                             schema = Type.TableSchema(x)
+                                           in
+                                             "table " &
+                                             (if Table.IsEmpty(schema) then "" else 
+                                                 "[" & List.Accumulate(
+                                                    List.Transform(
+                                                        Table.ToRecords(Table.Sort(schema,"Position")),
+                                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                    "",
+                                                    (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                ) & "] " ),
+
+        _serialize_record_type =    (x) => 
+                                            let flds = Type.RecordFields(x)
+                                            in
+                                                if Record.FieldCount(flds)=0 then "record" else
+                                                    "[" & List.Accumulate(
+                                                        Record.FieldNames(flds),
+                                                        "",
+                                                        (seed,item) => 
+                                                            seed &
+                                                            (if seed<>"" then ", " else "") &
+                                                            (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                    ) & 
+                                                    (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                    "]",
+
+        _serialize_function_type =  (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(x),
+                                              Type.FunctionRequiredParameters(x) ) &
+                                            " as " &
+                                            _serialize_function_return_type(x),
+    
+        _serialize_function_param_type = (t,n) => 
+                                let
+                                    funsig = Table.ToRecords(
+                                        Table.TransformColumns(
+                                            Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                            { "isOptional", (x)=> x>n } ) )
+                                in
+                                    "(" & 
+                                    List.Accumulate(
+                                        funsig,
+                                        "",
+                                        (seed,item)=>
+                                            (if seed="" then "" else seed & ", ") &
+                                            (if item[isOptional] then "optional " else "") &
+                                            Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                     & ")",
+
+        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+        Serialize = (x) as text => 
+                           if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                           if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                           if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                           if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                           if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                           if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                           if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                           if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                           if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                           if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                           if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                           if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                           if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                           if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                           if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                           "[#_unable_to_serialize_#]"                     
+    in
+        try Serialize(value) otherwise "<serialization failed>";

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/Diagnostics.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/Diagnostics.pqm
@@ -1,0 +1,275 @@
+﻿let
+    Diagnostics.LogValue = (prefix, value) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogFailure = (text, function) =>
+        let
+            result = try function()
+        in
+            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
+
+    Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
+        Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
+
+    Diagnostics.WrapHandlers = (handlers as record) as record =>
+        Record.FromList(
+            List.Transform(
+                Record.FieldNames(handlers),
+                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
+            Record.FieldNames(handlers)),
+
+    Diagnostics.ValueToText = (value) =>
+        let
+            _canBeIdentifier = (x) =>
+                                            let
+                                                keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                                charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                                charDigit = (c as number) => c>= 48 and c <= 57
+                                            in
+                                                try
+                                                    charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                    and
+                                                        List.MatchesAll(
+                                                            Text.ToList(x),
+                                                            (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                        )
+                                                    and not 
+                                                        List.MatchesAny( keywords, (li)=> li=x )
+                                                otherwise 
+                                                    false,
+    
+            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+            Serialize.Date =        (x) => "#date(" & 
+                                           Text.From(Date.Year(x))  & ", " & 
+                                           Text.From(Date.Month(x)) & ", " & 
+                                           Text.From(Date.Day(x))   & ") ",
+
+            Serialize.Datetime =    (x) => "#datetime(" &
+                                           Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                           Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                           Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                           Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                           Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                           Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+            Serialize.Datetimezone =(x) => let 
+                                              dtz = DateTimeZone.ToRecord(x) 
+                                           in
+                                              "#datetimezone(" & 
+                                              Text.From(dtz[Year])        & ", " &
+                                              Text.From(dtz[Month])       & ", " &
+                                              Text.From(dtz[Day])         & ", " &
+                                              Text.From(dtz[Hour])        & ", " &
+                                              Text.From(dtz[Minute])      & ", " &
+                                              Text.From(dtz[Second])      & ", " &
+                                              Text.From(dtz[ZoneHours])   & ", " &
+                                              Text.From(dtz[ZoneMinutes]) & ") ",
+
+            Serialize.Duration =    (x) => let
+                                              dur = Duration.ToRecord(x)
+                                           in
+                                              "#duration(" &
+                                              Text.From(dur[Days])    & ", " &
+                                              Text.From(dur[Hours])   & ", " &
+                                              Text.From(dur[Minutes]) & ", " &
+                                              Text.From(dur[Seconds]) & ") ",
+
+            Serialize.Function =    (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(Value.Type(x)),
+                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                           " as " &
+                                           _serialize_function_return_type(Value.Type(x)) &
+                                           " => (...) ",
+
+            Serialize.List =        (x) => "{" & 
+                                           List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                           "} ",
+
+            Serialize.Logical =     (x) => Text.From(x),
+
+            Serialize.Null =        (x) => "null",
+
+            Serialize.Number =      (x) => 
+                                        let Text.From = (i as number) as text => 
+                                            if Number.IsNaN(i) then "#nan" else
+                                            if i=Number.PositiveInfinity then "#infinity" else
+                                            if i=Number.NegativeInfinity then "-#infinity" else
+                                            Text.From(i)
+                                        in
+                                            Text.From(x),
+
+            Serialize.Record =      (x) => "[ " &
+                                           List.Accumulate(
+                                                Record.FieldNames(x), 
+                                                "", 
+                                                (seed,item) => 
+                                                    (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                           ) &
+                                           " ] ",
+
+            Serialize.Table =       (x) => "#table( type " &
+                                            _serialize_table_type(Value.Type(x)) &
+                                            ", " &
+                                            Serialize(Table.ToRows(x)) &
+                                            ") ",
+                                    
+            Serialize.Text =        (x) => """" & 
+                                           _serialize_text_content(x) & 
+                                           """",
+
+            _serialize_text_content =  (x) => let 
+                                                escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                            in
+                                            List.Accumulate(
+                                               List.Transform(
+                                                   Text.ToList(x),
+                                                   (c) => let n=Character.ToNumber(c) in 
+                                                            if n = 9   then "#(#)(tab)" else
+                                                            if n = 10  then "#(#)(lf)"  else
+                                                            if n = 13  then "#(#)(cr)"  else
+                                                            if n = 34  then """"""      else
+                                                            if n = 35  then "#(#)(#)"   else
+                                                            if n < 32  then escapeText(n) else 
+                                                            if n < 127 then Character.FromNumber(n) else 
+                                                            escapeText(n) 
+                                                ),
+                                                "",
+                                                (s,i)=>s&i
+                                            ),
+        
+            Serialize.Identifier =   (x) => 
+                                            if _canBeIdentifier(x) then 
+                                                x 
+                                            else 
+                                                "#""" &
+                                                _serialize_text_content(x) &
+                                                """",
+
+            Serialize.Time =        (x) => "#time(" &
+                                           Text.From(Time.Hour(x))   & ", " & 
+                                           Text.From(Time.Minute(x)) & ", " & 
+                                           Text.From(Time.Second(x)) & ") ",
+                                
+            Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                        let
+                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                        in
+                                
+                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                            if x = type any then "any" else
+                                            let base = Type.NonNullable(x) in
+                                              (if Type.IsNullable(x) then "nullable " else "") &       
+                                              (if base = type anynonnull then "anynonnull" else                
+                                              if base = type binary then "binary" else                
+                                              if base = type date   then "date"   else
+                                              if base = type datetime then "datetime" else
+                                              if base = type datetimezone then "datetimezone" else
+                                              if base = type duration then "duration" else
+                                              if base = type logical then "logical" else
+                                              if base = type none then "none" else
+                                              if base = type null then "null" else
+                                              if base = type number then "number" else
+                                              if base = type text then "text" else 
+                                              if base = type time then "time" else 
+                                              if base = type type then "type" else 
+                                      
+                                              /* Abstract types: */
+                                              if base = type function then "function" else
+                                              if base = type table then "table" else
+                                              if base = type record then "record" else
+                                              if base = type list then "list" else
+                                      
+                                              "any /*Actually unknown type*/"),
+
+            _serialize_table_type =     (x) => 
+                                               let 
+                                                 schema = Type.TableSchema(x)
+                                               in
+                                                 "table " &
+                                                 (if Table.IsEmpty(schema) then "" else 
+                                                     "[" & List.Accumulate(
+                                                        List.Transform(
+                                                            Table.ToRecords(Table.Sort(schema,"Position")),
+                                                            each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                        "",
+                                                        (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                    ) & "] " ),
+
+            _serialize_record_type =    (x) => 
+                                                let flds = Type.RecordFields(x)
+                                                in
+                                                    if Record.FieldCount(flds)=0 then "record" else
+                                                        "[" & List.Accumulate(
+                                                            Record.FieldNames(flds),
+                                                            "",
+                                                            (seed,item) => 
+                                                                seed &
+                                                                (if seed<>"" then ", " else "") &
+                                                                (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                        ) & 
+                                                        (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                        "]",
+
+            _serialize_function_type =  (x) => _serialize_function_param_type(
+                                                  Type.FunctionParameters(x),
+                                                  Type.FunctionRequiredParameters(x) ) &
+                                                " as " &
+                                                _serialize_function_return_type(x),
+    
+            _serialize_function_param_type = (t,n) => 
+                                    let
+                                        funsig = Table.ToRecords(
+                                            Table.TransformColumns(
+                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                                { "isOptional", (x)=> x>n } ) )
+                                    in
+                                        "(" & 
+                                        List.Accumulate(
+                                            funsig,
+                                            "",
+                                            (seed,item)=>
+                                                (if seed="" then "" else seed & ", ") &
+                                                (if item[isOptional] then "optional " else "") &
+                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                         & ")",
+
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+            Serialize = (x) as text => 
+                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                               if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                               if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                               if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                               if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                               if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                               if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                               if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                               if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                               if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                               "[#_unable_to_serialize_#]"                     
+        in
+            try Serialize(value) otherwise "<serialization failed>"
+in
+    [ 
+        LogValue = Diagnostics.LogValue,
+        LogValue2 = Diagnostics.LogValue2,
+        LogFailure = Diagnostics.LogFailure,
+        WrapFunctionResult = Diagnostics.WrapFunctionResult,
+        WrapHandlers = Diagnostics.WrapHandlers,
+        ValueToText = Diagnostics.ValueToText
+    ]

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/Table.ChangeType.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/Table.ChangeType.pqm
@@ -1,0 +1,138 @@
+﻿let
+    // table should be an actual Table.Type, or a List.Type of Records
+    Table.ChangeType = (table, tableType as type) as nullable table =>
+        // we only operate on table types
+        if (not Type.Is(tableType, type table)) then error "type argument should be a table type" else
+        // if we have a null value, just return it
+        if (table = null) then table else
+        let
+            columnsForType = Type.RecordFields(Type.TableRow(tableType)),
+            columnsAsTable = Record.ToTable(columnsForType),
+            schema = Table.ExpandRecordColumn(columnsAsTable, "Value", {"Type"}, {"Type"}),
+            previousMeta = Value.Metadata(tableType),
+
+            // make sure we have a table
+            parameterType = Value.Type(table),
+            _table =
+                if (Type.Is(parameterType, type table)) then table
+                else if (Type.Is(parameterType, type list)) then
+                    let
+                        asTable = Table.FromList(table, Splitter.SplitByNothing(), {"Column1"}),
+                        firstValueType = Value.Type(Table.FirstValue(asTable, null)),
+                        result =
+                            // if the member is a record (as expected), then expand it. 
+                            if (Type.Is(firstValueType, type record)) then
+                                Table.ExpandRecordColumn(asTable, "Column1", schema[Name])
+                            else
+                                error Error.Record("Error.Parameter", "table argument is a list, but not a list of records", [ ValueType = firstValueType ])
+                    in
+                        if (List.IsEmpty(table)) then
+                            #table({"a"}, {})
+                        else result
+                else
+                    error Error.Record("Error.Parameter", "table argument should be a table or list of records", [ValueType = parameterType]),
+
+            reordered = Table.SelectColumns(_table, schema[Name], MissingField.UseNull),
+
+            // process primitive values - this will call Table.TransformColumnTypes
+            map = (t) => if Type.Is(t, type table) or Type.Is(t, type list) or Type.Is(t, type record) or t = type any then null else t,        
+            mapped = Table.TransformColumns(schema, {"Type", map}),
+            omitted = Table.SelectRows(mapped, each [Type] <> null),
+            existingColumns = Table.ColumnNames(reordered),
+            removeMissing = Table.SelectRows(omitted, each List.Contains(existingColumns, [Name])),
+            primativeTransforms = Table.ToRows(removeMissing),
+            changedPrimatives = Table.TransformColumnTypes(reordered, primativeTransforms),
+        
+            // Get the list of transforms we'll use for Record types
+            recordColumns = Table.SelectRows(schema, each Type.Is([Type], type record)),
+            recordTypeTransformations = Table.AddColumn(recordColumns, "RecordTransformations", each (r) => Record.ChangeType(r, [Type]), type function),
+            recordChanges = Table.ToRows(Table.SelectColumns(recordTypeTransformations, {"Name", "RecordTransformations"})),
+
+            // Get the list of transforms we'll use for List types
+            listColumns = Table.SelectRows(schema, each Type.Is([Type], type list)),
+            listTransforms = Table.AddColumn(listColumns, "ListTransformations", each (t) => List.ChangeType(t, [Type]), Function.Type),
+            listChanges = Table.ToRows(Table.SelectColumns(listTransforms, {"Name", "ListTransformations"})),
+
+            // Get the list of transforms we'll use for Table types
+            tableColumns = Table.SelectRows(schema, each Type.Is([Type], type table)),
+            tableTransforms = Table.AddColumn(tableColumns, "TableTransformations", each (t) => @Table.ChangeType(t, [Type]), Function.Type),
+            tableChanges = Table.ToRows(Table.SelectColumns(tableTransforms, {"Name", "TableTransformations"})),
+
+            // Perform all of our transformations
+            allColumnTransforms = recordChanges & listChanges & tableChanges,
+            changedRecordTypes = if (List.IsEmpty(allColumnTransforms)) then changedPrimatives else Table.TransformColumns(changedPrimatives, allColumnTransforms, null, MissingField.Ignore),
+
+            // set final type
+            withType = Value.ReplaceType(changedRecordTypes, tableType)
+        in
+            if (List.IsEmpty(Record.FieldNames(columnsForType))) then table else withType meta previousMeta,
+
+    // If given a generic record type (no predefined fields), the original record is returned
+    Record.ChangeType = (record as record, recordType as type) =>
+        let
+            // record field format is [ fieldName = [ Type = type, Optional = logical], ... ]
+            fields = try Type.RecordFields(recordType) otherwise error "Record.ChangeType: failed to get record fields. Is this a record type?",
+            fieldNames = Record.FieldNames(fields),
+            fieldTable = Record.ToTable(fields),
+            optionalFields = Table.SelectRows(fieldTable, each [Value][Optional])[Name],
+            requiredFields = List.Difference(fieldNames, optionalFields),
+            // make sure all required fields exist
+            withRequired = Record.SelectFields(record, requiredFields, MissingField.UseNull),
+            // append optional fields
+            withOptional = withRequired & Record.SelectFields(record, optionalFields, MissingField.Ignore),
+            // set types
+            transforms = GetTransformsForType(recordType),
+            withTypes = Record.TransformFields(withOptional, transforms, MissingField.Ignore),
+            // order the same as the record type
+            reorder = Record.ReorderFields(withTypes, fieldNames, MissingField.Ignore)
+        in
+            if (List.IsEmpty(fieldNames)) then record else reorder,
+
+    List.ChangeType = (list as list, listType as type) =>
+        if (not Type.Is(listType, type list)) then error "type argument should be a list type" else
+        let
+            listItemType = Type.ListItem(listType),
+            transform = GetTransformByType(listItemType),
+            modifiedValues = List.Transform(list, transform),
+            typed = Value.ReplaceType(modifiedValues, listType)
+        in
+            typed,
+
+    // Returns a table type for the provided schema table
+    Schema.ToTableType = (schema as table) as type =>
+        let
+            toList = List.Transform(schema[Type], (t) => [Type=t, Optional=false]),
+            toRecord = Record.FromList(toList, schema[Name]),
+            toType = Type.ForRecord(toRecord, false),
+            previousMeta = Value.Metadata(schema)
+        in
+            type table (toType) meta previousMeta,
+
+    // Returns a list of transformations that can be passed to Table.TransformColumns, or Record.TransformFields
+    // Format: {"Column", (f) => ...) .... ex: {"A", Number.From}
+    GetTransformsForType = (_type as type) as list =>
+        let
+            fieldsOrColumns = if (Type.Is(_type, type record)) then Type.RecordFields(_type)
+                            else if (Type.Is(_type, type table)) then Type.RecordFields(Type.TableRow(_type))
+                            else error "GetTransformsForType: record or table type expected",
+            toTable = Record.ToTable(fieldsOrColumns),
+            transformColumn = Table.AddColumn(toTable, "Transform", each GetTransformByType([Value][Type]), Function.Type),
+            transformMap = Table.ToRows(Table.SelectColumns(transformColumn, {"Name", "Transform"}))
+        in
+            transformMap,
+
+    GetTransformByType = (_type as type) as function =>
+                if (Type.Is(_type, type number)) then Number.From
+        else if (Type.Is(_type, type text)) then Text.From
+        else if (Type.Is(_type, type date)) then Date.From
+        else if (Type.Is(_type, type datetime)) then DateTime.From
+        else if (Type.Is(_type, type duration)) then Duration.From
+        else if (Type.Is(_type, type datetimezone)) then DateTimeZone.From
+        else if (Type.Is(_type, type logical)) then Logical.From
+        else if (Type.Is(_type, type time)) then Time.From
+        else if (Type.Is(_type, type record)) then (t) => if (t <> null) then @Record.ChangeType(t, _type) else t
+        else if (Type.Is(_type, type table)) then (t) => if (t <> null) then @Table.ChangeType(t, _type) else t
+        else if (Type.Is(_type, type list)) then (t) => if (t <> null) then @List.ChangeType(t, _type) else t
+        else (t) => t
+in
+    Table.ChangeType

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/Table.GenerateByPage.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/Table.GenerateByPage.pqm
@@ -1,0 +1,23 @@
+﻿(getNextPage as function) as table =>
+    let        
+        listOfPages = List.Generate(
+            () => getNextPage(null),            // get the first page of data
+            (lastPage) => lastPage <> null,     // stop when the function returns null
+            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+        ),
+        // concatenate the pages together
+        tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
+        firstRow = tableOfPages{0}?
+    in
+        // if we didn't get back any pages of data, return an empty table
+        // otherwise set the table type based on the columns of the first page
+        if (firstRow = null) then
+            Table.FromRows({})
+		// check for empty first table
+		else if (Table.IsEmpty(firstRow[Column1])) then
+			firstRow[Column1]
+        else
+            Value.ReplaceType(
+                Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
+                Value.Type(firstRow[Column1])
+            )

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/Table.ToNavigationTable.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/Table.ToNavigationTable.pqm
@@ -1,0 +1,22 @@
+﻿(
+    table as table,
+    keyColumns as list,
+    nameColumn as text,
+    dataColumn as text,
+    itemKindColumn as text,
+    itemNameColumn as text,
+    isLeafColumn as text
+) as table =>
+    let
+        tableType = Value.Type(table),
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
+        [
+            NavigationTable.NameColumn = nameColumn, 
+            NavigationTable.DataColumn = dataColumn,
+            NavigationTable.ItemKindColumn = itemKindColumn, 
+            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.IsLeafColumn = isLeafColumn
+        ],
+        navigationTable = Value.ReplaceType(table, newTableType)
+    in
+        navigationTable

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/TripPin.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/TripPin.pq
@@ -1,0 +1,187 @@
+﻿section TripPin;
+
+// Data Source Kind description
+TripPin = [
+    Authentication = [
+        Anonymous = []
+    ],
+    Label = "TripPin Part 8 - Diagnostics"
+];
+
+// Data Source UI publishing description
+TripPin.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "TripPin Diagnostics", "TripPin Diagnostics" }
+];
+
+//
+// Implementation
+// 
+
+DefaultRequestHeaders = [
+    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
+    #"OData-MaxVersion" = "4.0"                             // we only support v4
+];
+
+BaseUrl = "http://services.odata.org/v4/TripPinService/";
+
+// Define our top level table types
+AirlinesType = type table [ AirlineCode = text, Name = text ];
+
+AirportsType = type table [
+    Name = text,
+    IataCode = text,
+    Location = LocationType
+];
+
+PeopleType = type table [
+    UserName = text,
+    FirstName = text,
+    LastName = text,
+    Emails = {text},
+    AddressInfo = {nullable LocationType},
+    Gender = nullable text,
+    Concurrency = Int64.Type
+];
+
+// remaining structured types
+LocationType = type [
+    Address = text,
+    City = CityType,
+    Loc = LocType
+];
+
+CityType = type [
+    CountryRegion = text,
+    Name = text,
+    Region = text
+];
+
+LocType = type [
+    #"type" = text,
+    coordinates = {number},
+    crs = CrsType
+];
+
+CrsType = type [
+    #"type" = text,
+    properties = record
+];
+
+SchemaTable = #table({"Entity", "Type"}, {
+    {"Airlines", AirlinesType },    
+    {"Airports", AirportsType },
+    {"People", PeopleType}    
+});
+        
+GetSchemaForEntity = (entity as text) as type =>
+    try 
+        SchemaTable{[Entity=entity]}[Type]
+    otherwise
+        let
+            message = Text.Format("Couldn't find entity: '#{0}'", {entity})
+        in
+            Diagnostics.Trace(TraceLevel.Error, message, () => error message, true);
+
+
+[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
+
+TripPinNavTable = (url as text) as table =>
+    let
+        // Use our schema table as the source of top level items in the navigation tree
+        entities = Table.SelectColumns(SchemaTable, {"Entity"}),
+        rename = Table.RenameColumns(entities, {{"Entity", "Name"}}),
+        // Add Data as a calculated column
+        //withData = Table.AddColumn(rename, "Data", each Diagnostics.LogFailure("Error in GetEntity", () => GetEntity(url, "DoesNotExist")), type table),
+        //withData = Table.AddColumn(rename, "Data", each GetEntity(url, "DoesNotExist"), type table),
+        withData = Table.AddColumn(rename, "Data", each GetEntity(url, [Name]), type table),
+        // Add ItemKind and ItemName as fixed text values
+        withItemKind = Table.AddColumn(withData, "ItemKind", each "Table", type text),
+        withItemName = Table.AddColumn(withItemKind, "ItemName", each "Table", type text),
+        // Indicate that the node should not be expandable
+        withIsLeaf = Table.AddColumn(withItemName, "IsLeaf", each true, type logical),
+        // Generate the nav table
+        navTable = Table.ToNavigationTable(withIsLeaf, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        navTable;
+
+TripPin.Feed = (url as text, optional schema as type) as table =>
+    let
+        _url = Diagnostics.LogValue("Accessing url", url),
+        _schema = Diagnostics.LogValue("Schema type", schema),
+        //result = GetAllPagesByNextLink(url, schema)
+        result = GetAllPagesByNextLink(_url, _schema)
+    in
+        result;
+
+GetEntity = (url as text, entity as text) as table => 
+    let
+        fullUrl = Uri.Combine(url, entity),
+        schema = GetSchemaForEntity(entity),
+        result = TripPin.Feed(fullUrl, schema),
+        appliedSchema = Table.ChangeType(result, schema)
+    in
+        appliedSchema;
+
+GetPage = (url as text, optional schema as type) as table =>
+    let
+        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        body = Json.Document(response),
+        nextLink = GetNextLink(body),
+        
+        // If we have no schema, use Table.FromRecords() instead
+        // (and hope that our results all have the same fields).
+        // If we have a schema, expand the record using its field names
+        data =
+            if (schema = null) then
+                Diagnostics.LogFailure("Error converting response body. Are the records uniform?", () => Table.FromRecords(body[value]))
+            else
+                let
+                    // convert the list of records into a table (single column of records)
+                    asTable = Table.FromList(body[value], Splitter.SplitByNothing(), {"Column1"}),
+                    fields = Record.FieldNames(Type.RecordFields(Type.TableRow(schema))),
+                    expanded = Table.ExpandRecordColumn(asTable, "Column1", fields)
+                in
+                    expanded
+    in
+        data meta [NextLink = nextLink];
+
+// Read all pages of data.
+// After every page, we check the "NextLink" record on the metadata of the previous request.
+// Table.GenerateByPage will keep asking for more pages until we return null.
+GetAllPagesByNextLink = (url as text, optional schema as type) as table =>
+    Table.GenerateByPage((previous) => 
+        let
+            // if previous is null, then this is our first page of data
+            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+            // if NextLink was set to null by the previous call, we know we have no more data
+            page = if (nextLink <> null) then GetPage(nextLink, schema) else null
+        in
+            page
+    );
+
+// In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
+// We look for the '@odata.nextLink' field and simply return null if it doesn't exist.
+GetNextLink = (response) as nullable text => Record.FieldOrDefault(response, "@odata.nextLink");
+
+// 
+// Load common library functions
+// 
+// TEMPORARY WORKAROUND until we're able to reference other M modules
+Extension.LoadFunction = (name as text) =>
+    let
+        binary = Extension.Contents(name),
+        asText = Text.FromBinary(binary)
+    in
+        Expression.Evaluate(asText, #shared);
+
+Table.ChangeType = Extension.LoadFunction("Table.ChangeType.pqm");
+Table.GenerateByPage = Extension.LoadFunction("Table.GenerateByPage.pqm");
+Table.ToNavigationTable = Extension.LoadFunction("Table.ToNavigationTable.pqm");
+
+// Diagnostics module contains multiple functions. We can take the ones we need.
+Diagnostics = Extension.LoadFunction("Diagnostics.pqm");
+Diagnostics.LogValue = Diagnostics[LogValue];
+Diagnostics.LogFailure = Diagnostics[LogFailure];

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/TripPin.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/8-Diagnostics/TripPin.query.pq
@@ -1,0 +1,315 @@
+﻿section TripPinUnitTests;
+
+shared TripPin.UnitTest =
+[
+    // Put any common variables here if you only want them to be evaluated once
+    RootTable = TripPin.Contents(),
+    Airlines = RootTable{[Name="Airlines"]}[Data],
+    Airports = RootTable{[Name="Airports"]}[Data],
+    People = RootTable{[Name="People"]}[Data],
+
+    // Fact(<Name of the Test>, <Expected Value>, <Actual Value>)
+    // <Expected Value> and <Actual Value> can be a literal or let statement
+    facts =
+    {
+        Fact("Check that we have three entries in our nav table", 3, Table.RowCount(RootTable)),
+        Fact("We have Airline data?", true, not Table.IsEmpty(Airlines)),
+        Fact("We have People data?", true, not Table.IsEmpty(People)),
+        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),        
+        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),        
+        Fact("Airline table has the right fields",
+            {"AirlineCode","Name"},
+            Record.FieldNames(Type.RecordFields(Type.TableRow(Value.Type(Airlines))))
+        ),
+        Fact("Emails is properly typed", type text, Type.ListItem(Value.Type(People{0}[Emails])))
+    },
+
+    report = Facts.Summarize(facts)
+][report];
+
+/// COMMON UNIT TESTING CODE 
+Fact = (_subject as text, _expected, _actual) as record =>
+[   expected = try _expected,
+    safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],
+    actual = try _actual,
+    safeActual = if actual[HasError] then "Actual : "& @ValueToText(actual[Error]) else actual[Value],
+    attempt = try safeExpected = safeActual,
+    result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
+    resultOp = if result = "Success ✓" then " = " else " <> ",
+    addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
+    addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
+    addendumEvalActual = try @ValueToText (safeActual) otherwise "...",
+    fact =
+    [   Result = result &" "& addendumEvalAttempt,
+        Notes =_subject,
+        Details = " ("& addendumEvalExpected & resultOp & addendumEvalActual &")"
+    ]
+][fact];
+
+Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject,_{0},_{1}));
+
+Facts.Summarize = (_facts as list) as table =>
+[   Fact.CountSuccesses = (count, i) =>
+    [   result = try i[Result],
+        sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
+    ][sum],
+    passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
+    total = List.Count(_facts),
+    format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+    result = if passed = total then "Success" else "⛔",
+    rate = Number.IntegerDivide(100*passed, total),
+    header =
+    [   Result = result,
+        Notes = Text.Format(format, {passed, total-passed}),
+        Details = Text.Format("#{0}% success rate", {rate})
+    ],
+    report = Table.FromRecords(List.Combine({{header},_facts}))
+][report];
+
+ValueToText = (value, optional depth) =>
+    let
+        _canBeIdentifier = (x) =>
+                                        let
+                                            keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                            charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                            charDigit = (c as number) => c>= 48 and c <= 57
+                                        in
+                                            try
+                                                charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                and
+                                                    List.MatchesAll(
+                                                        Text.ToList(x),
+                                                        (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                    )
+                                                and not 
+                                                    List.MatchesAny( keywords, (li)=> li=x )
+                                            otherwise 
+                                                false,
+    
+        Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+        Serialize.Date =        (x) => "#date(" & 
+                                       Text.From(Date.Year(x))  & ", " & 
+                                       Text.From(Date.Month(x)) & ", " & 
+                                       Text.From(Date.Day(x))   & ") ",
+
+        Serialize.Datetime =    (x) => "#datetime(" &
+                                       Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                       Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                       Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                       Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                       Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                       Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+        Serialize.Datetimezone =(x) => let 
+                                          dtz = DateTimeZone.ToRecord(x) 
+                                       in
+                                          "#datetimezone(" & 
+                                          Text.From(dtz[Year])        & ", " &
+                                          Text.From(dtz[Month])       & ", " &
+                                          Text.From(dtz[Day])         & ", " &
+                                          Text.From(dtz[Hour])        & ", " &
+                                          Text.From(dtz[Minute])      & ", " &
+                                          Text.From(dtz[Second])      & ", " &
+                                          Text.From(dtz[ZoneHours])   & ", " &
+                                          Text.From(dtz[ZoneMinutes]) & ") ",
+
+        Serialize.Duration =    (x) => let
+                                          dur = Duration.ToRecord(x)
+                                       in
+                                          "#duration(" &
+                                          Text.From(dur[Days])    & ", " &
+                                          Text.From(dur[Hours])   & ", " &
+                                          Text.From(dur[Minutes]) & ", " &
+                                          Text.From(dur[Seconds]) & ") ",
+
+        Serialize.Function =    (x) => _serialize_function_param_type(
+                                          Type.FunctionParameters(Value.Type(x)),
+                                          Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                       " as " &
+                                       _serialize_function_return_type(Value.Type(x)) &
+                                       " => (...) ",
+
+        Serialize.List =        (x) => "{" & 
+                                       List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                       "} ",
+
+        Serialize.Logical =     (x) => Text.From(x),
+
+        Serialize.Null =        (x) => "null",
+
+        Serialize.Number =      (x) => 
+                                    let Text.From = (i as number) as text => 
+                                        if Number.IsNaN(i) then "#nan" else
+                                        if i=Number.PositiveInfinity then "#infinity" else
+                                        if i=Number.NegativeInfinity then "-#infinity" else
+                                        Text.From(i)
+                                    in
+                                        Text.From(x),
+
+        Serialize.Record =      (x) => "[ " &
+                                       List.Accumulate(
+                                            Record.FieldNames(x), 
+                                            "", 
+                                            (seed,item) => 
+                                                (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                       ) &
+                                       " ] ",
+
+        Serialize.Table =       (x) => "#table( type " &
+                                        _serialize_table_type(Value.Type(x)) &
+                                        ", " &
+                                        Serialize(Table.ToRows(x)) &
+                                        ") ",
+                                    
+        Serialize.Text =        (x) => """" & 
+                                       _serialize_text_content(x) & 
+                                       """",
+
+        _serialize_text_content =  (x) => let 
+                                            escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                        in
+                                        List.Accumulate(
+                                           List.Transform(
+                                               Text.ToList(x),
+                                               (c) => let n=Character.ToNumber(c) in 
+                                                        if n = 9   then "#(#)(tab)" else
+                                                        if n = 10  then "#(#)(lf)"  else
+                                                        if n = 13  then "#(#)(cr)"  else
+                                                        if n = 34  then """"""      else
+                                                        if n = 35  then "#(#)(#)"   else
+                                                        if n < 32  then escapeText(n) else 
+                                                        if n < 127 then Character.FromNumber(n) else 
+                                                        escapeText(n) 
+                                            ),
+                                            "",
+                                            (s,i)=>s&i
+                                        ),
+        
+        Serialize.Identifier =   (x) => 
+                                        if _canBeIdentifier(x) then 
+                                            x 
+                                        else 
+                                            "#""" &
+                                            _serialize_text_content(x) &
+                                            """",
+
+        Serialize.Time =        (x) => "#time(" &
+                                       Text.From(Time.Hour(x))   & ", " & 
+                                       Text.From(Time.Minute(x)) & ", " & 
+                                       Text.From(Time.Second(x)) & ") ",
+                                
+        Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+        _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                    let
+                                        isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                        isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                        isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                        isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                    in
+                                
+                                        if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                        if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                        if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                        if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                        if x = type any then "any" else
+                                        let base = Type.NonNullable(x) in
+                                          (if Type.IsNullable(x) then "nullable " else "") &       
+                                          (if base = type anynonnull then "anynonnull" else                
+                                          if base = type binary then "binary" else                
+                                          if base = type date   then "date"   else
+                                          if base = type datetime then "datetime" else
+                                          if base = type datetimezone then "datetimezone" else
+                                          if base = type duration then "duration" else
+                                          if base = type logical then "logical" else
+                                          if base = type none then "none" else
+                                          if base = type null then "null" else
+                                          if base = type number then "number" else
+                                          if base = type text then "text" else 
+                                          if base = type time then "time" else 
+                                          if base = type type then "type" else 
+                                      
+                                          /* Abstract types: */
+                                          if base = type function then "function" else
+                                          if base = type table then "table" else
+                                          if base = type record then "record" else
+                                          if base = type list then "list" else
+                                      
+                                          "any /*Actually unknown type*/"),
+
+        _serialize_table_type =     (x) => 
+                                           let 
+                                             schema = Type.TableSchema(x)
+                                           in
+                                             "table " &
+                                             (if Table.IsEmpty(schema) then "" else 
+                                                 "[" & List.Accumulate(
+                                                    List.Transform(
+                                                        Table.ToRecords(Table.Sort(schema,"Position")),
+                                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                    "",
+                                                    (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                ) & "] " ),
+
+        _serialize_record_type =    (x) => 
+                                            let flds = Type.RecordFields(x)
+                                            in
+                                                if Record.FieldCount(flds)=0 then "record" else
+                                                    "[" & List.Accumulate(
+                                                        Record.FieldNames(flds),
+                                                        "",
+                                                        (seed,item) => 
+                                                            seed &
+                                                            (if seed<>"" then ", " else "") &
+                                                            (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                    ) & 
+                                                    (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                    "]",
+
+        _serialize_function_type =  (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(x),
+                                              Type.FunctionRequiredParameters(x) ) &
+                                            " as " &
+                                            _serialize_function_return_type(x),
+    
+        _serialize_function_param_type = (t,n) => 
+                                let
+                                    funsig = Table.ToRecords(
+                                        Table.TransformColumns(
+                                            Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                            { "isOptional", (x)=> x>n } ) )
+                                in
+                                    "(" & 
+                                    List.Accumulate(
+                                        funsig,
+                                        "",
+                                        (seed,item)=>
+                                            (if seed="" then "" else seed & ", ") &
+                                            (if item[isOptional] then "optional " else "") &
+                                            Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                     & ")",
+
+        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+        Serialize = (x) as text => 
+                           if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                           if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                           if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                           if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                           if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                           if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                           if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                           if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                           if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                           if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                           if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                           if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                           if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                           if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                           if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                           "[#_unable_to_serialize_#]"                     
+    in
+        try Serialize(value) otherwise "<serialization failed>";

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/Diagnostics.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/Diagnostics.pqm
@@ -1,0 +1,275 @@
+﻿let
+    Diagnostics.LogValue = (prefix, value) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & (try Diagnostics.ValueToText(value) otherwise "<error getting value>"), value),
+    Diagnostics.LogValue2 = (prefix, value, result, optional delayed) => Diagnostics.Trace(TraceLevel.Information, prefix & ": " & Diagnostics.ValueToText(value), result, delayed),    
+    Diagnostics.LogFailure = (text, function) =>
+        let
+            result = try function()
+        in
+            if result[HasError] then Diagnostics.LogValue2(text, result[Error], () => error result[Error], true) else result[Value],
+
+    Diagnostics.WrapFunctionResult = (innerFunction as function, outerFunction as function) as function =>
+        Function.From(Value.Type(innerFunction), (list) => outerFunction(() => Function.Invoke(innerFunction, list))),
+
+    Diagnostics.WrapHandlers = (handlers as record) as record =>
+        Record.FromList(
+            List.Transform(
+                Record.FieldNames(handlers),
+                (h) => Diagnostics.WrapFunctionResult(Record.Field(handlers, h), (fn) => Diagnostics.LogFailure(h, fn))),
+            Record.FieldNames(handlers)),
+
+    Diagnostics.ValueToText = (value) =>
+        let
+            _canBeIdentifier = (x) =>
+                                            let
+                                                keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                                charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                                charDigit = (c as number) => c>= 48 and c <= 57
+                                            in
+                                                try
+                                                    charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                    and
+                                                        List.MatchesAll(
+                                                            Text.ToList(x),
+                                                            (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                        )
+                                                    and not 
+                                                        List.MatchesAny( keywords, (li)=> li=x )
+                                                otherwise 
+                                                    false,
+    
+            Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+            Serialize.Date =        (x) => "#date(" & 
+                                           Text.From(Date.Year(x))  & ", " & 
+                                           Text.From(Date.Month(x)) & ", " & 
+                                           Text.From(Date.Day(x))   & ") ",
+
+            Serialize.Datetime =    (x) => "#datetime(" &
+                                           Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                           Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                           Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                           Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                           Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                           Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+            Serialize.Datetimezone =(x) => let 
+                                              dtz = DateTimeZone.ToRecord(x) 
+                                           in
+                                              "#datetimezone(" & 
+                                              Text.From(dtz[Year])        & ", " &
+                                              Text.From(dtz[Month])       & ", " &
+                                              Text.From(dtz[Day])         & ", " &
+                                              Text.From(dtz[Hour])        & ", " &
+                                              Text.From(dtz[Minute])      & ", " &
+                                              Text.From(dtz[Second])      & ", " &
+                                              Text.From(dtz[ZoneHours])   & ", " &
+                                              Text.From(dtz[ZoneMinutes]) & ") ",
+
+            Serialize.Duration =    (x) => let
+                                              dur = Duration.ToRecord(x)
+                                           in
+                                              "#duration(" &
+                                              Text.From(dur[Days])    & ", " &
+                                              Text.From(dur[Hours])   & ", " &
+                                              Text.From(dur[Minutes]) & ", " &
+                                              Text.From(dur[Seconds]) & ") ",
+
+            Serialize.Function =    (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(Value.Type(x)),
+                                              Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                           " as " &
+                                           _serialize_function_return_type(Value.Type(x)) &
+                                           " => (...) ",
+
+            Serialize.List =        (x) => "{" & 
+                                           List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                           "} ",
+
+            Serialize.Logical =     (x) => Text.From(x),
+
+            Serialize.Null =        (x) => "null",
+
+            Serialize.Number =      (x) => 
+                                        let Text.From = (i as number) as text => 
+                                            if Number.IsNaN(i) then "#nan" else
+                                            if i=Number.PositiveInfinity then "#infinity" else
+                                            if i=Number.NegativeInfinity then "-#infinity" else
+                                            Text.From(i)
+                                        in
+                                            Text.From(x),
+
+            Serialize.Record =      (x) => "[ " &
+                                           List.Accumulate(
+                                                Record.FieldNames(x), 
+                                                "", 
+                                                (seed,item) => 
+                                                    (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                           ) &
+                                           " ] ",
+
+            Serialize.Table =       (x) => "#table( type " &
+                                            _serialize_table_type(Value.Type(x)) &
+                                            ", " &
+                                            Serialize(Table.ToRows(x)) &
+                                            ") ",
+                                    
+            Serialize.Text =        (x) => """" & 
+                                           _serialize_text_content(x) & 
+                                           """",
+
+            _serialize_text_content =  (x) => let 
+                                                escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                            in
+                                            List.Accumulate(
+                                               List.Transform(
+                                                   Text.ToList(x),
+                                                   (c) => let n=Character.ToNumber(c) in 
+                                                            if n = 9   then "#(#)(tab)" else
+                                                            if n = 10  then "#(#)(lf)"  else
+                                                            if n = 13  then "#(#)(cr)"  else
+                                                            if n = 34  then """"""      else
+                                                            if n = 35  then "#(#)(#)"   else
+                                                            if n < 32  then escapeText(n) else 
+                                                            if n < 127 then Character.FromNumber(n) else 
+                                                            escapeText(n) 
+                                                ),
+                                                "",
+                                                (s,i)=>s&i
+                                            ),
+        
+            Serialize.Identifier =   (x) => 
+                                            if _canBeIdentifier(x) then 
+                                                x 
+                                            else 
+                                                "#""" &
+                                                _serialize_text_content(x) &
+                                                """",
+
+            Serialize.Time =        (x) => "#time(" &
+                                           Text.From(Time.Hour(x))   & ", " & 
+                                           Text.From(Time.Minute(x)) & ", " & 
+                                           Text.From(Time.Second(x)) & ") ",
+                                
+            Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+            _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                        let
+                                            isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                            isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                            isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                            isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                        in
+                                
+                                            if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                            if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                            if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                            if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                            if x = type any then "any" else
+                                            let base = Type.NonNullable(x) in
+                                              (if Type.IsNullable(x) then "nullable " else "") &       
+                                              (if base = type anynonnull then "anynonnull" else                
+                                              if base = type binary then "binary" else                
+                                              if base = type date   then "date"   else
+                                              if base = type datetime then "datetime" else
+                                              if base = type datetimezone then "datetimezone" else
+                                              if base = type duration then "duration" else
+                                              if base = type logical then "logical" else
+                                              if base = type none then "none" else
+                                              if base = type null then "null" else
+                                              if base = type number then "number" else
+                                              if base = type text then "text" else 
+                                              if base = type time then "time" else 
+                                              if base = type type then "type" else 
+                                      
+                                              /* Abstract types: */
+                                              if base = type function then "function" else
+                                              if base = type table then "table" else
+                                              if base = type record then "record" else
+                                              if base = type list then "list" else
+                                      
+                                              "any /*Actually unknown type*/"),
+
+            _serialize_table_type =     (x) => 
+                                               let 
+                                                 schema = Type.TableSchema(x)
+                                               in
+                                                 "table " &
+                                                 (if Table.IsEmpty(schema) then "" else 
+                                                     "[" & List.Accumulate(
+                                                        List.Transform(
+                                                            Table.ToRecords(Table.Sort(schema,"Position")),
+                                                            each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                        "",
+                                                        (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                    ) & "] " ),
+
+            _serialize_record_type =    (x) => 
+                                                let flds = Type.RecordFields(x)
+                                                in
+                                                    if Record.FieldCount(flds)=0 then "record" else
+                                                        "[" & List.Accumulate(
+                                                            Record.FieldNames(flds),
+                                                            "",
+                                                            (seed,item) => 
+                                                                seed &
+                                                                (if seed<>"" then ", " else "") &
+                                                                (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                        ) & 
+                                                        (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                        "]",
+
+            _serialize_function_type =  (x) => _serialize_function_param_type(
+                                                  Type.FunctionParameters(x),
+                                                  Type.FunctionRequiredParameters(x) ) &
+                                                " as " &
+                                                _serialize_function_return_type(x),
+    
+            _serialize_function_param_type = (t,n) => 
+                                    let
+                                        funsig = Table.ToRecords(
+                                            Table.TransformColumns(
+                                                Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                                { "isOptional", (x)=> x>n } ) )
+                                    in
+                                        "(" & 
+                                        List.Accumulate(
+                                            funsig,
+                                            "",
+                                            (seed,item)=>
+                                                (if seed="" then "" else seed & ", ") &
+                                                (if item[isOptional] then "optional " else "") &
+                                                Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                         & ")",
+
+            _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+            Serialize = (x) as text => 
+                               if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                               if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                               if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                               if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                               if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                               if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                               if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                               if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                               if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                               if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                               if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                               if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                               if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                               if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                               if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                               "[#_unable_to_serialize_#]"                     
+        in
+            try Serialize(value) otherwise "<serialization failed>"
+in
+    [ 
+        LogValue = Diagnostics.LogValue,
+        LogValue2 = Diagnostics.LogValue2,
+        LogFailure = Diagnostics.LogFailure,
+        WrapFunctionResult = Diagnostics.WrapFunctionResult,
+        WrapHandlers = Diagnostics.WrapHandlers,
+        ValueToText = Diagnostics.ValueToText
+    ]

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/Table.ChangeType.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/Table.ChangeType.pqm
@@ -1,0 +1,138 @@
+﻿let
+    // table should be an actual Table.Type, or a List.Type of Records
+    Table.ChangeType = (table, tableType as type) as nullable table =>
+        // we only operate on table types
+        if (not Type.Is(tableType, type table)) then error "type argument should be a table type" else
+        // if we have a null value, just return it
+        if (table = null) then table else
+        let
+            columnsForType = Type.RecordFields(Type.TableRow(tableType)),
+            columnsAsTable = Record.ToTable(columnsForType),
+            schema = Table.ExpandRecordColumn(columnsAsTable, "Value", {"Type"}, {"Type"}),
+            previousMeta = Value.Metadata(tableType),
+
+            // make sure we have a table
+            parameterType = Value.Type(table),
+            _table =
+                if (Type.Is(parameterType, type table)) then table
+                else if (Type.Is(parameterType, type list)) then
+                    let
+                        asTable = Table.FromList(table, Splitter.SplitByNothing(), {"Column1"}),
+                        firstValueType = Value.Type(Table.FirstValue(asTable, null)),
+                        result =
+                            // if the member is a record (as expected), then expand it. 
+                            if (Type.Is(firstValueType, type record)) then
+                                Table.ExpandRecordColumn(asTable, "Column1", schema[Name])
+                            else
+                                error Error.Record("Error.Parameter", "table argument is a list, but not a list of records", [ ValueType = firstValueType ])
+                    in
+                        if (List.IsEmpty(table)) then
+                            #table({"a"}, {})
+                        else result
+                else
+                    error Error.Record("Error.Parameter", "table argument should be a table or list of records", [ValueType = parameterType]),
+
+            reordered = Table.SelectColumns(_table, schema[Name], MissingField.UseNull),
+
+            // process primitive values - this will call Table.TransformColumnTypes
+            map = (t) => if Type.Is(t, type table) or Type.Is(t, type list) or Type.Is(t, type record) or t = type any then null else t,        
+            mapped = Table.TransformColumns(schema, {"Type", map}),
+            omitted = Table.SelectRows(mapped, each [Type] <> null),
+            existingColumns = Table.ColumnNames(reordered),
+            removeMissing = Table.SelectRows(omitted, each List.Contains(existingColumns, [Name])),
+            primativeTransforms = Table.ToRows(removeMissing),
+            changedPrimatives = Table.TransformColumnTypes(reordered, primativeTransforms),
+        
+            // Get the list of transforms we'll use for Record types
+            recordColumns = Table.SelectRows(schema, each Type.Is([Type], type record)),
+            recordTypeTransformations = Table.AddColumn(recordColumns, "RecordTransformations", each (r) => Record.ChangeType(r, [Type]), type function),
+            recordChanges = Table.ToRows(Table.SelectColumns(recordTypeTransformations, {"Name", "RecordTransformations"})),
+
+            // Get the list of transforms we'll use for List types
+            listColumns = Table.SelectRows(schema, each Type.Is([Type], type list)),
+            listTransforms = Table.AddColumn(listColumns, "ListTransformations", each (t) => List.ChangeType(t, [Type]), Function.Type),
+            listChanges = Table.ToRows(Table.SelectColumns(listTransforms, {"Name", "ListTransformations"})),
+
+            // Get the list of transforms we'll use for Table types
+            tableColumns = Table.SelectRows(schema, each Type.Is([Type], type table)),
+            tableTransforms = Table.AddColumn(tableColumns, "TableTransformations", each (t) => @Table.ChangeType(t, [Type]), Function.Type),
+            tableChanges = Table.ToRows(Table.SelectColumns(tableTransforms, {"Name", "TableTransformations"})),
+
+            // Perform all of our transformations
+            allColumnTransforms = recordChanges & listChanges & tableChanges,
+            changedRecordTypes = if (List.IsEmpty(allColumnTransforms)) then changedPrimatives else Table.TransformColumns(changedPrimatives, allColumnTransforms, null, MissingField.Ignore),
+
+            // set final type
+            withType = Value.ReplaceType(changedRecordTypes, tableType)
+        in
+            if (List.IsEmpty(Record.FieldNames(columnsForType))) then table else withType meta previousMeta,
+
+    // If given a generic record type (no predefined fields), the original record is returned
+    Record.ChangeType = (record as record, recordType as type) =>
+        let
+            // record field format is [ fieldName = [ Type = type, Optional = logical], ... ]
+            fields = try Type.RecordFields(recordType) otherwise error "Record.ChangeType: failed to get record fields. Is this a record type?",
+            fieldNames = Record.FieldNames(fields),
+            fieldTable = Record.ToTable(fields),
+            optionalFields = Table.SelectRows(fieldTable, each [Value][Optional])[Name],
+            requiredFields = List.Difference(fieldNames, optionalFields),
+            // make sure all required fields exist
+            withRequired = Record.SelectFields(record, requiredFields, MissingField.UseNull),
+            // append optional fields
+            withOptional = withRequired & Record.SelectFields(record, optionalFields, MissingField.Ignore),
+            // set types
+            transforms = GetTransformsForType(recordType),
+            withTypes = Record.TransformFields(withOptional, transforms, MissingField.Ignore),
+            // order the same as the record type
+            reorder = Record.ReorderFields(withTypes, fieldNames, MissingField.Ignore)
+        in
+            if (List.IsEmpty(fieldNames)) then record else reorder,
+
+    List.ChangeType = (list as list, listType as type) =>
+        if (not Type.Is(listType, type list)) then error "type argument should be a list type" else
+        let
+            listItemType = Type.ListItem(listType),
+            transform = GetTransformByType(listItemType),
+            modifiedValues = List.Transform(list, transform),
+            typed = Value.ReplaceType(modifiedValues, listType)
+        in
+            typed,
+
+    // Returns a table type for the provided schema table
+    Schema.ToTableType = (schema as table) as type =>
+        let
+            toList = List.Transform(schema[Type], (t) => [Type=t, Optional=false]),
+            toRecord = Record.FromList(toList, schema[Name]),
+            toType = Type.ForRecord(toRecord, false),
+            previousMeta = Value.Metadata(schema)
+        in
+            type table (toType) meta previousMeta,
+
+    // Returns a list of transformations that can be passed to Table.TransformColumns, or Record.TransformFields
+    // Format: {"Column", (f) => ...) .... ex: {"A", Number.From}
+    GetTransformsForType = (_type as type) as list =>
+        let
+            fieldsOrColumns = if (Type.Is(_type, type record)) then Type.RecordFields(_type)
+                            else if (Type.Is(_type, type table)) then Type.RecordFields(Type.TableRow(_type))
+                            else error "GetTransformsForType: record or table type expected",
+            toTable = Record.ToTable(fieldsOrColumns),
+            transformColumn = Table.AddColumn(toTable, "Transform", each GetTransformByType([Value][Type]), Function.Type),
+            transformMap = Table.ToRows(Table.SelectColumns(transformColumn, {"Name", "Transform"}))
+        in
+            transformMap,
+
+    GetTransformByType = (_type as type) as function =>
+                if (Type.Is(_type, type number)) then Number.From
+        else if (Type.Is(_type, type text)) then Text.From
+        else if (Type.Is(_type, type date)) then Date.From
+        else if (Type.Is(_type, type datetime)) then DateTime.From
+        else if (Type.Is(_type, type duration)) then Duration.From
+        else if (Type.Is(_type, type datetimezone)) then DateTimeZone.From
+        else if (Type.Is(_type, type logical)) then Logical.From
+        else if (Type.Is(_type, type time)) then Time.From
+        else if (Type.Is(_type, type record)) then (t) => if (t <> null) then @Record.ChangeType(t, _type) else t
+        else if (Type.Is(_type, type table)) then (t) => if (t <> null) then @Table.ChangeType(t, _type) else t
+        else if (Type.Is(_type, type list)) then (t) => if (t <> null) then @List.ChangeType(t, _type) else t
+        else (t) => t
+in
+    Table.ChangeType

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/Table.GenerateByPage.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/Table.GenerateByPage.pqm
@@ -1,0 +1,23 @@
+﻿(getNextPage as function) as table =>
+    let        
+        listOfPages = List.Generate(
+            () => getNextPage(null),            // get the first page of data
+            (lastPage) => lastPage <> null,     // stop when the function returns null
+            (lastPage) => getNextPage(lastPage) // pass the previous page to the next function call
+        ),
+        // concatenate the pages together
+        tableOfPages = Table.FromList(listOfPages, Splitter.SplitByNothing(), {"Column1"}),
+        firstRow = tableOfPages{0}?
+    in
+        // if we didn't get back any pages of data, return an empty table
+        // otherwise set the table type based on the columns of the first page
+        if (firstRow = null) then
+            Table.FromRows({})
+		// check for empty first table
+		else if (Table.IsEmpty(firstRow[Column1])) then
+			firstRow[Column1]
+        else
+            Value.ReplaceType(
+                Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
+                Value.Type(firstRow[Column1])
+            )

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/Table.ToNavigationTable.pqm
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/Table.ToNavigationTable.pqm
@@ -1,0 +1,22 @@
+﻿(
+    table as table,
+    keyColumns as list,
+    nameColumn as text,
+    dataColumn as text,
+    itemKindColumn as text,
+    itemNameColumn as text,
+    isLeafColumn as text
+) as table =>
+    let
+        tableType = Value.Type(table),
+        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
+        [
+            NavigationTable.NameColumn = nameColumn, 
+            NavigationTable.DataColumn = dataColumn,
+            NavigationTable.ItemKindColumn = itemKindColumn, 
+            Preview.DelayColumn = itemNameColumn, 
+            NavigationTable.IsLeafColumn = isLeafColumn
+        ],
+        navigationTable = Value.ReplaceType(table, newTableType)
+    in
+        navigationTable

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/TripPin.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/TripPin.pq
@@ -1,0 +1,189 @@
+﻿section TripPin;
+
+// Data Source Kind description
+TripPin = [
+    // TestConnection is required to enable the connector through the Gateway
+    TestConnection = (dataSourcePath) => { "TripPin.Contents" },
+    Authentication = [
+        Anonymous = []
+    ],
+    Label = "TripPin Part 9 - TestConnection"
+];
+
+// Data Source UI publishing description
+TripPin.Publish = [
+    Beta = true,
+    Category = "Other",
+    ButtonText = { "TripPin TestConnection", "TripPin TestConnection" }
+];
+
+//
+// Implementation
+// 
+
+DefaultRequestHeaders = [
+    #"Accept" = "application/json;odata.metadata=minimal",  // column name and values only
+    #"OData-MaxVersion" = "4.0"                             // we only support v4
+];
+
+BaseUrl = "http://services.odata.org/v4/TripPinService/";
+
+// Define our top level table types
+AirlinesType = type table [ AirlineCode = text, Name = text ];
+
+AirportsType = type table [
+    Name = text,
+    IataCode = text,
+    Location = LocationType
+];
+
+PeopleType = type table [
+    UserName = text,
+    FirstName = text,
+    LastName = text,
+    Emails = {text},
+    AddressInfo = {nullable LocationType},
+    Gender = nullable text,
+    Concurrency = Int64.Type
+];
+
+// remaining structured types
+LocationType = type [
+    Address = text,
+    City = CityType,
+    Loc = LocType
+];
+
+CityType = type [
+    CountryRegion = text,
+    Name = text,
+    Region = text
+];
+
+LocType = type [
+    #"type" = text,
+    coordinates = {number},
+    crs = CrsType
+];
+
+CrsType = type [
+    #"type" = text,
+    properties = record
+];
+
+SchemaTable = #table({"Entity", "Type"}, {
+    {"Airlines", AirlinesType },    
+    {"Airports", AirportsType },
+    {"People", PeopleType}    
+});
+        
+GetSchemaForEntity = (entity as text) as type =>
+    try 
+        SchemaTable{[Entity=entity]}[Type]
+    otherwise
+        let
+            message = Text.Format("Couldn't find entity: '#{0}'", {entity})
+        in
+            Diagnostics.Trace(TraceLevel.Error, message, () => error message, true);
+
+
+[DataSource.Kind="TripPin", Publish="TripPin.Publish"]
+shared TripPin.Contents = () => TripPinNavTable(BaseUrl) as table;
+
+TripPinNavTable = (url as text) as table =>
+    let
+        // Use our schema table as the source of top level items in the navigation tree
+        entities = Table.SelectColumns(SchemaTable, {"Entity"}),
+        rename = Table.RenameColumns(entities, {{"Entity", "Name"}}),
+        // Add Data as a calculated column
+        //withData = Table.AddColumn(rename, "Data", each Diagnostics.LogFailure("Error in GetEntity", () => GetEntity(url, "DoesNotExist")), type table),
+        //withData = Table.AddColumn(rename, "Data", each GetEntity(url, "DoesNotExist"), type table),
+        withData = Table.AddColumn(rename, "Data", each GetEntity(url, [Name]), type table),
+        // Add ItemKind and ItemName as fixed text values
+        withItemKind = Table.AddColumn(withData, "ItemKind", each "Table", type text),
+        withItemName = Table.AddColumn(withItemKind, "ItemName", each "Table", type text),
+        // Indicate that the node should not be expandable
+        withIsLeaf = Table.AddColumn(withItemName, "IsLeaf", each true, type logical),
+        // Generate the nav table
+        navTable = Table.ToNavigationTable(withIsLeaf, {"Name"}, "Name", "Data", "ItemKind", "ItemName", "IsLeaf")
+    in
+        navTable;
+
+TripPin.Feed = (url as text, optional schema as type) as table =>
+    let
+        _url = Diagnostics.LogValue("Accessing url", url),
+        _schema = Diagnostics.LogValue("Schema type", schema),
+        //result = GetAllPagesByNextLink(url, schema)
+        result = GetAllPagesByNextLink(_url, _schema)
+    in
+        result;
+
+GetEntity = (url as text, entity as text) as table => 
+    let
+        fullUrl = Uri.Combine(url, entity),
+        schema = GetSchemaForEntity(entity),
+        result = TripPin.Feed(fullUrl, schema),
+        appliedSchema = Table.ChangeType(result, schema)
+    in
+        appliedSchema;
+
+GetPage = (url as text, optional schema as type) as table =>
+    let
+        response = Web.Contents(url, [ Headers = DefaultRequestHeaders ]),        
+        body = Json.Document(response),
+        nextLink = GetNextLink(body),
+        
+        // If we have no schema, use Table.FromRecords() instead
+        // (and hope that our results all have the same fields).
+        // If we have a schema, expand the record using its field names
+        data =
+            if (schema = null) then
+                Diagnostics.LogFailure("Error converting response body. Are the records uniform?", () => Table.FromRecords(body[value]))
+            else
+                let
+                    // convert the list of records into a table (single column of records)
+                    asTable = Table.FromList(body[value], Splitter.SplitByNothing(), {"Column1"}),
+                    fields = Record.FieldNames(Type.RecordFields(Type.TableRow(schema))),
+                    expanded = Table.ExpandRecordColumn(asTable, "Column1", fields)
+                in
+                    expanded
+    in
+        data meta [NextLink = nextLink];
+
+// Read all pages of data.
+// After every page, we check the "NextLink" record on the metadata of the previous request.
+// Table.GenerateByPage will keep asking for more pages until we return null.
+GetAllPagesByNextLink = (url as text, optional schema as type) as table =>
+    Table.GenerateByPage((previous) => 
+        let
+            // if previous is null, then this is our first page of data
+            nextLink = if (previous = null) then url else Value.Metadata(previous)[NextLink]?,
+            // if NextLink was set to null by the previous call, we know we have no more data
+            page = if (nextLink <> null) then GetPage(nextLink, schema) else null
+        in
+            page
+    );
+
+// In this implementation, 'response' will be the parsed body of the response after the call to Json.Document.
+// We look for the '@odata.nextLink' field and simply return null if it doesn't exist.
+GetNextLink = (response) as nullable text => Record.FieldOrDefault(response, "@odata.nextLink");
+
+// 
+// Load common library functions
+// 
+// TEMPORARY WORKAROUND until we're able to reference other M modules
+Extension.LoadFunction = (name as text) =>
+    let
+        binary = Extension.Contents(name),
+        asText = Text.FromBinary(binary)
+    in
+        Expression.Evaluate(asText, #shared);
+
+Table.ChangeType = Extension.LoadFunction("Table.ChangeType.pqm");
+Table.GenerateByPage = Extension.LoadFunction("Table.GenerateByPage.pqm");
+Table.ToNavigationTable = Extension.LoadFunction("Table.ToNavigationTable.pqm");
+
+// Diagnostics module contains multiple functions. We can take the ones we need.
+Diagnostics = Extension.LoadFunction("Diagnostics.pqm");
+Diagnostics.LogValue = Diagnostics[LogValue];
+Diagnostics.LogFailure = Diagnostics[LogFailure];

--- a/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/TripPin.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/TripPin/9-TestConnection/TripPin.query.pq
@@ -1,0 +1,315 @@
+﻿section TripPinUnitTests;
+
+shared TripPin.UnitTest =
+[
+    // Put any common variables here if you only want them to be evaluated once
+    RootTable = TripPin.Contents(),
+    Airlines = RootTable{[Name="Airlines"]}[Data],
+    Airports = RootTable{[Name="Airports"]}[Data],
+    People = RootTable{[Name="People"]}[Data],
+
+    // Fact(<Name of the Test>, <Expected Value>, <Actual Value>)
+    // <Expected Value> and <Actual Value> can be a literal or let statement
+    facts =
+    {
+        Fact("Check that we have three entries in our nav table", 3, Table.RowCount(RootTable)),
+        Fact("We have Airline data?", true, not Table.IsEmpty(Airlines)),
+        Fact("We have People data?", true, not Table.IsEmpty(People)),
+        Fact("We have Airport data?", true, not Table.IsEmpty(Airports)),        
+        Fact("Airlines only has 2 columns", 2, List.Count(Table.ColumnNames(Airlines))),        
+        Fact("Airline table has the right fields",
+            {"AirlineCode","Name"},
+            Record.FieldNames(Type.RecordFields(Type.TableRow(Value.Type(Airlines))))
+        ),
+        Fact("Emails is properly typed", type text, Type.ListItem(Value.Type(People{0}[Emails])))
+    },
+
+    report = Facts.Summarize(facts)
+][report];
+
+/// COMMON UNIT TESTING CODE 
+Fact = (_subject as text, _expected, _actual) as record =>
+[   expected = try _expected,
+    safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],
+    actual = try _actual,
+    safeActual = if actual[HasError] then "Actual : "& @ValueToText(actual[Error]) else actual[Value],
+    attempt = try safeExpected = safeActual,
+    result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
+    resultOp = if result = "Success ✓" then " = " else " <> ",
+    addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
+    addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
+    addendumEvalActual = try @ValueToText (safeActual) otherwise "...",
+    fact =
+    [   Result = result &" "& addendumEvalAttempt,
+        Notes =_subject,
+        Details = " ("& addendumEvalExpected & resultOp & addendumEvalActual &")"
+    ]
+][fact];
+
+Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject,_{0},_{1}));
+
+Facts.Summarize = (_facts as list) as table =>
+[   Fact.CountSuccesses = (count, i) =>
+    [   result = try i[Result],
+        sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
+    ][sum],
+    passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
+    total = List.Count(_facts),
+    format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+    result = if passed = total then "Success" else "⛔",
+    rate = Number.IntegerDivide(100*passed, total),
+    header =
+    [   Result = result,
+        Notes = Text.Format(format, {passed, total-passed}),
+        Details = Text.Format("#{0}% success rate", {rate})
+    ],
+    report = Table.FromRecords(List.Combine({{header},_facts}))
+][report];
+
+ValueToText = (value, optional depth) =>
+    let
+        _canBeIdentifier = (x) =>
+                                        let
+                                            keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                            charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                            charDigit = (c as number) => c>= 48 and c <= 57
+                                        in
+                                            try
+                                                charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                and
+                                                    List.MatchesAll(
+                                                        Text.ToList(x),
+                                                        (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                    )
+                                                and not 
+                                                    List.MatchesAny( keywords, (li)=> li=x )
+                                            otherwise 
+                                                false,
+    
+        Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+        Serialize.Date =        (x) => "#date(" & 
+                                       Text.From(Date.Year(x))  & ", " & 
+                                       Text.From(Date.Month(x)) & ", " & 
+                                       Text.From(Date.Day(x))   & ") ",
+
+        Serialize.Datetime =    (x) => "#datetime(" &
+                                       Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                       Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                       Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                       Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                       Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                       Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+        Serialize.Datetimezone =(x) => let 
+                                          dtz = DateTimeZone.ToRecord(x) 
+                                       in
+                                          "#datetimezone(" & 
+                                          Text.From(dtz[Year])        & ", " &
+                                          Text.From(dtz[Month])       & ", " &
+                                          Text.From(dtz[Day])         & ", " &
+                                          Text.From(dtz[Hour])        & ", " &
+                                          Text.From(dtz[Minute])      & ", " &
+                                          Text.From(dtz[Second])      & ", " &
+                                          Text.From(dtz[ZoneHours])   & ", " &
+                                          Text.From(dtz[ZoneMinutes]) & ") ",
+
+        Serialize.Duration =    (x) => let
+                                          dur = Duration.ToRecord(x)
+                                       in
+                                          "#duration(" &
+                                          Text.From(dur[Days])    & ", " &
+                                          Text.From(dur[Hours])   & ", " &
+                                          Text.From(dur[Minutes]) & ", " &
+                                          Text.From(dur[Seconds]) & ") ",
+
+        Serialize.Function =    (x) => _serialize_function_param_type(
+                                          Type.FunctionParameters(Value.Type(x)),
+                                          Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                       " as " &
+                                       _serialize_function_return_type(Value.Type(x)) &
+                                       " => (...) ",
+
+        Serialize.List =        (x) => "{" & 
+                                       List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                       "} ",
+
+        Serialize.Logical =     (x) => Text.From(x),
+
+        Serialize.Null =        (x) => "null",
+
+        Serialize.Number =      (x) => 
+                                    let Text.From = (i as number) as text => 
+                                        if Number.IsNaN(i) then "#nan" else
+                                        if i=Number.PositiveInfinity then "#infinity" else
+                                        if i=Number.NegativeInfinity then "-#infinity" else
+                                        Text.From(i)
+                                    in
+                                        Text.From(x),
+
+        Serialize.Record =      (x) => "[ " &
+                                       List.Accumulate(
+                                            Record.FieldNames(x), 
+                                            "", 
+                                            (seed,item) => 
+                                                (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                       ) &
+                                       " ] ",
+
+        Serialize.Table =       (x) => "#table( type " &
+                                        _serialize_table_type(Value.Type(x)) &
+                                        ", " &
+                                        Serialize(Table.ToRows(x)) &
+                                        ") ",
+                                    
+        Serialize.Text =        (x) => """" & 
+                                       _serialize_text_content(x) & 
+                                       """",
+
+        _serialize_text_content =  (x) => let 
+                                            escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                        in
+                                        List.Accumulate(
+                                           List.Transform(
+                                               Text.ToList(x),
+                                               (c) => let n=Character.ToNumber(c) in 
+                                                        if n = 9   then "#(#)(tab)" else
+                                                        if n = 10  then "#(#)(lf)"  else
+                                                        if n = 13  then "#(#)(cr)"  else
+                                                        if n = 34  then """"""      else
+                                                        if n = 35  then "#(#)(#)"   else
+                                                        if n < 32  then escapeText(n) else 
+                                                        if n < 127 then Character.FromNumber(n) else 
+                                                        escapeText(n) 
+                                            ),
+                                            "",
+                                            (s,i)=>s&i
+                                        ),
+        
+        Serialize.Identifier =   (x) => 
+                                        if _canBeIdentifier(x) then 
+                                            x 
+                                        else 
+                                            "#""" &
+                                            _serialize_text_content(x) &
+                                            """",
+
+        Serialize.Time =        (x) => "#time(" &
+                                       Text.From(Time.Hour(x))   & ", " & 
+                                       Text.From(Time.Minute(x)) & ", " & 
+                                       Text.From(Time.Second(x)) & ") ",
+                                
+        Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+        _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                    let
+                                        isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                        isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                        isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                        isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                    in
+                                
+                                        if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                        if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                        if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                        if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                        if x = type any then "any" else
+                                        let base = Type.NonNullable(x) in
+                                          (if Type.IsNullable(x) then "nullable " else "") &       
+                                          (if base = type anynonnull then "anynonnull" else                
+                                          if base = type binary then "binary" else                
+                                          if base = type date   then "date"   else
+                                          if base = type datetime then "datetime" else
+                                          if base = type datetimezone then "datetimezone" else
+                                          if base = type duration then "duration" else
+                                          if base = type logical then "logical" else
+                                          if base = type none then "none" else
+                                          if base = type null then "null" else
+                                          if base = type number then "number" else
+                                          if base = type text then "text" else 
+                                          if base = type time then "time" else 
+                                          if base = type type then "type" else 
+                                      
+                                          /* Abstract types: */
+                                          if base = type function then "function" else
+                                          if base = type table then "table" else
+                                          if base = type record then "record" else
+                                          if base = type list then "list" else
+                                      
+                                          "any /*Actually unknown type*/"),
+
+        _serialize_table_type =     (x) => 
+                                           let 
+                                             schema = Type.TableSchema(x)
+                                           in
+                                             "table " &
+                                             (if Table.IsEmpty(schema) then "" else 
+                                                 "[" & List.Accumulate(
+                                                    List.Transform(
+                                                        Table.ToRecords(Table.Sort(schema,"Position")),
+                                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                    "",
+                                                    (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                ) & "] " ),
+
+        _serialize_record_type =    (x) => 
+                                            let flds = Type.RecordFields(x)
+                                            in
+                                                if Record.FieldCount(flds)=0 then "record" else
+                                                    "[" & List.Accumulate(
+                                                        Record.FieldNames(flds),
+                                                        "",
+                                                        (seed,item) => 
+                                                            seed &
+                                                            (if seed<>"" then ", " else "") &
+                                                            (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                    ) & 
+                                                    (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                    "]",
+
+        _serialize_function_type =  (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(x),
+                                              Type.FunctionRequiredParameters(x) ) &
+                                            " as " &
+                                            _serialize_function_return_type(x),
+    
+        _serialize_function_param_type = (t,n) => 
+                                let
+                                    funsig = Table.ToRecords(
+                                        Table.TransformColumns(
+                                            Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                            { "isOptional", (x)=> x>n } ) )
+                                in
+                                    "(" & 
+                                    List.Accumulate(
+                                        funsig,
+                                        "",
+                                        (seed,item)=>
+                                            (if seed="" then "" else seed & ", ") &
+                                            (if item[isOptional] then "optional " else "") &
+                                            Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                     & ")",
+
+        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+        Serialize = (x) as text => 
+                           if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                           if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                           if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                           if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                           if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                           if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                           if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                           if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                           if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                           if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                           if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                           if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                           if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                           if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                           if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                           "[#_unable_to_serialize_#]"                     
+    in
+        try Serialize(value) otherwise "<serialization failed>";

--- a/src/test/parser/files/microsoft-DataConnectors/UnitTesting/UnitTesting.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/UnitTesting/UnitTesting.pq
@@ -1,0 +1,7 @@
+﻿section UnitTesting;
+
+shared UnitTesting.ReturnsABC = () => "ABC";
+shared UnitTesting.Returns123 = () => "123";
+shared UnitTesting.ReturnsTableWithFiveRows = () => Table.Repeat(#table({"a"},{{1}}), 5);
+
+

--- a/src/test/parser/files/microsoft-DataConnectors/UnitTesting/UnitTesting.query.pq
+++ b/src/test/parser/files/microsoft-DataConnectors/UnitTesting/UnitTesting.query.pq
@@ -1,0 +1,320 @@
+﻿section UnitTestingUnitTests;
+
+shared MyExtension.UnitTest =
+[
+    // Put any common variables here if you only want them to be evaluated once
+
+    // Fact(<Name of the Test>, <Expected Value>, <Actual Value>)
+    // <Expected Value> and <Actual Value> can be a literal or let statement
+    facts =
+    {        
+        Fact("Check that this function returns 'ABC'",  // name of the test
+             "ABC",                                     // expected value
+             UnitTesting.ReturnsABC()                   // expression to evaluate (let or single statement)
+        ),
+        Fact("Check that this function returns '123'",
+             "124",                                   
+             UnitTesting.Returns123()
+        ),
+        Fact("Result should contain 5 rows",
+            5,
+            Table.RowCount(UnitTesting.ReturnsTableWithFiveRows())
+        ),
+        Fact("Values should be equal (using a let statement)",
+            "Hello World",
+            let
+                a = "Hello World"
+            in
+                a
+        )
+    },
+
+    report = Facts.Summarize(facts)
+][report];
+
+/// COMMON UNIT TESTING CODE 
+Fact = (_subject as text, _expected, _actual) as record =>
+[   expected = try _expected,
+    safeExpected = if expected[HasError] then "Expected : "& @ValueToText(expected[Error]) else expected[Value],
+    actual = try _actual,
+    safeActual = if actual[HasError] then "Actual : "& @ValueToText(actual[Error]) else actual[Value],
+    attempt = try safeExpected = safeActual,
+    result = if attempt[HasError] or not attempt[Value] then "Failure ⛔" else "Success ✓",
+    resultOp = if result = "Success ✓" then " = " else " <> ",
+    addendumEvalAttempt = if attempt[HasError] then @ValueToText(attempt[Error]) else "",
+    addendumEvalExpected = try @ValueToText(safeExpected) otherwise "...",
+    addendumEvalActual = try @ValueToText (safeActual) otherwise "...",
+    fact =
+    [   Result = result &" "& addendumEvalAttempt,
+        Notes =_subject,
+        Details = " ("& addendumEvalExpected & resultOp & addendumEvalActual &")"
+    ]
+][fact];
+
+Facts = (_subject as text, _predicates as list) => List.Transform(_predicates, each Fact(_subject,_{0},_{1}));
+
+Facts.Summarize = (_facts as list) as table =>
+[   Fact.CountSuccesses = (count, i) =>
+    [   result = try i[Result],
+        sum = if result[HasError] or not Text.StartsWith(result[Value], "Success") then count else count + 1
+    ][sum],
+    passed = List.Accumulate(_facts, 0, Fact.CountSuccesses),
+    total = List.Count(_facts),
+    format = if passed = total then "All #{0} Passed !!! ✓" else "#{0} Passed ☺  #{1} Failed ☹",
+    result = if passed = total then "Success" else "⛔",
+    rate = Number.IntegerDivide(100*passed, total),
+    header =
+    [   Result = result,
+        Notes = Text.Format(format, {passed, total-passed}),
+        Details = Text.Format("#{0}% success rate", {rate})
+    ],
+    report = Table.FromRecords(List.Combine({{header},_facts}))
+][report];
+
+ValueToText = (value, optional depth) =>
+    let
+        _canBeIdentifier = (x) =>
+                                        let
+                                            keywords = {"and", "as", "each", "else", "error", "false", "if", "in", "is", "let", "meta", "not", "otherwise", "or", "section", "shared", "then", "true", "try", "type" },
+                                            charAlpha = (c as number) => (c>= 65 and c <= 90) or (c>= 97 and c <= 122) or c=95,
+                                            charDigit = (c as number) => c>= 48 and c <= 57
+                                        in
+                                            try
+                                                charAlpha(Character.ToNumber(Text.At(x,0))) 
+                                                and
+                                                    List.MatchesAll(
+                                                        Text.ToList(x),
+                                                        (c)=> let num = Character.ToNumber(c) in charAlpha(num) or charDigit(num)
+                                                    )
+                                                and not 
+                                                    List.MatchesAny( keywords, (li)=> li=x )
+                                            otherwise 
+                                                false,
+    
+        Serialize.Binary =      (x) => "#binary(" & Serialize(Binary.ToList(x)) & ") ",
+
+        Serialize.Date =        (x) => "#date(" & 
+                                       Text.From(Date.Year(x))  & ", " & 
+                                       Text.From(Date.Month(x)) & ", " & 
+                                       Text.From(Date.Day(x))   & ") ",
+
+        Serialize.Datetime =    (x) => "#datetime(" &
+                                       Text.From(Date.Year(DateTime.Date(x)))    & ", " &
+                                       Text.From(Date.Month(DateTime.Date(x)))   & ", " &
+                                       Text.From(Date.Day(DateTime.Date(x)))     & ", " &
+                                       Text.From(Time.Hour(DateTime.Time(x)))    & ", " &
+                                       Text.From(Time.Minute(DateTime.Time(x)))  & ", " &
+                                       Text.From(Time.Second(DateTime.Time(x)))  & ") ",
+
+        Serialize.Datetimezone =(x) => let 
+                                          dtz = DateTimeZone.ToRecord(x) 
+                                       in
+                                          "#datetimezone(" & 
+                                          Text.From(dtz[Year])        & ", " &
+                                          Text.From(dtz[Month])       & ", " &
+                                          Text.From(dtz[Day])         & ", " &
+                                          Text.From(dtz[Hour])        & ", " &
+                                          Text.From(dtz[Minute])      & ", " &
+                                          Text.From(dtz[Second])      & ", " &
+                                          Text.From(dtz[ZoneHours])   & ", " &
+                                          Text.From(dtz[ZoneMinutes]) & ") ",
+
+        Serialize.Duration =    (x) => let
+                                          dur = Duration.ToRecord(x)
+                                       in
+                                          "#duration(" &
+                                          Text.From(dur[Days])    & ", " &
+                                          Text.From(dur[Hours])   & ", " &
+                                          Text.From(dur[Minutes]) & ", " &
+                                          Text.From(dur[Seconds]) & ") ",
+
+        Serialize.Function =    (x) => _serialize_function_param_type(
+                                          Type.FunctionParameters(Value.Type(x)),
+                                          Type.FunctionRequiredParameters(Value.Type(x)) ) &
+                                       " as " &
+                                       _serialize_function_return_type(Value.Type(x)) &
+                                       " => (...) ",
+
+        Serialize.List =        (x) => "{" & 
+                                       List.Accumulate(x, "", (seed,item) => if seed="" then Serialize(item) else seed & ", " & Serialize(item)) &
+                                       "} ",
+
+        Serialize.Logical =     (x) => Text.From(x),
+
+        Serialize.Null =        (x) => "null",
+
+        Serialize.Number =      (x) => 
+                                    let Text.From = (i as number) as text => 
+                                        if Number.IsNaN(i) then "#nan" else
+                                        if i=Number.PositiveInfinity then "#infinity" else
+                                        if i=Number.NegativeInfinity then "-#infinity" else
+                                        Text.From(i)
+                                    in
+                                        Text.From(x),
+
+        Serialize.Record =      (x) => "[ " &
+                                       List.Accumulate(
+                                            Record.FieldNames(x), 
+                                            "", 
+                                            (seed,item) => 
+                                                (if seed="" then Serialize.Identifier(item) else seed & ", " & Serialize.Identifier(item)) & " = " & Serialize(Record.Field(x, item))
+                                       ) &
+                                       " ] ",
+
+        Serialize.Table =       (x) => "#table( type " &
+                                        _serialize_table_type(Value.Type(x)) &
+                                        ", " &
+                                        Serialize(Table.ToRows(x)) &
+                                        ") ",
+                                    
+        Serialize.Text =        (x) => """" & 
+                                       _serialize_text_content(x) & 
+                                       """",
+
+        _serialize_text_content =  (x) => let 
+                                            escapeText = (n as number) as text => "#(#)(" & Text.PadStart(Number.ToText(n, "X", "en-US"), 4, "0") & ")"
+                                        in
+                                        List.Accumulate(
+                                           List.Transform(
+                                               Text.ToList(x),
+                                               (c) => let n=Character.ToNumber(c) in 
+                                                        if n = 9   then "#(#)(tab)" else
+                                                        if n = 10  then "#(#)(lf)"  else
+                                                        if n = 13  then "#(#)(cr)"  else
+                                                        if n = 34  then """"""      else
+                                                        if n = 35  then "#(#)(#)"   else
+                                                        if n < 32  then escapeText(n) else 
+                                                        if n < 127 then Character.FromNumber(n) else 
+                                                        escapeText(n) 
+                                            ),
+                                            "",
+                                            (s,i)=>s&i
+                                        ),
+        
+        Serialize.Identifier =   (x) => 
+                                        if _canBeIdentifier(x) then 
+                                            x 
+                                        else 
+                                            "#""" &
+                                            _serialize_text_content(x) &
+                                            """",
+
+        Serialize.Time =        (x) => "#time(" &
+                                       Text.From(Time.Hour(x))   & ", " & 
+                                       Text.From(Time.Minute(x)) & ", " & 
+                                       Text.From(Time.Second(x)) & ") ",
+                                
+        Serialize.Type =        (x) => "type " & _serialize_typename(x),
+                                    
+                             
+        _serialize_typename =    (x, optional funtype as logical) =>                        /* Optional parameter: Is this being used as part of a function signature? */
+                                    let
+                                        isFunctionType = (x as type) => try if Type.FunctionReturn(x) is type then true else false otherwise false,
+                                        isTableType = (x as type) =>  try if Type.TableSchema(x) is table then true else false otherwise false,
+                                        isRecordType = (x as type) => try if Type.ClosedRecord(x) is type then true else false otherwise false,
+                                        isListType = (x as type) => try if Type.ListItem(x) is type then true else false otherwise false
+                                    in
+                                
+                                        if funtype=null and isTableType(x) then _serialize_table_type(x) else
+                                        if funtype=null and isListType(x) then "{ " & @_serialize_typename( Type.ListItem(x) ) & " }" else
+                                        if funtype=null and isFunctionType(x) then "function " & _serialize_function_type(x) else
+                                        if funtype=null and isRecordType(x) then _serialize_record_type(x) else
+                                    
+                                        if x = type any then "any" else
+                                        let base = Type.NonNullable(x) in
+                                          (if Type.IsNullable(x) then "nullable " else "") &       
+                                          (if base = type anynonnull then "anynonnull" else                
+                                          if base = type binary then "binary" else                
+                                          if base = type date   then "date"   else
+                                          if base = type datetime then "datetime" else
+                                          if base = type datetimezone then "datetimezone" else
+                                          if base = type duration then "duration" else
+                                          if base = type logical then "logical" else
+                                          if base = type none then "none" else
+                                          if base = type null then "null" else
+                                          if base = type number then "number" else
+                                          if base = type text then "text" else 
+                                          if base = type time then "time" else 
+                                          if base = type type then "type" else 
+                                      
+                                          /* Abstract types: */
+                                          if base = type function then "function" else
+                                          if base = type table then "table" else
+                                          if base = type record then "record" else
+                                          if base = type list then "list" else
+                                      
+                                          "any /*Actually unknown type*/"),
+
+        _serialize_table_type =     (x) => 
+                                           let 
+                                             schema = Type.TableSchema(x)
+                                           in
+                                             "table " &
+                                             (if Table.IsEmpty(schema) then "" else 
+                                                 "[" & List.Accumulate(
+                                                    List.Transform(
+                                                        Table.ToRecords(Table.Sort(schema,"Position")),
+                                                        each Serialize.Identifier(_[Name]) & " = " & _[Kind]),
+                                                    "",
+                                                    (seed,item) => (if seed="" then item else seed & ", " & item )
+                                                ) & "] " ),
+
+        _serialize_record_type =    (x) => 
+                                            let flds = Type.RecordFields(x)
+                                            in
+                                                if Record.FieldCount(flds)=0 then "record" else
+                                                    "[" & List.Accumulate(
+                                                        Record.FieldNames(flds),
+                                                        "",
+                                                        (seed,item) => 
+                                                            seed &
+                                                            (if seed<>"" then ", " else "") &
+                                                            (Serialize.Identifier(item) & "=" & _serialize_typename(Record.Field(flds,item)[Type]) )
+                                                    ) & 
+                                                    (if Type.IsOpenRecord(x) then ",..." else "") &
+                                                    "]",
+
+        _serialize_function_type =  (x) => _serialize_function_param_type(
+                                              Type.FunctionParameters(x),
+                                              Type.FunctionRequiredParameters(x) ) &
+                                            " as " &
+                                            _serialize_function_return_type(x),
+    
+        _serialize_function_param_type = (t,n) => 
+                                let
+                                    funsig = Table.ToRecords(
+                                        Table.TransformColumns(
+                                            Table.AddIndexColumn( Record.ToTable( t ), "isOptional", 1 ),
+                                            { "isOptional", (x)=> x>n } ) )
+                                in
+                                    "(" & 
+                                    List.Accumulate(
+                                        funsig,
+                                        "",
+                                        (seed,item)=>
+                                            (if seed="" then "" else seed & ", ") &
+                                            (if item[isOptional] then "optional " else "") &
+                                            Serialize.Identifier(item[Name]) & " as " & _serialize_typename(item[Value], true) )
+                                     & ")",
+
+        _serialize_function_return_type = (x) => _serialize_typename(Type.FunctionReturn(x), true), 
+
+        Serialize = (x) as text => 
+                           if x is binary       then try Serialize.Binary(x) otherwise "null /*serialize failed*/"        else 
+                           if x is date         then try Serialize.Date(x) otherwise "null /*serialize failed*/"          else 
+                           if x is datetime     then try Serialize.Datetime(x) otherwise "null /*serialize failed*/"      else 
+                           if x is datetimezone then try Serialize.Datetimezone(x) otherwise "null /*serialize failed*/"  else 
+                           if x is duration     then try Serialize.Duration(x) otherwise "null /*serialize failed*/"      else 
+                           if x is function     then try Serialize.Function(x) otherwise "null /*serialize failed*/"      else 
+                           if x is list         then try Serialize.List(x) otherwise "null /*serialize failed*/"          else 
+                           if x is logical      then try Serialize.Logical(x) otherwise "null /*serialize failed*/"       else
+                           if x is null         then try Serialize.Null(x) otherwise "null /*serialize failed*/"          else
+                           if x is number       then try Serialize.Number(x) otherwise "null /*serialize failed*/"        else
+                           if x is record       then try Serialize.Record(x) otherwise "null /*serialize failed*/"        else 
+                           if x is table        then try Serialize.Table(x) otherwise "null /*serialize failed*/"         else 
+                           if x is text         then try Serialize.Text(x) otherwise "null /*serialize failed*/"          else 
+                           if x is time         then try Serialize.Time(x) otherwise "null /*serialize failed*/"          else 
+                           if x is type         then try Serialize.Type(x) otherwise "null /*serialize failed*/"          else 
+                           "[#_unable_to_serialize_#]"                     
+    in
+        try Serialize(value) otherwise "<serialization failed>";

--- a/src/test/parser/files/microsoft-DataConnectors/readme.md
+++ b/src/test/parser/files/microsoft-DataConnectors/readme.md
@@ -1,0 +1,2 @@
+Pulled from https://github.com/microsoft/DataConnectors
+SHA: d2e82c80709ac1b836f4451997c45b891b61eb17

--- a/src/test/parser/simple.ts
+++ b/src/test/parser/simple.ts
@@ -603,6 +603,53 @@ describe("Parser.AbridgedNode", () => {
         });
     });
 
+    describe(`${Ast.NodeKind.FunctionType} abc123`, () => {
+        it(`type function () as number`, () => {
+            const text: string = `type function () as number`;
+            const expected: ReadonlyArray<AbridgedNode> = [
+                [Ast.NodeKind.TypePrimaryType, undefined],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.FunctionType, 1],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.ParameterList, 1],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.ArrayWrapper, 1],
+                [Ast.NodeKind.Constant, 2],
+                [Ast.NodeKind.AsType, 2],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.PrimitiveType, 1],
+                [Ast.NodeKind.Constant, 0],
+            ];
+            expectAbridgeNodes(text, expected);
+        });
+
+        it(`type function (x as number) as number`, () => {
+            const text: string = `type function (x as number) as number`;
+            const expected: ReadonlyArray<AbridgedNode> = [
+                [Ast.NodeKind.TypePrimaryType, undefined],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.FunctionType, 1],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.ParameterList, 1],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.ArrayWrapper, 1],
+                [Ast.NodeKind.Csv, 0],
+                [Ast.NodeKind.Parameter, 0],
+                [Ast.NodeKind.Identifier, 1],
+                [Ast.NodeKind.AsType, 2],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.PrimitiveType, 1],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.Constant, 2],
+                [Ast.NodeKind.AsType, 2],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.PrimitiveType, 1],
+                [Ast.NodeKind.Constant, 0],
+            ];
+            expectAbridgeNodes(text, expected);
+        });
+    });
+
     // Ast.NodeKind.FieldTypeSpecification covered by AsType
 
     it(Ast.NodeKind.GeneralizedIdentifier, () => {

--- a/src/test/parser/simple.ts
+++ b/src/test/parser/simple.ts
@@ -603,7 +603,7 @@ describe("Parser.AbridgedNode", () => {
         });
     });
 
-    describe(`${Ast.NodeKind.FunctionType} abc123`, () => {
+    describe(`${Ast.NodeKind.FunctionType}`, () => {
         it(`type function () as number`, () => {
             const text: string = `type function () as number`;
             const expected: ReadonlyArray<AbridgedNode> = [

--- a/src/test/parser/simple.ts
+++ b/src/test/parser/simple.ts
@@ -776,6 +776,26 @@ describe("Parser.AbridgedNode", () => {
         expectAbridgeNodes(text, expected);
     });
 
+    describe(`keywords`, () => {
+        it(`#sections`, () => {
+            const text: string = `#sections`;
+            const expected: ReadonlyArray<AbridgedNode> = [
+                [Ast.NodeKind.IdentifierExpression, undefined],
+                [Ast.NodeKind.Identifier, 1],
+            ];
+            expectAbridgeNodes(text, expected);
+        });
+
+        it(`#shared`, () => {
+            const text: string = `#shared`;
+            const expected: ReadonlyArray<AbridgedNode> = [
+                [Ast.NodeKind.IdentifierExpression, undefined],
+                [Ast.NodeKind.Identifier, 1],
+            ];
+            expectAbridgeNodes(text, expected);
+        });
+    });
+
     it(Ast.NodeKind.LetExpression, () => {
         const text: string = `let x = 1 in x`;
         const expected: ReadonlyArray<AbridgedNode> = [

--- a/src/test/parser/simple.ts
+++ b/src/test/parser/simple.ts
@@ -1122,7 +1122,19 @@ describe("Parser.AbridgedNode", () => {
         expectAbridgeNodes(text, expected);
     });
 
-    // Ast.NodeKind.PrimitiveType covered by many
+    describe(`${Ast.NodeKind.PrimitiveType}`, () => {
+        it(`1 as time`, () => {
+            const text: string = `1 as time`;
+            const expected: ReadonlyArray<AbridgedNode> = [
+                [Ast.NodeKind.AsExpression, undefined],
+                [Ast.NodeKind.LiteralExpression, 0],
+                [Ast.NodeKind.Constant, 1],
+                [Ast.NodeKind.PrimitiveType, 2],
+                [Ast.NodeKind.Constant, 0],
+            ];
+            expectAbridgeNodes(text, expected);
+        });
+    });
 
     describe(`${Ast.NodeKind.RecordExpression}`, () => {
         it(`[x=1]`, () => {


### PR DESCRIPTION
Pulled in https://github.com/microsoft/DataConnectors as a source of test files. Found and resolved the following issues:

* Missing support for the following keywords: #sections #shared #time
* Mishandling of an error in function parameter assertions when the assertion was of type TPrimaryExpression (eg. `foo as (parenthesized-expression)`)
* Lexing error on non-empty, all white whitespace lines. Funnily I never ran into this thanks to VSCode's `trim on save` feature