### PR TITLE
Bug fix inspection position check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.1.30",
+    "version": "0.1.31",
     "description": "A parser for the Power Query/M formula language.",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/inspection/position.ts
+++ b/src/inspection/position.ts
@@ -111,7 +111,7 @@ export function isPositionBeforeTokenPosition(position: Position, tokenPositionS
     } else if (positionLineNumber > tokenPositionStart.lineNumber) {
         return false;
     } else {
-        return position.lineCodeUnit <= tokenPositionStart.codeUnit;
+        return position.lineCodeUnit <= tokenPositionStart.lineCodeUnit;
     }
 }
 
@@ -123,6 +123,6 @@ export function isPositionAfterTokenPosition(position: Position, tokenPositionEn
     } else if (positionLineNumber > tokenPositionEnd.lineNumber) {
         return true;
     } else {
-        return position.lineCodeUnit > tokenPositionEnd.codeUnit;
+        return position.lineCodeUnit > tokenPositionEnd.lineCodeUnit;
     }
 }


### PR DESCRIPTION
`codeUnit` should've been `lineCodeUnit`. Sometimes resulted in position checks (such as in LetExpression keys) being incorrect.