### PR TITLE
Match reading GeneralizedIdentifiers with C# parser

### DIFF
--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -202,7 +202,7 @@ export function isOnIdentifierConstant(state: IParserState, identifierConstant: 
     }
 }
 
-export function isOnGeneralizedIdentifierToken(state: IParserState, tokenIndex: number = state.tokenIndex): boolean {
+export function isOnGeneralizedIdentifierStart(state: IParserState, tokenIndex: number = state.tokenIndex): boolean {
     const maybeToken: Option<Token> = state.lexerSnapshot.tokens[tokenIndex];
     if (maybeToken === undefined) {
         return false;

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -23,6 +23,12 @@ interface WrappedRead<Kind, Content> extends Ast.IWrapped<Kind, Content> {
     readonly maybeOptionalConstant: Option<Ast.Constant>;
 }
 
+const InvalidGeneralizedIdentifierTokenKinds: ReadonlyArray<TokenKind> = [
+    TokenKind.Comma,
+    TokenKind.Equal,
+    TokenKind.RightBracket,
+];
+
 // -------------------------------------------
 // ---------- // 12.1.6 Identifiers ----------
 // -------------------------------------------
@@ -43,6 +49,7 @@ export function readIdentifier(state: IParserState, _parser: IParser<IParserStat
     return astNode;
 }
 
+// This behavior matches the C# parser and not the language specification.
 export function readGeneralizedIdentifier(
     state: IParserState,
     _parser: IParser<IParserState>,
@@ -53,29 +60,12 @@ export function readGeneralizedIdentifier(
     let literal: string;
     let astNode: Ast.GeneralizedIdentifier;
 
-    // Edge case where GeneralizedIdentifier is only decmal numbers.
-    // The logic should be more robust as it should technically support the following:
-    // `1.a`
-    // `෬` - non ASCII character from Unicode class Nd (U+0DEC SINHALA LITH DIGIT SIX)
-    if (
-        state.maybeCurrentToken !== undefined &&
-        state.maybeCurrentToken.kind === TokenKind.NumericLiteral &&
-        state.maybeCurrentToken.data.match("^\\d+$")
-    ) {
-        literal = readToken(state);
-        astNode = {
-            ...IParserStateUtils.expectContextNodeMetadata(state),
-            kind: nodeKind,
-            isLeaf: true,
-            literal,
-        };
-        IParserStateUtils.endContext(state, astNode);
-        return astNode;
-    }
-
     const tokenRangeStartIndex: number = state.tokenIndex;
     let tokenRangeEndIndex: number = tokenRangeStartIndex;
-    while (IParserStateUtils.isOnGeneralizedIdentifierToken(state)) {
+    while (
+        state.maybeCurrentTokenKind &&
+        InvalidGeneralizedIdentifierTokenKinds.indexOf(state.maybeCurrentTokenKind) === -1
+    ) {
         readToken(state);
         tokenRangeEndIndex = state.tokenIndex;
     }
@@ -1256,7 +1246,7 @@ export function readFieldSpecificationList(
             } else {
                 throw fieldSpecificationListReadError(state, allowOpenMarker);
             }
-        } else if (IParserStateUtils.isOnGeneralizedIdentifierToken(state)) {
+        } else if (IParserStateUtils.isOnGeneralizedIdentifierStart(state)) {
             const csvNodeKind: Ast.NodeKind.Csv = Ast.NodeKind.Csv;
             IParserStateUtils.startContext(state, csvNodeKind);
 

--- a/src/test/parser/simple.ts
+++ b/src/test/parser/simple.ts
@@ -676,6 +676,17 @@ describe("Parser.AbridgedNode", () => {
             ];
             expectAbridgeNodes(text, expected);
         });
+
+        it(`[a.1]`, () => {
+            const text: string = `[a.1]`;
+            const expected: ReadonlyArray<AbridgedNode> = [
+                [Ast.NodeKind.FieldSelector, undefined],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.GeneralizedIdentifier, 1],
+                [Ast.NodeKind.Constant, 2],
+            ];
+            expectAbridgeNodes(text, expected);
+        });
     });
 
     it(Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral, () => {


### PR DESCRIPTION
Solves #78 

The C# parser is way looser with what can be read for a generalized identifier. We're going to match its behavior.