### PR TITLE
Re-order state to be first argument(s)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.1.18",
+    "version": "0.1.19",
     "description": "A parser for the Power Query/M formula language.",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/common/traversal.ts
+++ b/src/common/traversal.ts
@@ -6,7 +6,7 @@ import { Ast, NodeIdMap, ParserContext } from "../parser";
 
 export type TriedTraverse<StateType> = Result<StateType, CommonError.CommonError>;
 
-export type TVisitNodeFn<Node, State, StateType, Return> = (state: State & IState<StateType>, node: Node) => Return;
+export type TVisitNodeFn<State, StateType, Node, Return> = (state: State & IState<StateType>, node: Node) => Return;
 
 export type TVisitChildNodeFn<Node, State, StateType, Return> = (
     state: State & IState<StateType>,
@@ -14,9 +14,9 @@ export type TVisitChildNodeFn<Node, State, StateType, Return> = (
     node: Node,
 ) => Return;
 
-export type TEarlyExitFn<Node, State, StateType> = TVisitNodeFn<Node, State, StateType, boolean>;
+export type TEarlyExitFn<State, StateType, Node> = TVisitNodeFn<State, StateType, Node, boolean>;
 
-export type TExpandNodesFn<Node, NodesById, State, StateType> = (
+export type TExpandNodesFn<State, StateType, Node, NodesById> = (
     state: State & IState<StateType>,
     node: Node,
     collection: NodesById,
@@ -37,11 +37,11 @@ export function tryTraverseAst<State, StateType>(
     nodeIdMapCollection: NodeIdMap.Collection,
     root: Ast.TNode,
     strategy: VisitNodeStrategy,
-    visitNodeFn: TVisitNodeFn<Ast.TNode, State, StateType, void>,
-    expandNodesFn: TExpandNodesFn<Ast.TNode, NodeIdMap.Collection, State, StateType>,
-    maybeEarlyExitFn: Option<TEarlyExitFn<Ast.TNode, State, StateType>>,
+    visitNodeFn: TVisitNodeFn<State, StateType, Ast.TNode, void>,
+    expandNodesFn: TExpandNodesFn<State, StateType, Ast.TNode, NodeIdMap.Collection>,
+    maybeEarlyExitFn: Option<TEarlyExitFn<State, StateType, Ast.TNode>>,
 ): TriedTraverse<StateType> {
-    return tryTraverse<Ast.TNode, NodeIdMap.Collection, State, StateType>(
+    return tryTraverse<State, StateType, Ast.TNode, NodeIdMap.Collection>(
         state,
         nodeIdMapCollection,
         root,
@@ -58,11 +58,11 @@ export function tryTraverseXor<State, StateType>(
     nodeIdMapCollection: NodeIdMap.Collection,
     root: NodeIdMap.TXorNode,
     strategy: VisitNodeStrategy,
-    visitNodeFn: TVisitNodeFn<NodeIdMap.TXorNode, State, StateType, void>,
-    expandNodesFn: TExpandNodesFn<NodeIdMap.TXorNode, NodeIdMap.Collection, State, StateType>,
-    maybeEarlyExitFn: Option<TEarlyExitFn<NodeIdMap.TXorNode, State, StateType>>,
+    visitNodeFn: TVisitNodeFn<State, StateType, NodeIdMap.TXorNode, void>,
+    expandNodesFn: TExpandNodesFn<State, StateType, NodeIdMap.TXorNode, NodeIdMap.Collection>,
+    maybeEarlyExitFn: Option<TEarlyExitFn<State, StateType, NodeIdMap.TXorNode>>,
 ): TriedTraverse<StateType> {
-    return tryTraverse<NodeIdMap.TXorNode, NodeIdMap.Collection, State, StateType>(
+    return tryTraverse<State, StateType, NodeIdMap.TXorNode, NodeIdMap.Collection>(
         state,
         nodeIdMapCollection,
         root,
@@ -73,17 +73,17 @@ export function tryTraverseXor<State, StateType>(
     );
 }
 
-export function tryTraverse<Node, NodesById, State, StateType>(
+export function tryTraverse<State, StateType, Node, NodesById>(
     state: State & IState<StateType>,
     nodesById: NodesById,
     root: Node,
     strategy: VisitNodeStrategy,
-    visitNodeFn: TVisitNodeFn<Node, State, StateType, void>,
-    expandNodesFn: TExpandNodesFn<Node, NodesById, State, StateType>,
-    maybeEarlyExitFn: Option<TEarlyExitFn<Node, State, StateType>>,
+    visitNodeFn: TVisitNodeFn<State, StateType, Node, void>,
+    expandNodesFn: TExpandNodesFn<State, StateType, Node, NodesById>,
+    maybeEarlyExitFn: Option<TEarlyExitFn<State, StateType, Node>>,
 ): TriedTraverse<StateType> {
     try {
-        traverseRecursion<Node, NodesById, State, StateType>(
+        traverseRecursion<State, StateType, Node, NodesById>(
             state,
             nodesById,
             root,
@@ -181,14 +181,14 @@ export function expectExpandAllXorChildren<State, StateType>(
     }
 }
 
-function traverseRecursion<Node, NodesById, State, StateType>(
+function traverseRecursion<State, StateType, Node, NodesById>(
     state: State & IState<StateType>,
     nodesById: NodesById,
     node: Node,
     strategy: VisitNodeStrategy,
-    visitNodeFn: TVisitNodeFn<Node, State, StateType, void>,
-    expandNodesFn: TExpandNodesFn<Node, NodesById, State, StateType>,
-    maybeEarlyExitFn: Option<TEarlyExitFn<Node, State, StateType>>,
+    visitNodeFn: TVisitNodeFn<State, StateType, Node, void>,
+    expandNodesFn: TExpandNodesFn<State, StateType, Node, NodesById>,
+    maybeEarlyExitFn: Option<TEarlyExitFn<State, StateType, Node>>,
 ): void {
     if (maybeEarlyExitFn && maybeEarlyExitFn(state, node)) {
         return;

--- a/src/common/traversal.ts
+++ b/src/common/traversal.ts
@@ -8,7 +8,7 @@ export type TriedTraverse<StateType> = Result<StateType, CommonError.CommonError
 
 export type TVisitNodeFn<State, StateType, Node, Return> = (state: State & IState<StateType>, node: Node) => Return;
 
-export type TVisitChildNodeFn<Node, State, StateType, Return> = (
+export type TVisitChildNodeFn<State, StateType, Node, Return> = (
     state: State & IState<StateType>,
     parent: Node,
     node: Node,

--- a/src/common/traversal.ts
+++ b/src/common/traversal.ts
@@ -6,12 +6,12 @@ import { Ast, NodeIdMap, ParserContext } from "../parser";
 
 export type TriedTraverse<StateType> = Result<StateType, CommonError.CommonError>;
 
-export type TVisitNodeFn<Node, State, StateType, Return> = (node: Node, state: State & IState<StateType>) => Return;
+export type TVisitNodeFn<Node, State, StateType, Return> = (state: State & IState<StateType>, node: Node) => Return;
 
 export type TVisitChildNodeFn<Node, State, StateType, Return> = (
+    state: State & IState<StateType>,
     parent: Node,
     node: Node,
-    state: State & IState<StateType>,
 ) => Return;
 
 export type TEarlyExitFn<Node, State, StateType> = TVisitNodeFn<Node, State, StateType, boolean>;
@@ -33,18 +33,18 @@ export interface IState<T> {
 
 // sets Node and NodesById for tryTraverse
 export function tryTraverseAst<State, StateType>(
-    root: Ast.TNode,
-    nodeIdMapCollection: NodeIdMap.Collection,
     state: State & IState<StateType>,
+    nodeIdMapCollection: NodeIdMap.Collection,
+    root: Ast.TNode,
     strategy: VisitNodeStrategy,
     visitNodeFn: TVisitNodeFn<Ast.TNode, State, StateType, void>,
     expandNodesFn: TExpandNodesFn<Ast.TNode, NodeIdMap.Collection, State, StateType>,
     maybeEarlyExitFn: Option<TEarlyExitFn<Ast.TNode, State, StateType>>,
 ): TriedTraverse<StateType> {
     return tryTraverse<Ast.TNode, NodeIdMap.Collection, State, StateType>(
-        root,
-        nodeIdMapCollection,
         state,
+        nodeIdMapCollection,
+        root,
         strategy,
         visitNodeFn,
         expandNodesFn,
@@ -54,18 +54,18 @@ export function tryTraverseAst<State, StateType>(
 
 // sets Node and NodesById for tryTraverse
 export function tryTraverseXor<State, StateType>(
-    root: NodeIdMap.TXorNode,
-    nodeIdMapCollection: NodeIdMap.Collection,
     state: State & IState<StateType>,
+    nodeIdMapCollection: NodeIdMap.Collection,
+    root: NodeIdMap.TXorNode,
     strategy: VisitNodeStrategy,
     visitNodeFn: TVisitNodeFn<NodeIdMap.TXorNode, State, StateType, void>,
     expandNodesFn: TExpandNodesFn<NodeIdMap.TXorNode, NodeIdMap.Collection, State, StateType>,
     maybeEarlyExitFn: Option<TEarlyExitFn<NodeIdMap.TXorNode, State, StateType>>,
 ): TriedTraverse<StateType> {
     return tryTraverse<NodeIdMap.TXorNode, NodeIdMap.Collection, State, StateType>(
-        root,
-        nodeIdMapCollection,
         state,
+        nodeIdMapCollection,
+        root,
         strategy,
         visitNodeFn,
         expandNodesFn,
@@ -74,9 +74,9 @@ export function tryTraverseXor<State, StateType>(
 }
 
 export function tryTraverse<Node, NodesById, State, StateType>(
-    root: Node,
-    nodesById: NodesById,
     state: State & IState<StateType>,
+    nodesById: NodesById,
+    root: Node,
     strategy: VisitNodeStrategy,
     visitNodeFn: TVisitNodeFn<Node, State, StateType, void>,
     expandNodesFn: TExpandNodesFn<Node, NodesById, State, StateType>,
@@ -84,9 +84,9 @@ export function tryTraverse<Node, NodesById, State, StateType>(
 ): TriedTraverse<StateType> {
     try {
         traverseRecursion<Node, NodesById, State, StateType>(
-            root,
-            nodesById,
             state,
+            nodesById,
+            root,
             strategy,
             visitNodeFn,
             expandNodesFn,
@@ -182,25 +182,25 @@ export function expectExpandAllXorChildren<State, StateType>(
 }
 
 function traverseRecursion<Node, NodesById, State, StateType>(
-    node: Node,
-    nodesById: NodesById,
     state: State & IState<StateType>,
+    nodesById: NodesById,
+    node: Node,
     strategy: VisitNodeStrategy,
     visitNodeFn: TVisitNodeFn<Node, State, StateType, void>,
     expandNodesFn: TExpandNodesFn<Node, NodesById, State, StateType>,
     maybeEarlyExitFn: Option<TEarlyExitFn<Node, State, StateType>>,
 ): void {
-    if (maybeEarlyExitFn && maybeEarlyExitFn(node, state)) {
+    if (maybeEarlyExitFn && maybeEarlyExitFn(state, node)) {
         return;
     } else if (strategy === VisitNodeStrategy.BreadthFirst) {
-        visitNodeFn(node, state);
+        visitNodeFn(state, node);
     }
 
     for (const child of expandNodesFn(state, node, nodesById)) {
-        traverseRecursion(child, nodesById, state, strategy, visitNodeFn, expandNodesFn, maybeEarlyExitFn);
+        traverseRecursion(state, nodesById, child, strategy, visitNodeFn, expandNodesFn, maybeEarlyExitFn);
     }
 
     if (strategy === VisitNodeStrategy.DepthFirst) {
-        visitNodeFn(node, state);
+        visitNodeFn(state, node);
     }
 }

--- a/src/inspection/inspection.ts
+++ b/src/inspection/inspection.ts
@@ -67,9 +67,9 @@ export function tryFrom(
     };
 
     const triedTraverse: TriedTraverse<UnfrozenInspected> = Traverse.tryTraverseXor<State, UnfrozenInspected>(
-        root,
-        nodeIdMapCollection,
         state,
+        nodeIdMapCollection,
+        root,
         Traverse.VisitNodeStrategy.BreadthFirst,
         visitNode,
         addParentXorNode,

--- a/src/inspection/visitNode.ts
+++ b/src/inspection/visitNode.ts
@@ -8,7 +8,7 @@ import { Position, State } from "./inspection";
 import { NodeKind, TNode } from "./node";
 import { PositionIdentifierKind } from "./positionIdentifier";
 
-export function visitNode(xorNode: NodeIdMap.TXorNode, state: State): void {
+export function visitNode(state: State, xorNode: NodeIdMap.TXorNode): void {
     // tslint:disable-next-line: switch-default
     switch (xorNode.node.kind) {
         case Ast.NodeKind.EachExpression:


### PR DESCRIPTION
For consistency sake all state related parameters were moved to the first argument position. This is a breaking change for traversal so it requires a version bump.