### PR TITLE
Fix for inspection of invoke expression argument's position

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -3,10 +3,11 @@
 
 /* tslint:disable:no-console */
 
+import { Inspection } from ".";
 import { Option, ResultKind } from "./common";
-import { TriedLexAndParse, tryLexAndParse } from "./jobs";
+import { LexAndParseOk, TriedLexAndParse, tryLexAndParse } from "./jobs";
 import { Lexer, LexerError, LexerSnapshot, TriedLexerSnapshot } from "./lexer";
-import { ParserError } from "./parser";
+import { NodeIdMap, ParserContext, ParserError } from "./parser";
 
 parseText(`if true then 1 else 2`);
 
@@ -86,4 +87,45 @@ function lexText(text: string): void {
         console.log(error.innerError.message);
         console.log(JSON.stringify(error.innerError, undefined, 4));
     }
+}
+
+// @ts-ignore
+function inspectText(text: string): void {
+    let nodeIdMapCollection: NodeIdMap.Collection;
+    let leafNodeIds: ReadonlyArray<number>;
+
+    // An inspection can be done if the text is successfully parsed,
+    // or a ParserError instance was thrown during the parsing.
+    const triedLexAndParse: TriedLexAndParse = tryLexAndParse(text);
+    if (triedLexAndParse.kind === ResultKind.Err) {
+        if (!(triedLexAndParse.error instanceof ParserError.ParserError)) {
+            console.log(`Lex and parse failed due to: ${triedLexAndParse.error.message}`);
+            return;
+        }
+
+        const contextState: ParserContext.State = triedLexAndParse.error.context;
+        nodeIdMapCollection = contextState.nodeIdMapCollection;
+        leafNodeIds = contextState.leafNodeIds;
+    } else {
+        const lexAndParseOk: LexAndParseOk = triedLexAndParse.value;
+        nodeIdMapCollection = lexAndParseOk.nodeIdMapCollection;
+        leafNodeIds = lexAndParseOk.leafNodeIds;
+    }
+
+    // Create the cursor position for the inspection.
+    const position: Inspection.Position = {
+        lineNumber: 0,
+        lineCodeUnit: 6,
+    };
+
+    // An inspection can fail if given invalid arguments.
+    const triedInspection: Inspection.TriedInspection = Inspection.tryFrom(position, nodeIdMapCollection, leafNodeIds);
+    if (triedInspection.kind === ResultKind.Err) {
+        console.log(`Inspection failed due to: ${triedInspection.error.message}`);
+        return;
+    }
+    const inspected: Inspection.Inspected = triedInspection.value;
+
+    console.log(`Inspection scope: ${[...inspected.scope.entries()]}`);
+    console.log(`Inspection nodes: ${JSON.stringify(inspected.nodes, undefined, 4)}`);
 }

--- a/src/example.ts
+++ b/src/example.ts
@@ -90,7 +90,7 @@ function lexText(text: string): void {
 }
 
 // @ts-ignore
-function inspectText(text: string): void {
+function inspectText(text: string, position: Inspection.Position): void {
     let nodeIdMapCollection: NodeIdMap.Collection;
     let leafNodeIds: ReadonlyArray<number>;
 
@@ -111,12 +111,6 @@ function inspectText(text: string): void {
         nodeIdMapCollection = lexAndParseOk.nodeIdMapCollection;
         leafNodeIds = lexAndParseOk.leafNodeIds;
     }
-
-    // Create the cursor position for the inspection.
-    const position: Inspection.Position = {
-        lineNumber: 0,
-        lineCodeUnit: 6,
-    };
 
     // An inspection can fail if given invalid arguments.
     const triedInspection: Inspection.TriedInspection = Inspection.tryFrom(position, nodeIdMapCollection, leafNodeIds);

--- a/src/inspection/visitNode.ts
+++ b/src/inspection/visitNode.ts
@@ -96,7 +96,7 @@ function inspectFunctionExpression(state: State, fnExpressionXorNode: NodeIdMap.
         throw expectedNodeKindError(fnExpressionXorNode, Ast.NodeKind.FunctionExpression);
     }
 
-    const drilldownToCsvArrayRequest: NodeIdMap.MultipleChildByAttributeIndexRequest = {
+    const drilldownToCsvArrayRequest: NodeIdMap.RepeatedChildByAttributeIndexRequest = {
         nodeIdMapCollection: state.nodeIdMapCollection,
         firstDrilldown: {
             rootNodeId: fnExpressionXorNode.node.id,
@@ -110,7 +110,7 @@ function inspectFunctionExpression(state: State, fnExpressionXorNode: NodeIdMap.
             },
         ],
     };
-    const maybeCsvArrayXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeMultipleChildByAttributeRequest(
+    const maybeCsvArrayXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeRepeatedChildByAttributeRequest(
         drilldownToCsvArrayRequest,
     );
 
@@ -183,7 +183,7 @@ function inspectIdentifierExpression(state: State, identifierExprXorNode: NodeId
             const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
 
             // Add the optional inclusive constant `@` if it was parsed.
-            const maybeInclusiveConstant: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+            const maybeInclusiveConstant: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
                 nodeIdMapCollection,
                 identifierExprXorNode.node.id,
                 0,
@@ -194,7 +194,7 @@ function inspectIdentifierExpression(state: State, identifierExprXorNode: NodeId
                 key += inclusiveConstant.literal;
             }
 
-            const maybeIdentifier: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+            const maybeIdentifier: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
                 nodeIdMapCollection,
                 identifierExprXorNode.node.id,
                 1,
@@ -273,7 +273,7 @@ function inspectInvokeExpression(state: State, invokeExprXorNode: NodeIdMap.TXor
 
     // Grab arguments if they exist.
     // If they do not, return a Node where maybeArguments is undefined.
-    const maybeCsvArrayXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+    const maybeCsvArrayXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
         state.nodeIdMapCollection,
         invokeExprXorNode.node.id,
         1,
@@ -327,7 +327,7 @@ function inspectInvokeExpression(state: State, invokeExprXorNode: NodeIdMap.TXor
 function inspectLetExpression(state: State, letExprXorNode: NodeIdMap.TXorNode): void {
     const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
 
-    const maybeCsvArrayXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+    const maybeCsvArrayXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
         nodeIdMapCollection,
         letExprXorNode.node.id,
         1,
@@ -341,7 +341,7 @@ function inspectLetExpression(state: State, letExprXorNode: NodeIdMap.TXorNode):
     for (const keyValuePairXorNode of nodesOnCsvFromCsvArray(nodeIdMapCollection, csvArrayXorNode)) {
         const keyValuePairId: number = keyValuePairXorNode.node.id;
 
-        const maybeKeyXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+        const maybeKeyXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
             nodeIdMapCollection,
             keyValuePairId,
             0,
@@ -359,7 +359,7 @@ function inspectLetExpression(state: State, letExprXorNode: NodeIdMap.TXorNode):
             }
         }
 
-        const maybeValueXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+        const maybeValueXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
             nodeIdMapCollection,
             keyValuePairId,
             2,
@@ -412,7 +412,7 @@ function inspectListExpressionOrLiteral(state: State, listXorNode: NodeIdMap.TXo
 }
 
 function inspectParameter(state: State, parameterXorNode: NodeIdMap.TXorNode): void {
-    const maybeNameXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+    const maybeNameXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
         state.nodeIdMapCollection,
         parameterXorNode.node.id,
         1,
@@ -469,7 +469,7 @@ function inspectRecordExpressionOrLiteral(state: State, recordXorNode: NodeIdMap
             throw isNever(recordXorNode);
     }
 
-    const maybeCsvArrayXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+    const maybeCsvArrayXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
         nodeIdMapCollection,
         recordXorNode.node.id,
         1,
@@ -483,7 +483,7 @@ function inspectRecordExpressionOrLiteral(state: State, recordXorNode: NodeIdMap
     for (const keyValuePairXorNode of nodesOnCsvFromCsvArray(nodeIdMapCollection, csvArrayXorNode)) {
         const keyValuePairId: number = keyValuePairXorNode.node.id;
 
-        const maybeKeyXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+        const maybeKeyXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
             nodeIdMapCollection,
             keyValuePairId,
             0,
@@ -495,7 +495,7 @@ function inspectRecordExpressionOrLiteral(state: State, recordXorNode: NodeIdMap
         const keyXorNode: NodeIdMap.TXorNode = maybeKeyXorNode;
         inspectGeneralizedIdentifier(state, keyXorNode);
 
-        const maybeValueXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+        const maybeValueXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
             nodeIdMapCollection,
             keyValuePairId,
             2,
@@ -509,7 +509,7 @@ function inspectRecordExpressionOrLiteral(state: State, recordXorNode: NodeIdMap
 }
 
 function inspectRecursivePrimaryExpression(state: State, recursivePrimaryExprXorNode: NodeIdMap.TXorNode): void {
-    const maybeHeadXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+    const maybeHeadXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
         state.nodeIdMapCollection,
         recursivePrimaryExprXorNode.node.id,
         0,
@@ -525,7 +525,7 @@ function inspectRecursivePrimaryExpression(state: State, recursivePrimaryExprXor
 function inspectSection(state: State, sectionXorNode: NodeIdMap.TXorNode): void {
     const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
 
-    const maybeSectionMemberArrayXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+    const maybeSectionMemberArrayXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
         nodeIdMapCollection,
         sectionXorNode.node.id,
         4,
@@ -542,7 +542,7 @@ function inspectSection(state: State, sectionXorNode: NodeIdMap.TXorNode): void 
     );
 
     for (const sectionMember of sectionMemberXorNodes) {
-        const maybeIdentifierPairedExprXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+        const maybeIdentifierPairedExprXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
             nodeIdMapCollection,
             sectionMember.node.id,
             2,
@@ -554,7 +554,7 @@ function inspectSection(state: State, sectionXorNode: NodeIdMap.TXorNode): void 
         const identifierPairedExprXorNode: NodeIdMap.TXorNode = maybeIdentifierPairedExprXorNode;
         const identifierPairedExprId: number = identifierPairedExprXorNode.node.id;
 
-        const maybeNameXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+        const maybeNameXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
             nodeIdMapCollection,
             identifierPairedExprId,
             0,
@@ -571,7 +571,7 @@ function inspectSection(state: State, sectionXorNode: NodeIdMap.TXorNode): void 
             }
         }
 
-        const maybeValueXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+        const maybeValueXorNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
             nodeIdMapCollection,
             identifierPairedExprId,
             2,
@@ -703,7 +703,7 @@ function nodesOnCsvFromCsvArray(
 
     const result: NodeIdMap.TXorNode[] = [];
     for (const csvXorNode of csvXorNodes) {
-        const maybeCsvNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeChildByAttributeIndex(
+        const maybeCsvNode: Option<NodeIdMap.TXorNode> = NodeIdMap.maybeXorChildByAttributeIndex(
             nodeIdMapCollection,
             csvXorNode.node.id,
             0,

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -13,6 +13,7 @@ export interface LexAndParseOk {
     readonly ast: Ast.TDocument;
     readonly comments: ReadonlyArray<TComment>;
     readonly nodeIdMapCollection: NodeIdMap.Collection;
+    readonly leafNodeIds: ReadonlyArray<number>;
 }
 
 export function tryLexAndParse(text: string): TriedLexAndParse {
@@ -48,6 +49,7 @@ export function tryLexAndParse(text: string): TriedLexAndParse {
             ast: parseOk.document,
             comments: lexerSnapshot.comments,
             nodeIdMapCollection: parseOk.nodeIdMapCollection,
+            leafNodeIds: parseOk.leafNodeIds,
         },
     };
 }

--- a/src/parser/nodeIdMap.ts
+++ b/src/parser/nodeIdMap.ts
@@ -31,7 +31,7 @@ export interface Collection {
     readonly childIdsById: ChildIdsById;
 }
 
-export interface RepeatedChildByAttributeIndexRequest {
+export interface RepeatedAttributeIndexRequest {
     readonly nodeIdMapCollection: Collection;
     readonly firstDrilldown: FirstDrilldown;
     readonly drilldowns: ReadonlyArray<Drilldown>;
@@ -102,7 +102,7 @@ export function maybeAstChildren(nodeIdMapCollection: Collection, parentId: numb
 }
 
 // Helper function for repeatedly calling maybeXorChildByAttributeIndex.
-export function maybeRepeatedChildByAttributeRequest(request: RepeatedChildByAttributeIndexRequest): Option<TXorNode> {
+export function maybeXorChildByRepeatedAttributeIndex(request: RepeatedAttributeIndexRequest): Option<TXorNode> {
     const nodeIdMapCollection: Collection = request.nodeIdMapCollection;
     const firstDrilldown: FirstDrilldown = request.firstDrilldown;
 
@@ -170,6 +170,26 @@ export function maybeXorChildByAttributeIndex(
     }
 
     return undefined;
+}
+
+export function maybeAstChildByAttributeIndex(
+    nodeIdMapCollection: Collection,
+    parentId: number,
+    attributeIndex: number,
+    maybeChildNodeKinds: Option<ReadonlyArray<Ast.NodeKind>>,
+): Option<Ast.TNode> {
+    const maybeNode: Option<TXorNode> = maybeXorChildByAttributeIndex(
+        nodeIdMapCollection,
+        parentId,
+        attributeIndex,
+        maybeChildNodeKinds,
+    );
+
+    if (maybeNode === undefined || maybeNode.kind === XorNodeKind.Context) {
+        return undefined;
+    } else {
+        return maybeNode.node;
+    }
 }
 
 export function maybeInvokeExpressionName(nodeIdMapCollection: Collection, nodeId: number): Option<string> {
@@ -271,7 +291,27 @@ export function expectXorChildByAttributeIndex(
     );
     if (maybeNode === undefined) {
         const details: {} = { parentId, attributeIndex };
-        throw new CommonError.InvariantError(`parentId doesn't have a child at given index`, details);
+        throw new CommonError.InvariantError(`parentId doesn't have a child at the given index`, details);
+    }
+
+    return maybeNode;
+}
+
+export function expectAstChildByAttributeIndex(
+    nodeIdMapCollection: Collection,
+    parentId: number,
+    attributeIndex: number,
+    maybeChildNodeKinds: Option<ReadonlyArray<Ast.NodeKind>>,
+): Ast.TNode {
+    const maybeNode: Option<Ast.TNode> = maybeAstChildByAttributeIndex(
+        nodeIdMapCollection,
+        parentId,
+        attributeIndex,
+        maybeChildNodeKinds,
+    );
+    if (maybeNode === undefined) {
+        const details: {} = { parentId, attributeIndex };
+        throw new CommonError.InvariantError(`parentId doesn't have an Ast child at the given index`, details);
     }
 
     return maybeNode;

--- a/src/parser/nodeIdMap.ts
+++ b/src/parser/nodeIdMap.ts
@@ -31,7 +31,7 @@ export interface Collection {
     readonly childIdsById: ChildIdsById;
 }
 
-export interface MultipleChildByAttributeIndexRequest {
+export interface RepeatedChildByAttributeIndexRequest {
     readonly nodeIdMapCollection: Collection;
     readonly firstDrilldown: FirstDrilldown;
     readonly drilldowns: ReadonlyArray<Drilldown>;
@@ -101,12 +101,12 @@ export function maybeAstChildren(nodeIdMapCollection: Collection, parentId: numb
     return childIds.map(childId => expectAstNode(astNodeById, childId));
 }
 
-// Helper function for repeatedly calling maybeChildByAttributeIndex.
-export function maybeMultipleChildByAttributeRequest(request: MultipleChildByAttributeIndexRequest): Option<TXorNode> {
+// Helper function for repeatedly calling maybeXorChildByAttributeIndex.
+export function maybeRepeatedChildByAttributeRequest(request: RepeatedChildByAttributeIndexRequest): Option<TXorNode> {
     const nodeIdMapCollection: Collection = request.nodeIdMapCollection;
     const firstDrilldown: FirstDrilldown = request.firstDrilldown;
 
-    let maybeChildXorNode: Option<TXorNode> = maybeChildByAttributeIndex(
+    let maybeChildXorNode: Option<TXorNode> = maybeXorChildByAttributeIndex(
         nodeIdMapCollection,
         firstDrilldown.rootNodeId,
         firstDrilldown.attributeIndex,
@@ -118,7 +118,7 @@ export function maybeMultipleChildByAttributeRequest(request: MultipleChildByAtt
             return maybeChildXorNode;
         }
 
-        maybeChildXorNode = maybeChildByAttributeIndex(
+        maybeChildXorNode = maybeXorChildByAttributeIndex(
             nodeIdMapCollection,
             maybeChildXorNode.node.id,
             drilldown.attributeIndex,
@@ -138,7 +138,7 @@ export function maybeMultipleChildByAttributeRequest(request: MultipleChildByAtt
 //
 // An optional array of Ast.NodeKind can be given for validation purposes.
 // If the child's node kind isn't in the given array, then an exception is thrown.
-export function maybeChildByAttributeIndex(
+export function maybeXorChildByAttributeIndex(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
@@ -190,7 +190,7 @@ export function maybeInvokeExpressionName(nodeIdMapCollection: Collection, nodeI
         // Grab the RecursivePrimaryExpression's head if it's an IdentifierExpression
         const recursiveArrayXorNode: TXorNode = expectParentXorNode(nodeIdMapCollection, invokeExprXorNode.node.id);
         const recursiveExprXorNode: TXorNode = expectParentXorNode(nodeIdMapCollection, recursiveArrayXorNode.node.id);
-        const headXorNode: TXorNode = expectChildByAttributeIndex(
+        const headXorNode: TXorNode = expectXorChildByAttributeIndex(
             nodeIdMapCollection,
             recursiveExprXorNode.node.id,
             0,
@@ -257,13 +257,13 @@ export function expectParentAstNode(nodeIdMapCollection: Collection, nodeId: num
     return maybeNode;
 }
 
-export function expectChildByAttributeIndex(
+export function expectXorChildByAttributeIndex(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
     maybeChildNodeKinds: Option<ReadonlyArray<Ast.NodeKind>>,
 ): TXorNode {
-    const maybeNode: Option<TXorNode> = maybeChildByAttributeIndex(
+    const maybeNode: Option<TXorNode> = maybeXorChildByAttributeIndex(
         nodeIdMapCollection,
         parentId,
         attributeIndex,

--- a/src/test/inspection/abridgedInspected.ts
+++ b/src/test/inspection/abridgedInspected.ts
@@ -657,6 +657,30 @@ describe(`Inspection`, () => {
                 expectParseErrAbridgedInspectionEqual(text, position, expected);
             });
 
+            it(`foo(x, |`, () => {
+                const [text, position] = textWithPosition(`foo(x, |`);
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.InvokeExpression,
+                            maybePositionStart: {
+                                codeUnit: 3,
+                                lineCodeUnit: 3,
+                                lineNumber: 0,
+                            },
+                            maybeName: "foo",
+                            maybePositionEnd: undefined,
+                            maybeArguments: {
+                                numArguments: 2,
+                                positionArgumentIndex: 1,
+                            },
+                        },
+                    ],
+                    scope: [`x`, `foo`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
             it(`[x](y|`, () => {
                 const text: string = `[x](y`;
                 const position: Inspection.Position = {

--- a/src/test/inspection/abridgedInspected.ts
+++ b/src/test/inspection/abridgedInspected.ts
@@ -633,6 +633,30 @@ describe(`Inspection`, () => {
                 expectParseErrAbridgedInspectionEqual(text, position, expected);
             });
 
+            it(`foo(x,|`, () => {
+                const [text, position] = textWithPosition(`foo(x,|`);
+                const expected: AbridgedInspection = {
+                    nodes: [
+                        {
+                            kind: NodeKind.InvokeExpression,
+                            maybePositionStart: {
+                                codeUnit: 3,
+                                lineCodeUnit: 3,
+                                lineNumber: 0,
+                            },
+                            maybeName: "foo",
+                            maybePositionEnd: undefined,
+                            maybeArguments: {
+                                numArguments: 2,
+                                positionArgumentIndex: 1,
+                            },
+                        },
+                    ],
+                    scope: [`x`, `foo`],
+                };
+                expectParseErrAbridgedInspectionEqual(text, position, expected);
+            });
+
             it(`[x](y|`, () => {
                 const text: string = `[x](y`;
                 const position: Inspection.Position = {


### PR DESCRIPTION
Hopefully resolves #58. Also threw in the renaming of NodeIdMap functions like `expectChildByAttributeIndex` into `expectXorChildByAttributeIndex`.