### PR TITLE
Improvements to Inspection scope

### DIFF
--- a/src/inspection/visitNode.ts
+++ b/src/inspection/visitNode.ts
@@ -351,7 +351,7 @@ function inspectLetExpression(state: State, letExprXorNode: NodeIdMap.TXorNode):
         if (keyXorNode.kind === NodeIdMap.XorNodeKind.Ast && keyXorNode.node.kind === Ast.NodeKind.Identifier) {
             // Add identifiers to current scope, excluding the current paired expression
             if (!state.assignmentKeyNodeIdMap.has(keyXorNode.node.id)) {
-                addToScopeIfNew(state, keyXorNode.node.literal, keyXorNode);
+                addToScopeIfNew(state, keyXorNode.node.literal, keyValuePairXorNode);
             }
         }
 

--- a/src/test/inspection/abridgedInspected.ts
+++ b/src/test/inspection/abridgedInspected.ts
@@ -1018,39 +1018,28 @@ describe(`Inspection`, () => {
         });
 
         describe(`${Ast.NodeKind.SectionMember} (Ast)`, () => {
+            // TODO (issue #61): should we be providing scope members if cursor is on section declaration?
             it(`s|ection foo; x = 1; y = 2;`, () => {
-                const text: string = `section foo; x = 1; y = 2;`;
-                const position: Inspection.Position = {
-                    lineNumber: 0,
-                    lineCodeUnit: 1,
-                };
+                const [text, position] = textWithPosition(`s|ection foo; x = 1; y = 2;`);
                 const expected: AbridgedInspection = {
                     nodes: [],
-                    scope: [],
+                    scope: [`x`, `y`],
                 };
                 expectParseOkAbridgedInspectionEqual(text, position, expected);
             });
 
             it(`section foo; x = 1|; y = 2;`, () => {
-                const text: string = `section foo; x = 1; y = 2;`;
-                const position: Inspection.Position = {
-                    lineNumber: 0,
-                    lineCodeUnit: 18,
-                };
+                const [text, position] = textWithPosition(`section foo; x = 1|; y = 2;`);
                 const expected: AbridgedInspection = {
                     nodes: [],
-                    scope: [],
+                    scope: [`y`],
                 };
 
                 expectParseOkAbridgedInspectionEqual(text, position, expected);
             });
 
             it(`section foo; x = 1; y = 2;|`, () => {
-                const text: string = `section foo; x = 1; y = 2;|`;
-                const position: Inspection.Position = {
-                    lineNumber: 0,
-                    lineCodeUnit: 26,
-                };
+                const [text, position] = textWithPosition(`section foo; x = 1; y = 2;|`);
                 const expected: AbridgedInspection = {
                     nodes: [],
                     scope: [`x`, `y`],
@@ -1069,28 +1058,21 @@ describe(`Inspection`, () => {
         });
 
         describe(`${Ast.NodeKind.SectionMember} (ParserContext)`, () => {
+            // TODO (issue #61): should we be providing scope members if cursor is on section declaration?
             it(`s|ection foo; x = 1; y = 2`, () => {
-                const text: string = `section foo; x = 1; y = 2`;
-                const position: Inspection.Position = {
-                    lineNumber: 0,
-                    lineCodeUnit: 1,
-                };
+                const [text, position] = textWithPosition(`s|ection foo; x = 1; y = 2`);
                 const expected: AbridgedInspection = {
                     nodes: [],
-                    scope: [],
+                    scope: [`x`, `y`],
                 };
                 expectParseErrAbridgedInspectionEqual(text, position, expected);
             });
 
             it(`section foo; x = 1|; y = 2`, () => {
-                const text: string = `section foo; x = 1; y = 2`;
-                const position: Inspection.Position = {
-                    lineNumber: 0,
-                    lineCodeUnit: 18,
-                };
+                const [text, position] = textWithPosition(`section foo; x = 1|; y = 2`);
                 const expected: AbridgedInspection = {
                     nodes: [],
-                    scope: [],
+                    scope: [`y`],
                 };
                 expectParseErrAbridgedInspectionEqual(text, position, expected);
             });

--- a/src/test/inspection/abridgedInspected.ts
+++ b/src/test/inspection/abridgedInspected.ts
@@ -1039,7 +1039,7 @@ describe(`Inspection`, () => {
                 };
                 const expected: AbridgedInspection = {
                     nodes: [],
-                    scope: [`x`],
+                    scope: [],
                 };
 
                 expectParseOkAbridgedInspectionEqual(text, position, expected);
@@ -1090,20 +1090,16 @@ describe(`Inspection`, () => {
                 };
                 const expected: AbridgedInspection = {
                     nodes: [],
-                    scope: [`x`],
+                    scope: [],
                 };
                 expectParseErrAbridgedInspectionEqual(text, position, expected);
             });
 
             it(`section foo; x = 1; y = 2|`, () => {
-                const text: string = `section foo; x = 1; y = 2|`;
-                const position: Inspection.Position = {
-                    lineNumber: 0,
-                    lineCodeUnit: 25,
-                };
+                const [text, position] = textWithPosition(`section foo; x = 1; y = 2|`);
                 const expected: AbridgedInspection = {
                     nodes: [],
-                    scope: [`x`, `y`],
+                    scope: [`x`],
                 };
                 expectParseErrAbridgedInspectionEqual(text, position, expected);
             });

--- a/src/test/inspection/abridgedInspected.ts
+++ b/src/test/inspection/abridgedInspected.ts
@@ -1057,6 +1057,15 @@ describe(`Inspection`, () => {
                 };
                 expectParseOkAbridgedInspectionEqual(text, position, expected);
             });
+
+            it(`section foo; x = 1; y = 2; z = let a = 1 in |a;`, () => {
+                const [text, position] = textWithPosition(`section foo; x = 1; y = 2; z = let a = 1 in |a;`);
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`a`, `x`, `y`],
+                };
+                expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
         });
 
         describe(`${Ast.NodeKind.SectionMember} (ParserContext)`, () => {
@@ -1100,16 +1109,7 @@ describe(`Inspection`, () => {
             });
         });
 
-        describe(`${Ast.NodeKind.LetExpression} (ParserContext)`, () => {
-            it(`let a = 1, b = 2, c = 3 in |`, () => {
-                const [text, position] = textWithPosition(`let a = 1, b = 2, c = 3 in |`);
-                const expected: AbridgedInspection = {
-                    nodes: [],
-                    scope: [`a`, `b`, `c`],
-                };
-                expectParseErrAbridgedInspectionEqual(text, position, expected);
-            });
-
+        describe(`${Ast.NodeKind.LetExpression} (Ast)`, () => {
             it(`let a = 1, b = 2, c = |3 in c`, () => {
                 const [text, position] = textWithPosition(`let a = 1, b = 2, c = |3 in c`);
                 const expected: AbridgedInspection = {
@@ -1137,15 +1137,6 @@ describe(`Inspection`, () => {
                 expectParseOkAbridgedInspectionEqual(text, position, expected);
             });
 
-            it(`let a = let a = 1 in | in a`, () => {
-                const [text, position] = textWithPosition(`let a = let a = 1 in | in a`);
-                const expected: AbridgedInspection = {
-                    nodes: [],
-                    scope: [`a`],
-                };
-                expectParseErrAbridgedInspectionEqual(text, position, expected);
-            });
-
             it(`let a = let a1 = 1 in |a1, b = 2, c = 3 in c`, () => {
                 const [text, position] = textWithPosition(`let a = let a1 = 1 in |a1, b = 2, c = 3 in c`);
                 const expected: AbridgedInspection = {
@@ -1153,6 +1144,26 @@ describe(`Inspection`, () => {
                     scope: [`a1`, `b`, `c`],
                 };
                 expectParseOkAbridgedInspectionEqual(text, position, expected);
+            });
+        });
+
+        describe(`${Ast.NodeKind.LetExpression} (ParserContext)`, () => {
+            it(`let a = 1, b = 2, c = 3 in |`, () => {
+                const [text, position] = textWithPosition(`let a = 1, b = 2, c = 3 in |`);
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`a`, `b`, `c`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
+            it(`let a = let a = 1 in | in a`, () => {
+                const [text, position] = textWithPosition(`let a = let a = 1 in | in a`);
+                const expected: AbridgedInspection = {
+                    nodes: [],
+                    scope: [`a`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
             });
         });
     });


### PR DESCRIPTION
This PR makes the following improvements to the inspection scope: 

- #57: exclude current section member from scope
- #60: set scope node to `IdentifierPairedExpression` so intellisense code can determine identifier type
- #61: include section members declared after cursor position
