### PR TITLE
[Build] Enable policheck in azure pipeline build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,19 +18,29 @@ steps:
     versionSpec: '10.x'
   displayName: 'Install Node.js'
 
-- script: npm install
+- task: Npm@1
+  displayName: 'npm install'
+  inputs:
+    command: 'install'
 
-- script: npm run-script build
+- task: Npm@1
+  displayName: 'build'
+  inputs:
+    command: 'custom'
+    customCommand: 'run build'
 
-- script: npm test
-  displayName: 'run tests'
+- task: Npm@1
+  displayName: 'npm test'
+  inputs:
+    command: 'custom'
+    customCommand: 'test'
 
 - task: PoliCheck@1
   inputs:
     inputType: 'Basic'
     targetType: 'F'
     targetArgument: '$(Build.SourcesDirectory)'
-    result: '$(Build.ArtifactStagingDirectory)/PoliCheck.xml'
+    result: 'PoliCheck.xml'
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()
@@ -44,8 +54,8 @@ steps:
     ArtifactName: lib
   displayName: 'publish lib'
 
-# - task: PublishBuildArtifacts@1
-#  inputs:
-#    PathtoPublish: '$(Build.ArtifactStagingDirectory)/PoliCheck.xml'
-#    ArtifactName: PoliCheck
-#  displayName: 'publish policheck results'
+- task: PublishBuildArtifacts@1
+  inputs:
+   PathtoPublish: '$(System.DefaultWorkingDirectory)/PoliCheck.xml'
+   ArtifactName: PoliCheck
+  displayName: 'publish policheck results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ steps:
 
 - task: PublishBuildArtifacts@1
   inputs:
-    PathtoPublish: '$(System.DefaultWorkingDirectory)/lib'
+    PathtoPublish: '$(Build.SourcesDirectory)/lib'
     ArtifactName: lib
   displayName: 'publish lib'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ steps:
   inputs:
     inputType: 'Basic'
     targetType: 'F'
-    targetArgument: '$(Build.SourcesDirectory)'
+    targetArgument: '$(Build.SourcesDirectory)/src'
     result: 'PoliCheck.xml'
 
 - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
 - master
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'windows-latest'
 
 steps:
 - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,13 @@ steps:
 - script: npm test
   displayName: 'run tests'
 
+- task: PoliCheck@1
+  inputs:
+    inputType: 'Basic'
+    targetType: 'F'
+    targetArgument: '$(Build.SourcesDirectory)'
+    result: 'PoliCheck.xml'
+
 - task: PublishTestResults@2
   condition: succeededOrFailed()
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,6 +56,6 @@ steps:
 
 - task: PublishBuildArtifacts@1
   inputs:
-   PathtoPublish: '$(System.DefaultWorkingDirectory)/PoliCheck.xml'
+   PathtoPublish: '$(System.DefaultWorkingDirectory)/../_sdt/logs/PoliCheck'
    ArtifactName: PoliCheck
   displayName: 'publish policheck results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ steps:
     inputType: 'Basic'
     targetType: 'F'
     targetArgument: '$(Build.SourcesDirectory)'
-    result: 'PoliCheck.xml'
+    result: '$(Build.ArtifactStagingDirectory)/PoliCheck.xml'
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()
@@ -44,3 +44,9 @@ steps:
     PathtoPublish: '$(System.DefaultWorkingDirectory)/lib'
     ArtifactName: lib
   displayName: 'publish lib'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/PoliCheck.xml'
+    ArtifactName: PoliCheck
+  displayName: 'publish policheck results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,10 +18,9 @@ steps:
     versionSpec: '10.x'
   displayName: 'Install Node.js'
 
-- script: |
-    npm install
-    npm run-script build
-  displayName: 'npm install and build'
+- script: npm install
+
+- script: npm run-script build
 
 - script: npm test
   displayName: 'run tests'
@@ -41,12 +40,12 @@ steps:
 
 - task: PublishBuildArtifacts@1
   inputs:
-    PathtoPublish: '$(Build.SourcesDirectory)/lib'
+    PathtoPublish: '$(System.DefaultWorkingDirectory)/lib'
     ArtifactName: lib
   displayName: 'publish lib'
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/PoliCheck.xml'
-    ArtifactName: PoliCheck
-  displayName: 'publish policheck results'
+# - task: PublishBuildArtifacts@1
+#  inputs:
+#    PathtoPublish: '$(Build.ArtifactStagingDirectory)/PoliCheck.xml'
+#    ArtifactName: PoliCheck
+#  displayName: 'publish policheck results'


### PR DESCRIPTION
Enables Policheck on default build pipeline. Switch to windows VM was required to run the tools. The full log output now ends up with the artifacts.

The Policheck task seems to ignore the full path you provide to its target output file, so I had to do some directory manipulation to be able to fetch the file in the end.