### PR TITLE
Refactor ConstantKind

### DIFF
--- a/src/inspection/activeNode/activeNodeUtils.ts
+++ b/src/inspection/activeNode/activeNodeUtils.ts
@@ -188,7 +188,7 @@ function isAnchorNode(position: Position, astNode: Ast.TNode): boolean {
     ) {
         return true;
     } else if (astNode.kind === Ast.NodeKind.Constant) {
-        switch (astNode.literal) {
+        switch (astNode.constantKind) {
             case Ast.ConstantKind.As:
             case Ast.ConstantKind.Each:
             case Ast.ConstantKind.Else:
@@ -234,11 +234,12 @@ function positionAstSearch(
         let isBoundIncluded: boolean;
         if (
             // let x|=1
-            (candidate.kind === Ast.NodeKind.Constant && ShiftRightConstantKinds.indexOf(candidate.literal) !== -1) ||
+            (candidate.kind === Ast.NodeKind.Constant &&
+                ShiftRightConstantKinds.indexOf(candidate.constantKind) !== -1) ||
             // let x=|1
             (maybeCurrentOnOrBefore !== undefined &&
                 maybeCurrentOnOrBefore.kind === Ast.NodeKind.Constant &&
-                ShiftRightConstantKinds.indexOf(maybeCurrentOnOrBefore.literal) !== -1)
+                ShiftRightConstantKinds.indexOf(maybeCurrentOnOrBefore.constantKind) !== -1)
         ) {
             isBoundIncluded = false;
         } else {
@@ -272,13 +273,10 @@ function positionAstSearch(
 
         // Requires a shift into an empty ArrayWrapper.
         if (
-            DrilldownConstantKind.indexOf(maybeCurrentOnOrBefore.literal) !== -1 &&
+            DrilldownConstantKind.indexOf(maybeCurrentOnOrBefore.constantKind) !== -1 &&
             maybeCurrentAfter !== undefined &&
             maybeCurrentAfter.kind === Ast.NodeKind.Constant &&
-            AstUtils.isPairedConstant(
-                maybeCurrentOnOrBefore.literal as Ast.ConstantKind,
-                maybeCurrentAfter.literal as Ast.ConstantKind,
-            )
+            AstUtils.isPairedConstant(maybeCurrentOnOrBefore.constantKind, maybeCurrentAfter.constantKind)
         ) {
             const parent: Ast.TNode = NodeIdMapUtils.expectParentAstNode(nodeIdMapCollection, currentOnOrBefore.id, [
                 Ast.NodeKind.RecordExpression,
@@ -296,7 +294,7 @@ function positionAstSearch(
             maybeShiftedNode = arrayWrapper;
         }
         // Requires a shift to the right.
-        else if (ShiftRightConstantKinds.indexOf(currentOnOrBefore.literal) !== -1) {
+        else if (ShiftRightConstantKinds.indexOf(currentOnOrBefore.constantKind) !== -1) {
             maybeShiftedNode = maybeCurrentAfter;
         }
         // No shifting.
@@ -350,7 +348,7 @@ function maybeIdentifierUnderPosition(
     let identifier: Ast.Identifier | Ast.GeneralizedIdentifier;
 
     // If closestLeaf is '@', then check if it's part of an IdentifierExpression.
-    if (leaf.node.kind === Ast.NodeKind.Constant && leaf.node.literal === `@`) {
+    if (leaf.node.kind === Ast.NodeKind.Constant && leaf.node.constantKind === Ast.ConstantKind.AtSign) {
         const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(leaf.node.id);
         if (maybeParentId === undefined) {
             return undefined;

--- a/src/inspection/activeNode/activeNodeUtils.ts
+++ b/src/inspection/activeNode/activeNodeUtils.ts
@@ -159,19 +159,19 @@ interface AstNodeSearch {
 }
 
 const DrilldownConstantKind: ReadonlyArray<string> = [
-    Ast.ConstantKind.LeftBrace,
-    Ast.ConstantKind.LeftBracket,
-    Ast.ConstantKind.LeftParenthesis,
+    Ast.WrapperConstantKind.LeftBrace,
+    Ast.WrapperConstantKind.LeftBracket,
+    Ast.WrapperConstantKind.LeftParenthesis,
 ];
 
 const ShiftRightConstantKinds: ReadonlyArray<string> = [
-    Ast.ConstantKind.Comma,
-    Ast.ConstantKind.Equal,
-    Ast.ConstantKind.FatArrow,
-    Ast.ConstantKind.RightBrace,
-    Ast.ConstantKind.RightBracket,
-    Ast.ConstantKind.RightParenthesis,
-    Ast.ConstantKind.Semicolon,
+    Ast.MiscConstantKind.Comma,
+    Ast.MiscConstantKind.Equal,
+    Ast.MiscConstantKind.FatArrow,
+    Ast.WrapperConstantKind.RightBrace,
+    Ast.WrapperConstantKind.RightBracket,
+    Ast.WrapperConstantKind.RightParenthesis,
+    Ast.MiscConstantKind.Semicolon,
     ...DrilldownConstantKind,
 ];
 
@@ -189,22 +189,23 @@ function isAnchorNode(position: Position, astNode: Ast.TNode): boolean {
         return true;
     } else if (astNode.kind === Ast.NodeKind.Constant) {
         switch (astNode.constantKind) {
-            case Ast.ConstantKind.As:
-            case Ast.ConstantKind.Each:
-            case Ast.ConstantKind.Else:
-            case Ast.ConstantKind.Error:
-            case Ast.ConstantKind.If:
-            case Ast.ConstantKind.In:
-            case Ast.ConstantKind.Is:
-            case Ast.ConstantKind.Section:
-            case Ast.ConstantKind.Shared:
-            case Ast.ConstantKind.Let:
-            case Ast.ConstantKind.Meta:
-            case Ast.ConstantKind.Null:
-            case Ast.ConstantKind.Otherwise:
-            case Ast.ConstantKind.Then:
-            case Ast.ConstantKind.Try:
-            case Ast.ConstantKind.Type:
+            case Ast.KeywordConstantKind.As:
+            case Ast.KeywordConstantKind.Each:
+            case Ast.KeywordConstantKind.Else:
+            case Ast.KeywordConstantKind.Error:
+            case Ast.KeywordConstantKind.If:
+            case Ast.KeywordConstantKind.In:
+            case Ast.KeywordConstantKind.Is:
+            case Ast.KeywordConstantKind.Section:
+            case Ast.KeywordConstantKind.Shared:
+            case Ast.KeywordConstantKind.Let:
+            case Ast.KeywordConstantKind.Meta:
+            case Ast.KeywordConstantKind.Otherwise:
+            case Ast.KeywordConstantKind.Then:
+            case Ast.KeywordConstantKind.Try:
+            case Ast.KeywordConstantKind.Type:
+
+            case Ast.MiscConstantKind.Null:
                 return true;
 
             default:
@@ -276,7 +277,7 @@ function positionAstSearch(
             DrilldownConstantKind.indexOf(maybeCurrentOnOrBefore.constantKind) !== -1 &&
             maybeCurrentAfter !== undefined &&
             maybeCurrentAfter.kind === Ast.NodeKind.Constant &&
-            AstUtils.isPairedConstant(maybeCurrentOnOrBefore.constantKind, maybeCurrentAfter.constantKind)
+            AstUtils.isPairedWrapperConstantKinds(maybeCurrentOnOrBefore.constantKind, maybeCurrentAfter.constantKind)
         ) {
             const parent: Ast.TNode = NodeIdMapUtils.expectParentAstNode(nodeIdMapCollection, currentOnOrBefore.id, [
                 Ast.NodeKind.RecordExpression,
@@ -348,7 +349,7 @@ function maybeIdentifierUnderPosition(
     let identifier: Ast.Identifier | Ast.GeneralizedIdentifier;
 
     // If closestLeaf is '@', then check if it's part of an IdentifierExpression.
-    if (leaf.node.kind === Ast.NodeKind.Constant && leaf.node.constantKind === Ast.ConstantKind.AtSign) {
+    if (leaf.node.kind === Ast.NodeKind.Constant && leaf.node.constantKind === Ast.MiscConstantKind.AtSign) {
         const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(leaf.node.id);
         if (maybeParentId === undefined) {
             return undefined;

--- a/src/inspection/identifier.ts
+++ b/src/inspection/identifier.ts
@@ -250,7 +250,7 @@ function inspectIdentifierExpression(
 
             const key: string =
                 maybeInclusiveConstant !== undefined
-                    ? maybeInclusiveConstant.literal + identifier.literal
+                    ? maybeInclusiveConstant.constantKind + identifier.literal
                     : identifier.literal;
             addAstToScopeIfNew(state, key, identifierExprAstNode);
             break;
@@ -269,7 +269,8 @@ function inspectIdentifierExpression(
             );
             if (maybeInclusiveConstant !== undefined) {
                 const inclusiveConstant: Ast.Constant = maybeInclusiveConstant.node as Ast.Constant;
-                key += inclusiveConstant.literal;
+                // Adds the '@' prefix.
+                key = inclusiveConstant.constantKind;
             }
 
             const maybeIdentifier: NodeIdMap.TXorNode | undefined = NodeIdMapUtils.maybeXorChildByAttributeIndex(

--- a/src/parser/ast/ast.ts
+++ b/src/parser/ast/ast.ts
@@ -794,6 +794,7 @@ export interface Identifier extends INode {
 export const enum ConstantKind {
     // TokenKind
     As = "as",
+    Ampersand = "&",
     AtSign = "@",
     Comma = ",",
     DotDot = "..",
@@ -851,6 +852,10 @@ export const enum ConstantKind {
     Plus = "+",
     Minus = "-",
 
+    // EqualityOperator
+    // EqualTo ('=') is already covered by Equal
+    NotEqual = "<>",
+
     // LogicalOperator
     And = "and",
     Or = "or",
@@ -861,6 +866,7 @@ export const enum ConstantKind {
     GreaterThan = ">",
     GreaterThanEqualTo = ">=",
 
+    // Positive and Negative ('+' and '-') are already by Plus and Minus
     // UnaryOperator
     Not = "not",
 }

--- a/src/parser/ast/ast.ts
+++ b/src/parser/ast/ast.ts
@@ -306,7 +306,12 @@ export type TArithmeticExpression = ArithmeticExpression | TMetadataExpression;
 export type TMetadataExpression = MetadataExpression | TUnaryExpression;
 
 export interface MetadataExpression
-    extends IBinOpExpression<NodeKind.MetadataExpression, TUnaryExpression, ConstantKind.Meta, TUnaryExpression> {}
+    extends IBinOpExpression<
+        NodeKind.MetadataExpression,
+        TUnaryExpression,
+        KeywordConstantKind.Meta,
+        TUnaryExpression
+    > {}
 
 // -----------------------------------------------
 // ---------- 12.2.3.9 Unary expression ----------
@@ -627,8 +632,8 @@ export type TBinOpExpression =
 // The following types are needed for recursiveReadBinOpExpressionHelper,
 // and are created by converting IBinOpExpression<A, B, C, D> to IBinOpExpression<A, D, C, D>.
 export type TBinOpExpressionSubtype =
-    | IBinOpExpression<NodeKind.AsExpression, TNullablePrimitiveType, ConstantKind.As, TNullablePrimitiveType>
-    | IBinOpExpression<NodeKind.IsExpression, TNullablePrimitiveType, ConstantKind.Is, TNullablePrimitiveType>;
+    | IBinOpExpression<NodeKind.AsExpression, TNullablePrimitiveType, KeywordConstantKind.As, TNullablePrimitiveType>
+    | IBinOpExpression<NodeKind.IsExpression, TNullablePrimitiveType, KeywordConstantKind.Is, TNullablePrimitiveType>;
 
 export interface IBinOpExpression<Kind, Left, Operator, Right> extends INode {
     readonly kind: Kind & TBinOpExpressionNodeKind;
@@ -646,18 +651,28 @@ export interface ArithmeticExpression
     extends IBinOpExpression<
         NodeKind.ArithmeticExpression,
         TArithmeticExpression,
-        ArithmeticOperator,
+        ArithmeticOperatorKind,
         TArithmeticExpression
     > {}
 
 export interface AsExpression
-    extends IBinOpExpression<NodeKind.AsExpression, TEqualityExpression, ConstantKind.As, TNullablePrimitiveType> {}
+    extends IBinOpExpression<
+        NodeKind.AsExpression,
+        TEqualityExpression,
+        KeywordConstantKind.As,
+        TNullablePrimitiveType
+    > {}
 
 export interface EqualityExpression
-    extends IBinOpExpression<NodeKind.EqualityExpression, TEqualityExpression, EqualityOperator, TEqualityExpression> {}
+    extends IBinOpExpression<
+        NodeKind.EqualityExpression,
+        TEqualityExpression,
+        EqualityOperatorKind,
+        TEqualityExpression
+    > {}
 
 export interface IsExpression
-    extends IBinOpExpression<NodeKind.IsExpression, TAsExpression, ConstantKind.Is, TNullablePrimitiveType> {}
+    extends IBinOpExpression<NodeKind.IsExpression, TAsExpression, KeywordConstantKind.Is, TNullablePrimitiveType> {}
 
 export interface LogicalExpression
     extends IBinOpExpression<NodeKind.LogicalExpression, TLogicalExpression, LogicalOperator, TLogicalExpression> {}
@@ -666,7 +681,7 @@ export interface RelationalExpression
     extends IBinOpExpression<
         NodeKind.RelationalExpression,
         TRelationalExpression,
-        RelationalOperator,
+        RelationalOperatorKind,
         TRelationalExpression
     > {}
 
@@ -675,38 +690,13 @@ export interface RelationalExpression
 // ------------------------------------------------
 
 export type TBinOpExpressionOperator =
-    | ArithmeticOperator
-    | EqualityOperator
+    | ArithmeticOperatorKind
+    | EqualityOperatorKind
     | LogicalOperator
-    | RelationalOperator
-    | ConstantKind.As
-    | ConstantKind.Is
-    | ConstantKind.Meta;
-
-export const enum ArithmeticOperator {
-    Multiplication = "*",
-    Division = "/",
-    Addition = "+",
-    Subtraction = "-",
-    And = "&",
-}
-
-export const enum EqualityOperator {
-    EqualTo = "=",
-    NotEqualTo = "<>",
-}
-
-export const enum LogicalOperator {
-    And = "and",
-    Or = "or",
-}
-
-export const enum RelationalOperator {
-    LessThan = "<",
-    LessThanEqualTo = "<=",
-    GreaterThan = ">",
-    GreaterThanEqualTo = ">=",
-}
+    | RelationalOperatorKind
+    | KeywordConstantKind.As
+    | KeywordConstantKind.Is
+    | KeywordConstantKind.Meta;
 
 // ------------------------------------------
 // ---------- Key value pair nodes ----------
@@ -753,7 +743,7 @@ export interface AsType extends IPairedConstant<NodeKind.AsType, TType> {}
 export interface Constant extends INode {
     readonly kind: NodeKind.Constant;
     readonly isLeaf: true;
-    readonly constantKind: ConstantKind;
+    readonly constantKind: TConstantKind;
 }
 
 export interface FieldSpecification extends INode {
@@ -791,84 +781,60 @@ export interface Identifier extends INode {
 // ---------- const enums ----------
 // ---------------------------------
 
-export const enum ConstantKind {
+export type TConstantKind =
+    | MiscConstantKind
+    | WrapperConstantKind
+    | KeywordConstantKind
+    | IdentifierConstant
+    | ArithmeticOperatorKind
+    | EqualityOperatorKind
+    | LogicalOperator
+    | RelationalOperatorKind
+    | UnaryOperator;
+
+export const enum MiscConstantKind {
     // TokenKind
-    As = "as",
     Ampersand = "&",
     AtSign = "@",
     Comma = ",",
     DotDot = "..",
-    Each = "each",
     Ellipsis = "...",
-    Else = "else",
     Equal = "=",
-    Error = "error",
     FatArrow = "=>",
-    If = "if",
-    In = "in",
-    Is = "is",
-    Section = "section",
     Semicolon = ";",
-    Shared = "shared",
+    Null = "null",
+    QuestionMark = "?",
+}
+
+export const enum WrapperConstantKind {
     LeftBrace = "{",
     LeftBracket = "[",
     LeftParenthesis = "(",
-    Let = "let",
-    Meta = "meta",
-    Null = "null",
-    Otherwise = "otherwise",
-    QuestionMark = "?",
     RightBrace = "}",
     RightBracket = "]",
     RightParenthesis = ")",
+}
+
+export const enum KeywordConstantKind {
+    And = "and",
+    As = "as",
+    Each = "each",
+    Else = "else",
+    Error = "error",
+    False = "false",
+    If = "if",
+    In = "in",
+    Is = "is",
+    Let = "let",
+    Meta = "meta",
+    Otherwise = "otherwise",
+    Or = "or",
+    Section = "section",
+    Shared = "shared",
     Then = "then",
+    True = "true",
     Try = "try",
     Type = "type",
-
-    // IdentifierConstant
-    Action = "action",
-    Any = "any",
-    AnyNonNull = "anynonnull",
-    Binary = "binary",
-    Date = "date",
-    DateTime = "datetime",
-    DateTimeZone = "datetimezone",
-    Duration = "duration",
-    Function = "function",
-    List = "list",
-    Logical = "logical",
-    None = "none",
-    Nullable = "nullable",
-    Number = "number",
-    Optional = "optional",
-    Record = "record",
-    Table = "table",
-    Text = "text",
-    Time = "time",
-
-    // ArithmeticOperator
-    Asterisk = "*",
-    Division = "/",
-    Plus = "+",
-    Minus = "-",
-
-    // EqualityOperator
-    // EqualTo ('=') is already covered by Equal
-    NotEqual = "<>",
-
-    // LogicalOperator
-    And = "and",
-    Or = "or",
-
-    // RelationalOperator
-    LessThan = "<",
-    LessThanEqualTo = "<=",
-    GreaterThan = ">",
-    GreaterThanEqualTo = ">=",
-
-    // Positive and Negative ('+' and '-') are already by Plus and Minus
-    // UnaryOperator
-    Not = "not",
 }
 
 export const enum IdentifierConstant {
@@ -891,4 +857,29 @@ export const enum IdentifierConstant {
     Table = "table",
     Text = "text",
     Time = "time",
+}
+
+export const enum ArithmeticOperatorKind {
+    Multiplication = "*",
+    Division = "/",
+    Addition = "+",
+    Subtraction = "-",
+    And = "&",
+}
+
+export const enum EqualityOperatorKind {
+    EqualTo = "=",
+    NotEqualTo = "<>",
+}
+
+export const enum LogicalOperator {
+    And = "and",
+    Or = "or",
+}
+
+export const enum RelationalOperatorKind {
+    LessThan = "<",
+    LessThanEqualTo = "<=",
+    GreaterThan = ">",
+    GreaterThanEqualTo = ">=",
 }

--- a/src/parser/ast/ast.ts
+++ b/src/parser/ast/ast.ts
@@ -753,7 +753,7 @@ export interface AsType extends IPairedConstant<NodeKind.AsType, TType> {}
 export interface Constant extends INode {
     readonly kind: NodeKind.Constant;
     readonly isLeaf: true;
-    readonly literal: string;
+    readonly constantKind: ConstantKind;
 }
 
 export interface FieldSpecification extends INode {
@@ -796,6 +796,7 @@ export const enum ConstantKind {
     As = "as",
     AtSign = "@",
     Comma = ",",
+    DotDot = "..",
     Each = "each",
     Ellipsis = "...",
     Else = "else",
@@ -859,6 +860,9 @@ export const enum ConstantKind {
     LessThanEqualTo = "<=",
     GreaterThan = ">",
     GreaterThanEqualTo = ">=",
+
+    // UnaryOperator
+    Not = "not",
 }
 
 export const enum IdentifierConstant {

--- a/src/parser/ast/astUtils.ts
+++ b/src/parser/ast/astUtils.ts
@@ -18,29 +18,31 @@ export function maybeUnaryOperatorFrom(maybeTokenKind: TokenKind | undefined): A
     }
 }
 
-export function maybeArithmeticOperatorFrom(maybeTokenKind: TokenKind | undefined): Ast.ArithmeticOperator | undefined {
+export function maybeArithmeticOperatorFrom(
+    maybeTokenKind: TokenKind | undefined,
+): Ast.ArithmeticOperatorKind | undefined {
     switch (maybeTokenKind) {
         case TokenKind.Asterisk:
-            return Ast.ArithmeticOperator.Multiplication;
+            return Ast.ArithmeticOperatorKind.Multiplication;
         case TokenKind.Division:
-            return Ast.ArithmeticOperator.Division;
+            return Ast.ArithmeticOperatorKind.Division;
         case TokenKind.Plus:
-            return Ast.ArithmeticOperator.Addition;
+            return Ast.ArithmeticOperatorKind.Addition;
         case TokenKind.Minus:
-            return Ast.ArithmeticOperator.Subtraction;
+            return Ast.ArithmeticOperatorKind.Subtraction;
         case TokenKind.Ampersand:
-            return Ast.ArithmeticOperator.And;
+            return Ast.ArithmeticOperatorKind.And;
         default:
             return undefined;
     }
 }
 
-export function maybeEqualityOperatorFrom(maybeTokenKind: TokenKind | undefined): Ast.EqualityOperator | undefined {
+export function maybeEqualityOperatorFrom(maybeTokenKind: TokenKind | undefined): Ast.EqualityOperatorKind | undefined {
     switch (maybeTokenKind) {
         case TokenKind.Equal:
-            return Ast.EqualityOperator.EqualTo;
+            return Ast.EqualityOperatorKind.EqualTo;
         case TokenKind.NotEqual:
-            return Ast.EqualityOperator.NotEqualTo;
+            return Ast.EqualityOperatorKind.NotEqualTo;
         default:
             return undefined;
     }
@@ -57,16 +59,18 @@ export function maybeLogicalOperatorFrom(maybeTokenKind: TokenKind | undefined):
     }
 }
 
-export function maybeRelationalOperatorFrom(maybeTokenKind: TokenKind | undefined): Ast.RelationalOperator | undefined {
+export function maybeRelationalOperatorFrom(
+    maybeTokenKind: TokenKind | undefined,
+): Ast.RelationalOperatorKind | undefined {
     switch (maybeTokenKind) {
         case TokenKind.LessThan:
-            return Ast.RelationalOperator.LessThan;
+            return Ast.RelationalOperatorKind.LessThan;
         case TokenKind.LessThanEqualTo:
-            return Ast.RelationalOperator.LessThanEqualTo;
+            return Ast.RelationalOperatorKind.LessThanEqualTo;
         case TokenKind.GreaterThan:
-            return Ast.RelationalOperator.GreaterThan;
+            return Ast.RelationalOperatorKind.GreaterThan;
         case TokenKind.GreaterThanEqualTo:
-            return Ast.RelationalOperator.GreaterThanEqualTo;
+            return Ast.RelationalOperatorKind.GreaterThanEqualTo;
         default:
             return undefined;
     }
@@ -78,21 +82,21 @@ export function maybeBinOpExpressionOperatorFrom(
     switch (maybeTokenKind) {
         // ArithmeticOperator
         case TokenKind.Asterisk:
-            return Ast.ArithmeticOperator.Multiplication;
+            return Ast.ArithmeticOperatorKind.Multiplication;
         case TokenKind.Division:
-            return Ast.ArithmeticOperator.Division;
+            return Ast.ArithmeticOperatorKind.Division;
         case TokenKind.Plus:
-            return Ast.ArithmeticOperator.Addition;
+            return Ast.ArithmeticOperatorKind.Addition;
         case TokenKind.Minus:
-            return Ast.ArithmeticOperator.Subtraction;
+            return Ast.ArithmeticOperatorKind.Subtraction;
         case TokenKind.Ampersand:
-            return Ast.ArithmeticOperator.And;
+            return Ast.ArithmeticOperatorKind.And;
 
         // EqualityOperator
         case TokenKind.Equal:
-            return Ast.EqualityOperator.EqualTo;
+            return Ast.EqualityOperatorKind.EqualTo;
         case TokenKind.NotEqual:
-            return Ast.EqualityOperator.NotEqualTo;
+            return Ast.EqualityOperatorKind.NotEqualTo;
 
         // LogicalOperator
         case TokenKind.KeywordAnd:
@@ -102,21 +106,21 @@ export function maybeBinOpExpressionOperatorFrom(
 
         // RelationalOperator
         case TokenKind.LessThan:
-            return Ast.RelationalOperator.LessThan;
+            return Ast.RelationalOperatorKind.LessThan;
         case TokenKind.LessThanEqualTo:
-            return Ast.RelationalOperator.LessThanEqualTo;
+            return Ast.RelationalOperatorKind.LessThanEqualTo;
         case TokenKind.GreaterThan:
-            return Ast.RelationalOperator.GreaterThan;
+            return Ast.RelationalOperatorKind.GreaterThan;
         case TokenKind.GreaterThanEqualTo:
-            return Ast.RelationalOperator.GreaterThanEqualTo;
+            return Ast.RelationalOperatorKind.GreaterThanEqualTo;
 
         // Keyword operator
         case TokenKind.KeywordAs:
-            return Ast.ConstantKind.As;
+            return Ast.KeywordConstantKind.As;
         case TokenKind.KeywordIs:
-            return Ast.ConstantKind.Is;
+            return Ast.KeywordConstantKind.Is;
         case TokenKind.KeywordMeta:
-            return Ast.ConstantKind.Meta;
+            return Ast.KeywordConstantKind.Meta;
 
         default:
             return undefined;
@@ -125,32 +129,32 @@ export function maybeBinOpExpressionOperatorFrom(
 
 export function maybeBinOpExpressionOperatorPrecedence(operator: Ast.TBinOpExpressionOperator): number {
     switch (operator) {
-        case Ast.ConstantKind.Meta:
+        case Ast.KeywordConstantKind.Meta:
             return 110;
 
-        case Ast.ArithmeticOperator.Multiplication:
-        case Ast.ArithmeticOperator.Division:
+        case Ast.ArithmeticOperatorKind.Multiplication:
+        case Ast.ArithmeticOperatorKind.Division:
             return 100;
 
-        case Ast.ArithmeticOperator.Addition:
-        case Ast.ArithmeticOperator.Subtraction:
-        case Ast.ArithmeticOperator.And:
+        case Ast.ArithmeticOperatorKind.Addition:
+        case Ast.ArithmeticOperatorKind.Subtraction:
+        case Ast.ArithmeticOperatorKind.And:
             return 90;
 
-        case Ast.RelationalOperator.GreaterThan:
-        case Ast.RelationalOperator.GreaterThanEqualTo:
-        case Ast.RelationalOperator.LessThan:
-        case Ast.RelationalOperator.LessThanEqualTo:
+        case Ast.RelationalOperatorKind.GreaterThan:
+        case Ast.RelationalOperatorKind.GreaterThanEqualTo:
+        case Ast.RelationalOperatorKind.LessThan:
+        case Ast.RelationalOperatorKind.LessThanEqualTo:
             return 80;
 
-        case Ast.EqualityOperator.EqualTo:
-        case Ast.EqualityOperator.NotEqualTo:
+        case Ast.EqualityOperatorKind.EqualTo:
+        case Ast.EqualityOperatorKind.NotEqualTo:
             return 70;
 
-        case Ast.ConstantKind.As:
+        case Ast.KeywordConstantKind.As:
             return 60;
 
-        case Ast.ConstantKind.Is:
+        case Ast.KeywordConstantKind.Is:
             return 50;
 
         case Ast.LogicalOperator.And:
@@ -181,53 +185,6 @@ export function maybeLiteralKindFrom(maybeTokenKind: TokenKind | undefined): Ast
         case TokenKind.StringLiteral:
             return Ast.LiteralKind.Str;
 
-        default:
-            return undefined;
-    }
-}
-
-export function maybeConstantKindFromIdentifieConstant(
-    identifierConstant: Ast.IdentifierConstant,
-): Ast.ConstantKind | undefined {
-    switch (identifierConstant) {
-        case Ast.IdentifierConstant.Action:
-            return Ast.ConstantKind.Action;
-        case Ast.IdentifierConstant.Any:
-            return Ast.ConstantKind.Any;
-        case Ast.IdentifierConstant.AnyNonNull:
-            return Ast.ConstantKind.AnyNonNull;
-        case Ast.IdentifierConstant.Binary:
-            return Ast.ConstantKind.Binary;
-        case Ast.IdentifierConstant.Date:
-            return Ast.ConstantKind.Date;
-        case Ast.IdentifierConstant.DateTime:
-            return Ast.ConstantKind.DateTime;
-        case Ast.IdentifierConstant.DateTimeZone:
-            return Ast.ConstantKind.DateTimeZone;
-        case Ast.IdentifierConstant.Duration:
-            return Ast.ConstantKind.Duration;
-        case Ast.IdentifierConstant.Function:
-            return Ast.ConstantKind.Function;
-        case Ast.IdentifierConstant.List:
-            return Ast.ConstantKind.List;
-        case Ast.IdentifierConstant.Logical:
-            return Ast.ConstantKind.Logical;
-        case Ast.IdentifierConstant.None:
-            return Ast.ConstantKind.None;
-        case Ast.IdentifierConstant.Nullable:
-            return Ast.ConstantKind.Nullable;
-        case Ast.IdentifierConstant.Number:
-            return Ast.ConstantKind.Number;
-        case Ast.IdentifierConstant.Optional:
-            return Ast.ConstantKind.Optional;
-        case Ast.IdentifierConstant.Record:
-            return Ast.ConstantKind.Record;
-        case Ast.IdentifierConstant.Table:
-            return Ast.ConstantKind.Table;
-        case Ast.IdentifierConstant.Text:
-            return Ast.ConstantKind.Text;
-        case Ast.IdentifierConstant.Time:
-            return Ast.ConstantKind.Time;
         default:
             return undefined;
     }
@@ -277,19 +234,19 @@ export function isTBinOpExpression(node: Ast.TNode): node is Ast.TBinOpExpressio
     }
 }
 
-export function isPairedConstant(x: Ast.ConstantKind, y: Ast.ConstantKind): boolean {
+export function isPairedWrapperConstantKinds(x: Ast.TConstantKind, y: Ast.TConstantKind): boolean {
     if (x.length !== 1 || y.length !== 1) {
         return false;
     }
 
     // If given x === ')' and y === '(' then swap positions.
-    const low: Ast.ConstantKind = x < y ? x : y;
-    const high: Ast.ConstantKind = low === x ? y : x;
+    const low: Ast.TConstantKind = x < y ? x : y;
+    const high: Ast.TConstantKind = low === x ? y : x;
 
     return (
-        (low === Ast.ConstantKind.LeftBrace && high === Ast.ConstantKind.RightBrace) ||
-        (low === Ast.ConstantKind.LeftBracket && high === Ast.ConstantKind.RightBracket) ||
-        (low === Ast.ConstantKind.LeftParenthesis && high === Ast.ConstantKind.RightParenthesis)
+        (low === Ast.WrapperConstantKind.LeftBrace && high === Ast.WrapperConstantKind.RightBrace) ||
+        (low === Ast.WrapperConstantKind.LeftBracket && high === Ast.WrapperConstantKind.RightBracket) ||
+        (low === Ast.WrapperConstantKind.LeftParenthesis && high === Ast.WrapperConstantKind.RightParenthesis)
     );
 }
 

--- a/src/parser/ast/astUtils.ts
+++ b/src/parser/ast/astUtils.ts
@@ -5,7 +5,7 @@ import { CommonError, isNever } from "../../common";
 import { TokenKind } from "../../lexer";
 import * as Ast from "./ast";
 
-export function maybeUnaryOperatorFrom(maybeTokenKind: TokenKind | undefined): Ast.UnaryOperator | undefined {
+export function maybeUnaryOperatorKindFrom(maybeTokenKind: TokenKind | undefined): Ast.UnaryOperator | undefined {
     switch (maybeTokenKind) {
         case TokenKind.Plus:
             return Ast.UnaryOperator.Positive;
@@ -18,7 +18,7 @@ export function maybeUnaryOperatorFrom(maybeTokenKind: TokenKind | undefined): A
     }
 }
 
-export function maybeArithmeticOperatorFrom(
+export function maybeArithmeticOperatorKindFrom(
     maybeTokenKind: TokenKind | undefined,
 ): Ast.ArithmeticOperatorKind | undefined {
     switch (maybeTokenKind) {
@@ -37,7 +37,9 @@ export function maybeArithmeticOperatorFrom(
     }
 }
 
-export function maybeEqualityOperatorFrom(maybeTokenKind: TokenKind | undefined): Ast.EqualityOperatorKind | undefined {
+export function maybeEqualityOperatorKindFrom(
+    maybeTokenKind: TokenKind | undefined,
+): Ast.EqualityOperatorKind | undefined {
     switch (maybeTokenKind) {
         case TokenKind.Equal:
             return Ast.EqualityOperatorKind.EqualTo;
@@ -48,7 +50,7 @@ export function maybeEqualityOperatorFrom(maybeTokenKind: TokenKind | undefined)
     }
 }
 
-export function maybeLogicalOperatorFrom(maybeTokenKind: TokenKind | undefined): Ast.LogicalOperator | undefined {
+export function maybeLogicalOperatorKindFrom(maybeTokenKind: TokenKind | undefined): Ast.LogicalOperator | undefined {
     switch (maybeTokenKind) {
         case TokenKind.KeywordAnd:
             return Ast.LogicalOperator.And;
@@ -76,7 +78,7 @@ export function maybeRelationalOperatorFrom(
     }
 }
 
-export function maybeBinOpExpressionOperatorFrom(
+export function maybeBinOpExpressionOperatorKindFrom(
     maybeTokenKind: TokenKind | undefined,
 ): Ast.TBinOpExpressionOperator | undefined {
     switch (maybeTokenKind) {

--- a/src/parser/nodeIdMap/nodeIdMapUtils.ts
+++ b/src/parser/nodeIdMap/nodeIdMapUtils.ts
@@ -283,7 +283,7 @@ export function maybeInvokeExpressionName(nodeIdMapCollection: Collection, nodeI
             maybeName =
                 identifierExpression.maybeInclusiveConstant === undefined
                     ? identifierExpression.identifier.literal
-                    : identifierExpression.maybeInclusiveConstant.literal + identifierExpression.identifier.literal;
+                    : identifierExpression.maybeInclusiveConstant.constantKind + identifierExpression.identifier.literal;
         }
     }
 

--- a/src/parser/nodeIdMap/nodeIdMapUtils.ts
+++ b/src/parser/nodeIdMap/nodeIdMapUtils.ts
@@ -283,7 +283,8 @@ export function maybeInvokeExpressionName(nodeIdMapCollection: Collection, nodeI
             maybeName =
                 identifierExpression.maybeInclusiveConstant === undefined
                     ? identifierExpression.identifier.literal
-                    : identifierExpression.maybeInclusiveConstant.constantKind + identifierExpression.identifier.literal;
+                    : identifierExpression.maybeInclusiveConstant.constantKind +
+                      identifierExpression.identifier.literal;
         }
     }
 

--- a/src/parser/parsers/combinatorialParser.ts
+++ b/src/parser/parsers/combinatorialParser.ts
@@ -206,7 +206,13 @@ function readBinOpExpression(
     while (maybeOperator !== undefined) {
         const operator: Ast.TBinOpExpressionOperator = maybeOperator;
         operators.push(operator);
-        operatorConstants.push(readTokenKindAsConstant(state, state.maybeCurrentTokenKind!));
+        operatorConstants.push(
+            readTokenKindAsConstant(
+                state,
+                state.maybeCurrentTokenKind!,
+                (maybeOperator as unknown) as Ast.ConstantKind,
+            ),
+        );
 
         switch (operator) {
             case Ast.ConstantKind.As:

--- a/src/parser/parsers/combinatorialParser.ts
+++ b/src/parser/parsers/combinatorialParser.ts
@@ -332,21 +332,21 @@ function binOpExpressionNodeKindFrom(operator: Ast.TBinOpExpressionOperator): As
         case Ast.ConstantKind.Meta:
             return Ast.NodeKind.MetadataExpression;
 
-        case Ast.ArithmeticOperator.Multiplication:
-        case Ast.ArithmeticOperator.Division:
-        case Ast.ArithmeticOperator.Addition:
-        case Ast.ArithmeticOperator.Subtraction:
-        case Ast.ArithmeticOperator.And:
+        case Ast.ArithmeticOperatorKind.Multiplication:
+        case Ast.ArithmeticOperatorKind.Division:
+        case Ast.ArithmeticOperatorKind.Addition:
+        case Ast.ArithmeticOperatorKind.Subtraction:
+        case Ast.ArithmeticOperatorKind.And:
             return Ast.NodeKind.ArithmeticExpression;
 
-        case Ast.RelationalOperator.GreaterThan:
-        case Ast.RelationalOperator.GreaterThanEqualTo:
-        case Ast.RelationalOperator.LessThan:
-        case Ast.RelationalOperator.LessThanEqualTo:
+        case Ast.RelationalOperatorKind.GreaterThan:
+        case Ast.RelationalOperatorKind.GreaterThanEqualTo:
+        case Ast.RelationalOperatorKind.LessThan:
+        case Ast.RelationalOperatorKind.LessThanEqualTo:
             return Ast.NodeKind.RelationalExpression;
 
-        case Ast.EqualityOperator.EqualTo:
-        case Ast.EqualityOperator.NotEqualTo:
+        case Ast.EqualityOperatorKind.EqualTo:
+        case Ast.EqualityOperatorKind.NotEqualTo:
             return Ast.NodeKind.EqualityExpression;
 
         case Ast.ConstantKind.As:

--- a/src/parser/parsers/combinatorialParser.ts
+++ b/src/parser/parsers/combinatorialParser.ts
@@ -206,13 +206,7 @@ function readBinOpExpression(
     while (maybeOperator !== undefined) {
         const operator: Ast.TBinOpExpressionOperator = maybeOperator;
         operators.push(operator);
-        operatorConstants.push(
-            readTokenKindAsConstant(
-                state,
-                state.maybeCurrentTokenKind!,
-                (maybeOperator as unknown) as Ast.ConstantKind,
-            ),
-        );
+        operatorConstants.push(readTokenKindAsConstant(state, state.maybeCurrentTokenKind!, maybeOperator));
 
         switch (operator) {
             case Ast.KeywordConstantKind.As:

--- a/src/parser/parsers/combinatorialParser.ts
+++ b/src/parser/parsers/combinatorialParser.ts
@@ -200,7 +200,7 @@ function readBinOpExpression(
         parser.readUnaryExpression(state, parser),
     ];
 
-    let maybeOperator: Ast.TBinOpExpressionOperator | undefined = AstUtils.maybeBinOpExpressionOperatorFrom(
+    let maybeOperator: Ast.TBinOpExpressionOperator | undefined = AstUtils.maybeBinOpExpressionOperatorKindFrom(
         state.maybeCurrentTokenKind,
     );
     while (maybeOperator !== undefined) {
@@ -215,8 +215,8 @@ function readBinOpExpression(
         );
 
         switch (operator) {
-            case Ast.ConstantKind.As:
-            case Ast.ConstantKind.Is:
+            case Ast.KeywordConstantKind.As:
+            case Ast.KeywordConstantKind.Is:
                 expressions.push(parser.readNullablePrimitiveType(state, parser));
                 break;
 
@@ -225,7 +225,7 @@ function readBinOpExpression(
                 break;
         }
 
-        maybeOperator = AstUtils.maybeBinOpExpressionOperatorFrom(state.maybeCurrentTokenKind);
+        maybeOperator = AstUtils.maybeBinOpExpressionOperatorKindFrom(state.maybeCurrentTokenKind);
     }
 
     // There was a single TUnaryExpression, not a TBinOpExpression.
@@ -329,7 +329,7 @@ function readBinOpExpression(
 
 function binOpExpressionNodeKindFrom(operator: Ast.TBinOpExpressionOperator): Ast.TBinOpExpressionNodeKind {
     switch (operator) {
-        case Ast.ConstantKind.Meta:
+        case Ast.KeywordConstantKind.Meta:
             return Ast.NodeKind.MetadataExpression;
 
         case Ast.ArithmeticOperatorKind.Multiplication:
@@ -349,10 +349,10 @@ function binOpExpressionNodeKindFrom(operator: Ast.TBinOpExpressionOperator): As
         case Ast.EqualityOperatorKind.NotEqualTo:
             return Ast.NodeKind.EqualityExpression;
 
-        case Ast.ConstantKind.As:
+        case Ast.KeywordConstantKind.As:
             return Ast.NodeKind.AsExpression;
 
-        case Ast.ConstantKind.Is:
+        case Ast.KeywordConstantKind.Is:
             return Ast.NodeKind.IsExpression;
 
         case Ast.LogicalOperator.And:

--- a/src/parser/parsers/common.ts
+++ b/src/parser/parsers/common.ts
@@ -28,7 +28,11 @@ export function readToken(state: IParserState): string {
     return data;
 }
 
-export function readTokenKindAsConstant(state: IParserState, tokenKind: TokenKind): Ast.Constant {
+export function readTokenKindAsConstant(
+    state: IParserState,
+    tokenKind: TokenKind,
+    constantKind: Ast.ConstantKind,
+): Ast.Constant {
     IParserStateUtils.startContext(state, Ast.NodeKind.Constant);
 
     const maybeErr: ParseError.ExpectedTokenKindError | undefined = IParserStateUtils.testIsOnTokenKind(
@@ -39,29 +43,49 @@ export function readTokenKindAsConstant(state: IParserState, tokenKind: TokenKin
         throw maybeErr;
     }
 
-    const literal: string = readToken(state);
+    const tokenData: string = readToken(state);
+    if (tokenData !== constantKind) {
+        const details: {} = {
+            tokenData,
+            constantKind,
+        };
+        throw new CommonError.InvariantError("expected tokenData to be equal to constantKind", details);
+    }
+
     const astNode: Ast.Constant = {
         ...IParserStateUtils.expectContextNodeMetadata(state),
         kind: Ast.NodeKind.Constant,
         isLeaf: true,
-        literal,
+        constantKind,
     };
     IParserStateUtils.endContext(state, astNode);
 
     return astNode;
 }
 
-export function maybeReadTokenKindAsConstant(state: IParserState, tokenKind: TokenKind): Ast.Constant | undefined {
+export function maybeReadTokenKindAsConstant(
+    state: IParserState,
+    tokenKind: TokenKind,
+    constantKind: Ast.ConstantKind,
+): Ast.Constant | undefined {
     if (IParserStateUtils.isOnTokenKind(state, tokenKind)) {
         const nodeKind: Ast.NodeKind.Constant = Ast.NodeKind.Constant;
         IParserStateUtils.startContext(state, nodeKind);
 
-        const literal: string = readToken(state);
+        const tokenData: string = readToken(state);
+        if (tokenData !== constantKind) {
+            const details: {} = {
+                tokenData,
+                constantKind,
+            };
+            throw new CommonError.InvariantError("expected tokenData to be equal to constantKind", details);
+        }
+
         const astNode: Ast.Constant = {
             ...IParserStateUtils.expectContextNodeMetadata(state),
             kind: nodeKind,
             isLeaf: true,
-            literal,
+            constantKind,
         };
         IParserStateUtils.endContext(state, astNode);
 

--- a/src/parser/parsers/common.ts
+++ b/src/parser/parsers/common.ts
@@ -31,7 +31,7 @@ export function readToken(state: IParserState): string {
 export function readTokenKindAsConstant(
     state: IParserState,
     tokenKind: TokenKind,
-    constantKind: Ast.ConstantKind,
+    constantKind: Ast.TConstantKind,
 ): Ast.Constant {
     IParserStateUtils.startContext(state, Ast.NodeKind.Constant);
 
@@ -66,7 +66,7 @@ export function readTokenKindAsConstant(
 export function maybeReadTokenKindAsConstant(
     state: IParserState,
     tokenKind: TokenKind,
-    constantKind: Ast.ConstantKind,
+    constantKind: Ast.TConstantKind,
 ): Ast.Constant | undefined {
     if (IParserStateUtils.isOnTokenKind(state, tokenKind)) {
         const nodeKind: Ast.NodeKind.Constant = Ast.NodeKind.Constant;

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -539,7 +539,13 @@ export function readUnaryExpression(state: IParserState, parser: IParser<IParser
 
     const operatorConstants: Ast.Constant[] = [];
     while (maybeOperator) {
-        operatorConstants.push(readTokenKindAsConstant(state, state.maybeCurrentTokenKind as TokenKind));
+        operatorConstants.push(
+            readTokenKindAsConstant(
+                state,
+                state.maybeCurrentTokenKind as TokenKind,
+                (maybeOperator as unknown) as Ast.ConstantKind,
+            ),
+        );
         maybeOperator = AstUtils.maybeUnaryOperatorFrom(state.maybeCurrentTokenKind);
     }
     const operators: Ast.IArrayWrapper<Ast.Constant> = {
@@ -1902,7 +1908,11 @@ function recursiveReadBinOpExpression<Kind, Left, Operator, Right>(
         return left;
     }
     const operator: Operator = maybeOperator;
-    const operatorConstant: Ast.Constant = readTokenKindAsConstant(state, state.maybeCurrentTokenKind as TokenKind);
+    const operatorConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        state.maybeCurrentTokenKind as TokenKind,
+        (maybeOperator as unknown) as Ast.ConstantKind,
+    );
     const right: Right | Ast.IBinOpExpression<Kind, Right, Operator, Right> = recursiveReadBinOpExpressionHelper<
         Kind,
         Operator,
@@ -1941,7 +1951,11 @@ function recursiveReadBinOpExpressionHelper<Kind, Operator, Right>(
         return rightAsLeft;
     }
     const operator: Operator = maybeOperator;
-    const operatorConstant: Ast.Constant = readTokenKindAsConstant(state, state.maybeCurrentTokenKind as TokenKind);
+    const operatorConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        state.maybeCurrentTokenKind as TokenKind,
+        (maybeOperator as unknown) as Ast.ConstantKind,
+    );
     const right: Right | Ast.IBinOpExpression<Kind, Right, Operator, Right> = recursiveReadBinOpExpressionHelper<
         Kind,
         Operator,

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -541,13 +541,7 @@ export function readUnaryExpression(state: IParserState, parser: IParser<IParser
 
     const operatorConstants: Ast.Constant[] = [];
     while (maybeOperator) {
-        operatorConstants.push(
-            readTokenKindAsConstant(
-                state,
-                state.maybeCurrentTokenKind as TokenKind,
-                (maybeOperator as unknown) as Ast.ConstantKind,
-            ),
-        );
+        operatorConstants.push(readTokenKindAsConstant(state, state.maybeCurrentTokenKind as TokenKind, maybeOperator));
         maybeOperator = AstUtils.maybeUnaryOperatorKindFrom(state.maybeCurrentTokenKind);
     }
     const operators: Ast.IArrayWrapper<Ast.Constant> = {
@@ -1909,14 +1903,16 @@ function recursiveReadBinOpExpression<Kind, Left, Operator, Right>(
     state: IParserState,
     nodeKind: Kind & Ast.TBinOpExpressionNodeKind,
     leftReader: () => Left,
-    maybeOperatorFrom: (tokenKind: TokenKind | undefined) => Operator | undefined,
+    maybeOperatorFrom: (tokenKind: TokenKind | undefined) => (Operator & Ast.TBinOpExpressionOperator) | undefined,
     rightReader: () => Right,
 ): Left | Ast.IBinOpExpression<Kind, Left, Operator, Right> {
     IParserStateUtils.startContext(state, nodeKind);
     const left: Left = leftReader();
 
     // If no operator, return Left
-    const maybeOperator: Operator | undefined = maybeOperatorFrom(state.maybeCurrentTokenKind);
+    const maybeOperator: (Operator & Ast.TBinOpExpressionOperator) | undefined = maybeOperatorFrom(
+        state.maybeCurrentTokenKind,
+    );
     if (maybeOperator === undefined) {
         IParserStateUtils.deleteContext(state, undefined);
         return left;
@@ -1925,7 +1921,7 @@ function recursiveReadBinOpExpression<Kind, Left, Operator, Right>(
     const operatorConstant: Ast.Constant = readTokenKindAsConstant(
         state,
         state.maybeCurrentTokenKind as TokenKind,
-        (maybeOperator as unknown) as Ast.ConstantKind,
+        maybeOperator,
     );
     const right: Right | Ast.IBinOpExpression<Kind, Right, Operator, Right> = recursiveReadBinOpExpressionHelper<
         Kind,
@@ -1953,13 +1949,15 @@ function recursiveReadBinOpExpression<Kind, Left, Operator, Right>(
 function recursiveReadBinOpExpressionHelper<Kind, Operator, Right>(
     state: IParserState,
     nodeKind: Kind & Ast.TBinOpExpressionNodeKind,
-    maybeOperatorFrom: (tokenKind: TokenKind | undefined) => Operator | undefined,
+    maybeOperatorFrom: (tokenKind: TokenKind | undefined) => (Operator & Ast.TBinOpExpressionOperator) | undefined,
     rightReader: () => Right,
 ): Right | Ast.IBinOpExpression<Kind, Right, Operator, Right> {
     IParserStateUtils.startContext(state, nodeKind);
     const rightAsLeft: Right = rightReader();
 
-    const maybeOperator: Operator | undefined = maybeOperatorFrom(state.maybeCurrentTokenKind);
+    const maybeOperator: (Operator & Ast.TBinOpExpressionOperator) | undefined = maybeOperatorFrom(
+        state.maybeCurrentTokenKind,
+    );
     if (maybeOperator === undefined) {
         IParserStateUtils.deleteContext(state, undefined);
         return rightAsLeft;
@@ -1968,7 +1966,7 @@ function recursiveReadBinOpExpressionHelper<Kind, Operator, Right>(
     const operatorConstant: Ast.Constant = readTokenKindAsConstant(
         state,
         state.maybeCurrentTokenKind as TokenKind,
-        (maybeOperator as unknown) as Ast.ConstantKind,
+        maybeOperator,
     );
     const right: Right | Ast.IBinOpExpression<Kind, Right, Operator, Right> = recursiveReadBinOpExpressionHelper<
         Kind,

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -213,7 +213,11 @@ export function readSectionDocument(state: IParserState, parser: IParser<IParser
     IParserStateUtils.startContext(state, nodeKind);
 
     const maybeLiteralAttributes: Ast.RecordLiteral | undefined = maybeReadLiteralAttributes(state, parser);
-    const sectionConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordSection);
+    const sectionConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        TokenKind.KeywordSection,
+        Ast.ConstantKind.Section,
+    );
 
     let maybeName: Ast.Identifier | undefined;
     if (IParserStateUtils.isOnTokenKind(state, TokenKind.Identifier)) {
@@ -222,7 +226,11 @@ export function readSectionDocument(state: IParserState, parser: IParser<IParser
         IParserStateUtils.incrementAttributeCounter(state);
     }
 
-    const semicolonConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.Semicolon);
+    const semicolonConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        TokenKind.Semicolon,
+        Ast.ConstantKind.Semicolon,
+    );
     const sectionMembers: Ast.IArrayWrapper<Ast.SectionMember> = parser.readSectionMembers(state, parser);
 
     const astNode: Ast.Section = {
@@ -267,9 +275,17 @@ export function readSectionMember(state: IParserState, parser: IParser<IParserSt
     IParserStateUtils.startContext(state, nodeKind);
 
     const maybeLiteralAttributes: Ast.RecordLiteral | undefined = maybeReadLiteralAttributes(state, parser);
-    const maybeSharedConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(state, TokenKind.KeywordShared);
+    const maybeSharedConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
+        state,
+        TokenKind.KeywordShared,
+        Ast.ConstantKind.Shared,
+    );
     const namePairedExpression: Ast.IdentifierPairedExpression = parser.readIdentifierPairedExpression(state, parser);
-    const semicolonConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.Semicolon);
+    const semicolonConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        TokenKind.Semicolon,
+        Ast.ConstantKind.Semicolon,
+    );
 
     const astNode: Ast.SectionMember = {
         ...IParserStateUtils.expectContextNodeMetadata(state),
@@ -477,7 +493,11 @@ export function readMetadataExpression(state: IParserState, parser: IParser<IPar
     IParserStateUtils.startContext(state, nodeKind);
 
     const left: Ast.TUnaryExpression = parser.readUnaryExpression(state, parser);
-    const maybeMetaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(state, TokenKind.KeywordMeta);
+    const maybeMetaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
+        state,
+        TokenKind.KeywordMeta,
+        Ast.ConstantKind.Meta,
+    );
 
     if (maybeMetaConstant !== undefined) {
         const operatorConstant: Ast.Constant = maybeMetaConstant;
@@ -775,7 +795,11 @@ export function readIdentifierExpression(state: IParserState, parser: IParser<IP
     const nodeKind: Ast.NodeKind.IdentifierExpression = Ast.NodeKind.IdentifierExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const maybeInclusiveConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(state, TokenKind.AtSign);
+    const maybeInclusiveConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
+        state,
+        TokenKind.AtSign,
+        Ast.ConstantKind.AtSign,
+    );
     const identifier: Ast.Identifier = parser.readIdentifier(state, parser);
 
     const astNode: Ast.IdentifierExpression = {
@@ -800,9 +824,9 @@ export function readParenthesizedExpression(
     return readWrapped<Ast.NodeKind.ParenthesizedExpression, Ast.TExpression>(
         state,
         Ast.NodeKind.ParenthesizedExpression,
-        () => readTokenKindAsConstant(state, TokenKind.LeftParenthesis),
+        () => readTokenKindAsConstant(state, TokenKind.LeftParenthesis, Ast.ConstantKind.LeftParenthesis),
         () => parser.readExpression(state, parser),
-        () => readTokenKindAsConstant(state, TokenKind.RightParenthesis),
+        () => readTokenKindAsConstant(state, TokenKind.RightParenthesis, Ast.ConstantKind.RightParenthesis),
         false,
     );
 }
@@ -818,7 +842,11 @@ export function readNotImplementedExpression(
     const nodeKind: Ast.NodeKind.NotImplementedExpression = Ast.NodeKind.NotImplementedExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const ellipsisConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.Ellipsis);
+    const ellipsisConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        TokenKind.Ellipsis,
+        Ast.ConstantKind.Ellipsis,
+    );
 
     const astNode: Ast.NotImplementedExpression = {
         ...IParserStateUtils.expectContextNodeMetadata(state),
@@ -839,7 +867,7 @@ export function readInvokeExpression(state: IParserState, parser: IParser<IParse
     return readWrapped<Ast.NodeKind.InvokeExpression, Ast.ICsvArray<Ast.TExpression>>(
         state,
         Ast.NodeKind.InvokeExpression,
-        () => readTokenKindAsConstant(state, TokenKind.LeftParenthesis),
+        () => readTokenKindAsConstant(state, TokenKind.LeftParenthesis, Ast.ConstantKind.LeftParenthesis),
         () =>
             readCsvArray(
                 state,
@@ -847,7 +875,7 @@ export function readInvokeExpression(state: IParserState, parser: IParser<IParse
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForParenthesis,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightParenthesis),
+        () => readTokenKindAsConstant(state, TokenKind.RightParenthesis, Ast.ConstantKind.RightParenthesis),
         false,
     );
 }
@@ -861,7 +889,7 @@ export function readListExpression(state: IParserState, parser: IParser<IParserS
     return readWrapped<Ast.NodeKind.ListExpression, Ast.ICsvArray<Ast.TListItem>>(
         state,
         Ast.NodeKind.ListExpression,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBrace),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.ConstantKind.LeftBrace),
         () =>
             readCsvArray(
                 state,
@@ -869,7 +897,7 @@ export function readListExpression(state: IParserState, parser: IParser<IParserS
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBrace,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightBrace),
+        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.ConstantKind.RightBrace),
         false,
     );
 }
@@ -880,7 +908,7 @@ export function readListItem(state: IParserState, parser: IParser<IParserState>)
 
     const left: Ast.TExpression = parser.readExpression(state, parser);
     if (IParserStateUtils.isOnTokenKind(state, TokenKind.DotDot)) {
-        const rangeConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.DotDot);
+        const rangeConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.DotDot, Ast.ConstantKind.DotDot);
         const right: Ast.TExpression = parser.readExpression(state, parser);
         const astNode: Ast.RangeExpression = {
             ...IParserStateUtils.expectContextNodeMetadata(state),
@@ -908,7 +936,7 @@ export function readRecordExpression(state: IParserState, parser: IParser<IParse
     return readWrapped<Ast.NodeKind.RecordExpression, Ast.ICsvArray<Ast.GeneralizedIdentifierPairedExpression>>(
         state,
         Ast.NodeKind.RecordExpression,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBracket),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.ConstantKind.LeftBracket),
         () =>
             parser.readGeneralizedIdentifierPairedExpressions(
                 state,
@@ -916,7 +944,7 @@ export function readRecordExpression(state: IParserState, parser: IParser<IParse
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightBracket),
+        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.ConstantKind.RightBracket),
         false,
     );
 }
@@ -929,9 +957,9 @@ export function readItemAccessExpression(state: IParserState, parser: IParser<IP
     return readWrapped<Ast.NodeKind.ItemAccessExpression, Ast.TExpression>(
         state,
         Ast.NodeKind.ItemAccessExpression,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBrace),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.ConstantKind.LeftBrace),
         () => parser.readExpression(state, parser),
-        () => readTokenKindAsConstant(state, TokenKind.RightBrace),
+        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.ConstantKind.RightBrace),
         true,
     );
 }
@@ -948,7 +976,7 @@ export function readFieldProjection(state: IParserState, parser: IParser<IParser
     return readWrapped<Ast.NodeKind.FieldProjection, Ast.ICsvArray<Ast.FieldSelector>>(
         state,
         Ast.NodeKind.FieldProjection,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBracket),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.ConstantKind.LeftBracket),
         () =>
             readCsvArray(
                 state,
@@ -956,7 +984,7 @@ export function readFieldProjection(state: IParserState, parser: IParser<IParser
                 true,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightBracket),
+        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.ConstantKind.RightBracket),
         true,
     );
 }
@@ -969,9 +997,9 @@ export function readFieldSelector(
     return readWrapped<Ast.NodeKind.FieldSelector, Ast.GeneralizedIdentifier>(
         state,
         Ast.NodeKind.FieldSelector,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBracket),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.ConstantKind.LeftBracket),
         () => parser.readGeneralizedIdentifier(state, parser),
-        () => readTokenKindAsConstant(state, TokenKind.RightBracket),
+        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.ConstantKind.RightBracket),
         allowOptional,
     );
 }
@@ -992,7 +1020,11 @@ export function readFunctionExpression(state: IParserState, parser: IParser<IPar
         state,
         parser,
     );
-    const fatArrowConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.FatArrow);
+    const fatArrowConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        TokenKind.FatArrow,
+        Ast.ConstantKind.FatArrow,
+    );
     const expression: Ast.TExpression = parser.readExpression(state, parser);
 
     const astNode: Ast.FunctionExpression = {
@@ -1023,7 +1055,7 @@ function maybeReadAsNullablePrimitiveType(
         state,
         Ast.NodeKind.AsNullablePrimitiveType,
         () => IParserStateUtils.isOnTokenKind(state, TokenKind.KeywordAs),
-        () => readTokenKindAsConstant(state, TokenKind.KeywordAs),
+        () => readTokenKindAsConstant(state, TokenKind.KeywordAs, Ast.ConstantKind.As),
         () => parser.readNullablePrimitiveType(state, parser),
     );
 }
@@ -1032,7 +1064,7 @@ export function readAsType(state: IParserState, parser: IParser<IParserState>): 
     return readPairedConstant<Ast.NodeKind.AsType, Ast.TType>(
         state,
         Ast.NodeKind.AsType,
-        () => readTokenKindAsConstant(state, TokenKind.KeywordAs),
+        () => readTokenKindAsConstant(state, TokenKind.KeywordAs, Ast.ConstantKind.As),
         () => parser.readType(state, parser),
     );
 }
@@ -1045,7 +1077,7 @@ export function readEachExpression(state: IParserState, parser: IParser<IParserS
     return readPairedConstant<Ast.NodeKind.EachExpression, Ast.TExpression>(
         state,
         Ast.NodeKind.EachExpression,
-        () => readTokenKindAsConstant(state, TokenKind.KeywordEach),
+        () => readTokenKindAsConstant(state, TokenKind.KeywordEach, Ast.ConstantKind.Each),
         () => parser.readExpression(state, parser),
     );
 }
@@ -1058,7 +1090,7 @@ export function readLetExpression(state: IParserState, parser: IParser<IParserSt
     const nodeKind: Ast.NodeKind.LetExpression = Ast.NodeKind.LetExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const letConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordLet);
+    const letConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordLet, Ast.ConstantKind.Let);
     const identifierExpressionPairedExpressions: Ast.ICsvArray<
         Ast.IdentifierPairedExpression
     > = parser.readIdentifierPairedExpressions(
@@ -1067,7 +1099,7 @@ export function readLetExpression(state: IParserState, parser: IParser<IParserSt
         !IParserStateUtils.isNextTokenKind(state, TokenKind.KeywordIn),
         IParserStateUtils.testCsvContinuationLetExpression,
     );
-    const inConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordIn);
+    const inConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordIn, Ast.ConstantKind.In);
     const expression: Ast.TExpression = parser.readExpression(state, parser);
 
     const astNode: Ast.LetExpression = {
@@ -1091,13 +1123,13 @@ export function readIfExpression(state: IParserState, parser: IParser<IParserSta
     const nodeKind: Ast.NodeKind.IfExpression = Ast.NodeKind.IfExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const ifConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordIf);
+    const ifConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordIf, Ast.ConstantKind.If);
     const condition: Ast.TExpression = parser.readExpression(state, parser);
 
-    const thenConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordThen);
+    const thenConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordThen, Ast.ConstantKind.Then);
     const trueExpression: Ast.TExpression = parser.readExpression(state, parser);
 
-    const elseConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordElse);
+    const elseConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordElse, Ast.ConstantKind.Else);
     const falseExpression: Ast.TExpression = parser.readExpression(state, parser);
 
     const astNode: Ast.IfExpression = {
@@ -1124,7 +1156,7 @@ export function readTypeExpression(state: IParserState, parser: IParser<IParserS
         return readPairedConstant<Ast.NodeKind.TypePrimaryType, Ast.TPrimaryType>(
             state,
             Ast.NodeKind.TypePrimaryType,
-            () => readTokenKindAsConstant(state, TokenKind.KeywordType),
+            () => readTokenKindAsConstant(state, TokenKind.KeywordType, Ast.ConstantKind.Type),
             () => parser.readPrimaryType(state, parser),
         );
     } else {
@@ -1211,7 +1243,11 @@ export function readFieldSpecificationList(
     const nodeKind: Ast.NodeKind.FieldSpecificationList = Ast.NodeKind.FieldSpecificationList;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const leftBracketConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.LeftBracket);
+    const leftBracketConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        TokenKind.LeftBracket,
+        Ast.ConstantKind.LeftBracket,
+    );
     const fields: Ast.ICsv<Ast.FieldSpecification>[] = [];
     let continueReadingValues: boolean = true;
     let maybeOpenRecordMarkerConstant: Ast.Constant | undefined = undefined;
@@ -1230,7 +1266,11 @@ export function readFieldSpecificationList(
                 if (maybeOpenRecordMarkerConstant) {
                     throw fieldSpecificationListReadError(state, false);
                 } else {
-                    maybeOpenRecordMarkerConstant = readTokenKindAsConstant(state, TokenKind.Ellipsis);
+                    maybeOpenRecordMarkerConstant = readTokenKindAsConstant(
+                        state,
+                        TokenKind.Ellipsis,
+                        Ast.ConstantKind.Ellipsis,
+                    );
                     continueReadingValues = false;
                 }
             } else {
@@ -1255,7 +1295,11 @@ export function readFieldSpecificationList(
                 parser,
             );
 
-            const maybeCommaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(state, TokenKind.Comma);
+            const maybeCommaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
+                state,
+                TokenKind.Comma,
+                Ast.ConstantKind.Comma,
+            );
             continueReadingValues = maybeCommaConstant !== undefined;
 
             const field: Ast.FieldSpecification = {
@@ -1290,7 +1334,11 @@ export function readFieldSpecificationList(
     };
     IParserStateUtils.endContext(state, fieldArray);
 
-    const rightBracketConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.RightBracket);
+    const rightBracketConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        TokenKind.RightBracket,
+        Ast.ConstantKind.RightBracket,
+    );
 
     const astNode: Ast.FieldSpecificationList = {
         ...IParserStateUtils.expectContextNodeMetadata(state),
@@ -1312,7 +1360,11 @@ function maybeReadFieldTypeSpecification(
     const nodeKind: Ast.NodeKind.FieldTypeSpecification = Ast.NodeKind.FieldTypeSpecification;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const maybeEqualConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(state, TokenKind.Equal);
+    const maybeEqualConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
+        state,
+        TokenKind.Equal,
+        Ast.ConstantKind.Equal,
+    );
     if (maybeEqualConstant) {
         const fieldType: Ast.TType = parser.readType(state, parser);
 
@@ -1345,9 +1397,9 @@ export function readListType(state: IParserState, parser: IParser<IParserState>)
     return readWrapped<Ast.NodeKind.ListType, Ast.TType>(
         state,
         Ast.NodeKind.ListType,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBrace),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.ConstantKind.LeftBrace),
         () => parser.readType(state, parser),
-        () => readTokenKindAsConstant(state, TokenKind.RightBrace),
+        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.ConstantKind.RightBrace),
         false,
     );
 }
@@ -1431,7 +1483,7 @@ export function readErrorRaisingExpression(
     return readPairedConstant<Ast.NodeKind.ErrorRaisingExpression, Ast.TExpression>(
         state,
         Ast.NodeKind.ErrorRaisingExpression,
-        () => readTokenKindAsConstant(state, TokenKind.KeywordError),
+        () => readTokenKindAsConstant(state, TokenKind.KeywordError, Ast.ConstantKind.Error),
         () => parser.readExpression(state, parser),
     );
 }
@@ -1447,7 +1499,7 @@ export function readErrorHandlingExpression(
     const nodeKind: Ast.NodeKind.ErrorHandlingExpression = Ast.NodeKind.ErrorHandlingExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const tryConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordTry);
+    const tryConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordTry, Ast.ConstantKind.Try);
     const protectedExpression: Ast.TExpression = parser.readExpression(state, parser);
 
     const otherwiseExpressionNodeKind: Ast.NodeKind.OtherwiseExpression = Ast.NodeKind.OtherwiseExpression;
@@ -1458,7 +1510,7 @@ export function readErrorHandlingExpression(
         state,
         otherwiseExpressionNodeKind,
         () => IParserStateUtils.isOnTokenKind(state, TokenKind.KeywordOtherwise),
-        () => readTokenKindAsConstant(state, TokenKind.KeywordOtherwise),
+        () => readTokenKindAsConstant(state, TokenKind.KeywordOtherwise, Ast.ConstantKind.Otherwise),
         () => parser.readExpression(state, parser),
     );
 
@@ -1486,7 +1538,7 @@ export function readRecordLiteral(state: IParserState, parser: IParser<IParserSt
     > = readWrapped<Ast.NodeKind.RecordLiteral, Ast.ICsvArray<Ast.GeneralizedIdentifierPairedAnyLiteral>>(
         state,
         Ast.NodeKind.RecordLiteral,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBracket),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.ConstantKind.LeftBracket),
         () =>
             parser.readFieldNamePairedAnyLiterals(
                 state,
@@ -1494,7 +1546,7 @@ export function readRecordLiteral(state: IParserState, parser: IParser<IParserSt
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightBracket),
+        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.ConstantKind.RightBracket),
         false,
     );
     return {
@@ -1535,7 +1587,7 @@ export function readListLiteral(state: IParserState, parser: IParser<IParserStat
     >(
         state,
         Ast.NodeKind.ListLiteral,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBrace),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.ConstantKind.LeftBrace),
         () =>
             readCsvArray(
                 state,
@@ -1543,7 +1595,7 @@ export function readListLiteral(state: IParserState, parser: IParser<IParserStat
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBrace,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightBrace),
+        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.ConstantKind.RightBrace),
         false,
     );
     return {
@@ -1626,9 +1678,9 @@ function tryReadPrimitiveType(state: IParserState, _parser: IParser<IParserState
                 );
         }
     } else if (IParserStateUtils.isOnTokenKind(state, TokenKind.KeywordType)) {
-        primitiveType = readTokenKindAsConstant(state, TokenKind.KeywordType);
+        primitiveType = readTokenKindAsConstant(state, TokenKind.KeywordType, Ast.ConstantKind.Type);
     } else if (IParserStateUtils.isOnTokenKind(state, TokenKind.NullLiteral)) {
-        primitiveType = readTokenKindAsConstant(state, TokenKind.NullLiteral);
+        primitiveType = readTokenKindAsConstant(state, TokenKind.NullLiteral, Ast.ConstantKind.Null);
     } else {
         const details: {} = { tokenKind: state.maybeCurrentTokenKind };
         IParserStateUtils.applyFastStateBackup(state, stateBackup);
@@ -1931,7 +1983,11 @@ function readCsvArray<T>(
         }
 
         const node: T & Ast.TCsvType = valueReader();
-        const maybeCommaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(state, TokenKind.Comma);
+        const maybeCommaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
+            state,
+            TokenKind.Comma,
+            Ast.ConstantKind.Comma,
+        );
 
         const element: Ast.TCsv & Ast.ICsv<T & Ast.TCsvType> = {
             ...IParserStateUtils.expectContextNodeMetadata(state),
@@ -1965,7 +2021,7 @@ function readKeyValuePair<Kind, Key, Value>(
     IParserStateUtils.startContext(state, nodeKind);
 
     const key: Key = keyReader();
-    const equalConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.Equal);
+    const equalConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.Equal, Ast.ConstantKind.Equal);
     const value: Value = valueReader();
 
     const keyValuePair: Ast.IKeyValuePair<Kind, Key, Value> = {
@@ -2027,7 +2083,11 @@ function genericReadParameterList<T>(
     const nodeKind: Ast.NodeKind.ParameterList = Ast.NodeKind.ParameterList;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const leftParenthesisConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.LeftParenthesis);
+    const leftParenthesisConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        TokenKind.LeftParenthesis,
+        Ast.ConstantKind.LeftParenthesis,
+    );
     let continueReadingValues: boolean = !IParserStateUtils.isOnTokenKind(state, TokenKind.RightParenthesis);
     let reachedOptionalParameter: boolean = false;
 
@@ -2073,7 +2133,11 @@ function genericReadParameterList<T>(
         };
         IParserStateUtils.endContext(state, parameter);
 
-        const maybeCommaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(state, TokenKind.Comma);
+        const maybeCommaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
+            state,
+            TokenKind.Comma,
+            Ast.ConstantKind.Comma,
+        );
         continueReadingValues = maybeCommaConstant !== undefined;
 
         const csv: Ast.ICsv<Ast.IParameter<T & Ast.TParameterType>> = {
@@ -2096,7 +2160,11 @@ function genericReadParameterList<T>(
     };
     IParserStateUtils.endContext(state, parameterArray);
 
-    const rightParenthesisConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.RightParenthesis);
+    const rightParenthesisConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        TokenKind.RightParenthesis,
+        Ast.ConstantKind.RightParenthesis,
+    );
 
     const astNode: Ast.IParameterList<T & Ast.TParameterType> = {
         ...IParserStateUtils.expectContextNodeMetadata(state),
@@ -2126,7 +2194,11 @@ function readWrapped<Kind, Content>(
 
     let maybeOptionalConstant: Ast.Constant | undefined;
     if (allowOptionalConstant) {
-        maybeOptionalConstant = maybeReadTokenKindAsConstant(state, TokenKind.QuestionMark);
+        maybeOptionalConstant = maybeReadTokenKindAsConstant(
+            state,
+            TokenKind.QuestionMark,
+            Ast.ConstantKind.QuestionMark,
+        );
     }
 
     const wrapped: WrappedRead<Kind, Content> = {
@@ -2192,7 +2264,7 @@ function maybeReadIdentifierConstantAsConstant(
             ...IParserStateUtils.expectContextNodeMetadata(state),
             kind: nodeKind,
             isLeaf: true,
-            literal: maybeConstantKind,
+            constantKind: maybeConstantKind,
         };
         IParserStateUtils.endContext(state, astNode);
         return astNode;

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -216,7 +216,7 @@ export function readSectionDocument(state: IParserState, parser: IParser<IParser
     const sectionConstant: Ast.Constant = readTokenKindAsConstant(
         state,
         TokenKind.KeywordSection,
-        Ast.ConstantKind.Section,
+        Ast.KeywordConstantKind.Section,
     );
 
     let maybeName: Ast.Identifier | undefined;
@@ -229,7 +229,7 @@ export function readSectionDocument(state: IParserState, parser: IParser<IParser
     const semicolonConstant: Ast.Constant = readTokenKindAsConstant(
         state,
         TokenKind.Semicolon,
-        Ast.ConstantKind.Semicolon,
+        Ast.MiscConstantKind.Semicolon,
     );
     const sectionMembers: Ast.IArrayWrapper<Ast.SectionMember> = parser.readSectionMembers(state, parser);
 
@@ -278,13 +278,13 @@ export function readSectionMember(state: IParserState, parser: IParser<IParserSt
     const maybeSharedConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
         state,
         TokenKind.KeywordShared,
-        Ast.ConstantKind.Shared,
+        Ast.KeywordConstantKind.Shared,
     );
     const namePairedExpression: Ast.IdentifierPairedExpression = parser.readIdentifierPairedExpression(state, parser);
     const semicolonConstant: Ast.Constant = readTokenKindAsConstant(
         state,
         TokenKind.Semicolon,
-        Ast.ConstantKind.Semicolon,
+        Ast.MiscConstantKind.Semicolon,
     );
 
     const astNode: Ast.SectionMember = {
@@ -361,7 +361,7 @@ export function readLogicalExpression(state: IParserState, parser: IParser<IPars
         state,
         Ast.NodeKind.LogicalExpression,
         () => parser.readIsExpression(state, parser),
-        maybeCurrentTokenKind => AstUtils.maybeLogicalOperatorFrom(maybeCurrentTokenKind),
+        maybeCurrentTokenKind => AstUtils.maybeLogicalOperatorKindFrom(maybeCurrentTokenKind),
         () => parser.readIsExpression(state, parser),
     );
 }
@@ -374,13 +374,14 @@ export function readIsExpression(state: IParserState, parser: IParser<IParserSta
     return recursiveReadBinOpExpression<
         Ast.NodeKind.IsExpression,
         Ast.TAsExpression,
-        Ast.ConstantKind.Is,
+        Ast.KeywordConstantKind.Is,
         Ast.TNullablePrimitiveType
     >(
         state,
         Ast.NodeKind.IsExpression,
         () => parser.readAsExpression(state, parser),
-        maybeCurrentTokenKind => (maybeCurrentTokenKind === TokenKind.KeywordIs ? Ast.ConstantKind.Is : undefined),
+        maybeCurrentTokenKind =>
+            maybeCurrentTokenKind === TokenKind.KeywordIs ? Ast.KeywordConstantKind.Is : undefined,
         () => parser.readNullablePrimitiveType(state, parser),
     );
 }
@@ -410,13 +411,14 @@ export function readAsExpression(state: IParserState, parser: IParser<IParserSta
     return recursiveReadBinOpExpression<
         Ast.NodeKind.AsExpression,
         Ast.TEqualityExpression,
-        Ast.ConstantKind.As,
+        Ast.KeywordConstantKind.As,
         Ast.TNullablePrimitiveType
     >(
         state,
         Ast.NodeKind.AsExpression,
         () => parser.readEqualityExpression(state, parser),
-        maybeCurrentTokenKind => (maybeCurrentTokenKind === TokenKind.KeywordAs ? Ast.ConstantKind.As : undefined),
+        maybeCurrentTokenKind =>
+            maybeCurrentTokenKind === TokenKind.KeywordAs ? Ast.KeywordConstantKind.As : undefined,
         () => parser.readNullablePrimitiveType(state, parser),
     );
 }
@@ -435,7 +437,7 @@ export function readEqualityExpression(state: IParserState, parser: IParser<IPar
         state,
         Ast.NodeKind.EqualityExpression,
         () => parser.readRelationalExpression(state, parser),
-        maybeCurrentTokenKind => AstUtils.maybeEqualityOperatorFrom(maybeCurrentTokenKind),
+        maybeCurrentTokenKind => AstUtils.maybeEqualityOperatorKindFrom(maybeCurrentTokenKind),
         () => parser.readRelationalExpression(state, parser),
     );
 }
@@ -479,7 +481,7 @@ export function readArithmeticExpression(
         state,
         Ast.NodeKind.ArithmeticExpression,
         () => parser.readMetadataExpression(state, parser),
-        maybeCurrentTokenKind => AstUtils.maybeArithmeticOperatorFrom(maybeCurrentTokenKind),
+        maybeCurrentTokenKind => AstUtils.maybeArithmeticOperatorKindFrom(maybeCurrentTokenKind),
         () => parser.readMetadataExpression(state, parser),
     );
 }
@@ -496,7 +498,7 @@ export function readMetadataExpression(state: IParserState, parser: IParser<IPar
     const maybeMetaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
         state,
         TokenKind.KeywordMeta,
-        Ast.ConstantKind.Meta,
+        Ast.KeywordConstantKind.Meta,
     );
 
     if (maybeMetaConstant !== undefined) {
@@ -508,7 +510,7 @@ export function readMetadataExpression(state: IParserState, parser: IParser<IPar
             kind: nodeKind,
             isLeaf: false,
             left,
-            operator: Ast.ConstantKind.Meta,
+            operator: Ast.KeywordConstantKind.Meta,
             operatorConstant,
             right,
         };
@@ -526,7 +528,7 @@ export function readMetadataExpression(state: IParserState, parser: IParser<IPar
 // -----------------------------------------------
 
 export function readUnaryExpression(state: IParserState, parser: IParser<IParserState>): Ast.TUnaryExpression {
-    let maybeOperator: Ast.UnaryOperator | undefined = AstUtils.maybeUnaryOperatorFrom(state.maybeCurrentTokenKind);
+    let maybeOperator: Ast.UnaryOperator | undefined = AstUtils.maybeUnaryOperatorKindFrom(state.maybeCurrentTokenKind);
     if (maybeOperator === undefined) {
         return parser.readTypeExpression(state, parser);
     }
@@ -546,7 +548,7 @@ export function readUnaryExpression(state: IParserState, parser: IParser<IParser
                 (maybeOperator as unknown) as Ast.ConstantKind,
             ),
         );
-        maybeOperator = AstUtils.maybeUnaryOperatorFrom(state.maybeCurrentTokenKind);
+        maybeOperator = AstUtils.maybeUnaryOperatorKindFrom(state.maybeCurrentTokenKind);
     }
     const operators: Ast.IArrayWrapper<Ast.Constant> = {
         ...IParserStateUtils.expectContextNodeMetadata(state),
@@ -804,7 +806,7 @@ export function readIdentifierExpression(state: IParserState, parser: IParser<IP
     const maybeInclusiveConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
         state,
         TokenKind.AtSign,
-        Ast.ConstantKind.AtSign,
+        Ast.MiscConstantKind.AtSign,
     );
     const identifier: Ast.Identifier = parser.readIdentifier(state, parser);
 
@@ -830,9 +832,9 @@ export function readParenthesizedExpression(
     return readWrapped<Ast.NodeKind.ParenthesizedExpression, Ast.TExpression>(
         state,
         Ast.NodeKind.ParenthesizedExpression,
-        () => readTokenKindAsConstant(state, TokenKind.LeftParenthesis, Ast.ConstantKind.LeftParenthesis),
+        () => readTokenKindAsConstant(state, TokenKind.LeftParenthesis, Ast.WrapperConstantKind.LeftParenthesis),
         () => parser.readExpression(state, parser),
-        () => readTokenKindAsConstant(state, TokenKind.RightParenthesis, Ast.ConstantKind.RightParenthesis),
+        () => readTokenKindAsConstant(state, TokenKind.RightParenthesis, Ast.WrapperConstantKind.RightParenthesis),
         false,
     );
 }
@@ -851,7 +853,7 @@ export function readNotImplementedExpression(
     const ellipsisConstant: Ast.Constant = readTokenKindAsConstant(
         state,
         TokenKind.Ellipsis,
-        Ast.ConstantKind.Ellipsis,
+        Ast.MiscConstantKind.Ellipsis,
     );
 
     const astNode: Ast.NotImplementedExpression = {
@@ -873,7 +875,7 @@ export function readInvokeExpression(state: IParserState, parser: IParser<IParse
     return readWrapped<Ast.NodeKind.InvokeExpression, Ast.ICsvArray<Ast.TExpression>>(
         state,
         Ast.NodeKind.InvokeExpression,
-        () => readTokenKindAsConstant(state, TokenKind.LeftParenthesis, Ast.ConstantKind.LeftParenthesis),
+        () => readTokenKindAsConstant(state, TokenKind.LeftParenthesis, Ast.WrapperConstantKind.LeftParenthesis),
         () =>
             readCsvArray(
                 state,
@@ -881,7 +883,7 @@ export function readInvokeExpression(state: IParserState, parser: IParser<IParse
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForParenthesis,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightParenthesis, Ast.ConstantKind.RightParenthesis),
+        () => readTokenKindAsConstant(state, TokenKind.RightParenthesis, Ast.WrapperConstantKind.RightParenthesis),
         false,
     );
 }
@@ -895,7 +897,7 @@ export function readListExpression(state: IParserState, parser: IParser<IParserS
     return readWrapped<Ast.NodeKind.ListExpression, Ast.ICsvArray<Ast.TListItem>>(
         state,
         Ast.NodeKind.ListExpression,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.ConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.WrapperConstantKind.LeftBrace),
         () =>
             readCsvArray(
                 state,
@@ -903,7 +905,7 @@ export function readListExpression(state: IParserState, parser: IParser<IParserS
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBrace,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.ConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.WrapperConstantKind.RightBrace),
         false,
     );
 }
@@ -914,7 +916,11 @@ export function readListItem(state: IParserState, parser: IParser<IParserState>)
 
     const left: Ast.TExpression = parser.readExpression(state, parser);
     if (IParserStateUtils.isOnTokenKind(state, TokenKind.DotDot)) {
-        const rangeConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.DotDot, Ast.ConstantKind.DotDot);
+        const rangeConstant: Ast.Constant = readTokenKindAsConstant(
+            state,
+            TokenKind.DotDot,
+            Ast.MiscConstantKind.DotDot,
+        );
         const right: Ast.TExpression = parser.readExpression(state, parser);
         const astNode: Ast.RangeExpression = {
             ...IParserStateUtils.expectContextNodeMetadata(state),
@@ -942,7 +948,7 @@ export function readRecordExpression(state: IParserState, parser: IParser<IParse
     return readWrapped<Ast.NodeKind.RecordExpression, Ast.ICsvArray<Ast.GeneralizedIdentifierPairedExpression>>(
         state,
         Ast.NodeKind.RecordExpression,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.ConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.WrapperConstantKind.LeftBracket),
         () =>
             parser.readGeneralizedIdentifierPairedExpressions(
                 state,
@@ -950,7 +956,7 @@ export function readRecordExpression(state: IParserState, parser: IParser<IParse
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.ConstantKind.RightBracket),
+        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.WrapperConstantKind.RightBracket),
         false,
     );
 }
@@ -963,9 +969,9 @@ export function readItemAccessExpression(state: IParserState, parser: IParser<IP
     return readWrapped<Ast.NodeKind.ItemAccessExpression, Ast.TExpression>(
         state,
         Ast.NodeKind.ItemAccessExpression,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.ConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.WrapperConstantKind.LeftBrace),
         () => parser.readExpression(state, parser),
-        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.ConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.WrapperConstantKind.RightBrace),
         true,
     );
 }
@@ -982,7 +988,7 @@ export function readFieldProjection(state: IParserState, parser: IParser<IParser
     return readWrapped<Ast.NodeKind.FieldProjection, Ast.ICsvArray<Ast.FieldSelector>>(
         state,
         Ast.NodeKind.FieldProjection,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.ConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.WrapperConstantKind.LeftBracket),
         () =>
             readCsvArray(
                 state,
@@ -990,7 +996,7 @@ export function readFieldProjection(state: IParserState, parser: IParser<IParser
                 true,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.ConstantKind.RightBracket),
+        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.WrapperConstantKind.RightBracket),
         true,
     );
 }
@@ -1003,9 +1009,9 @@ export function readFieldSelector(
     return readWrapped<Ast.NodeKind.FieldSelector, Ast.GeneralizedIdentifier>(
         state,
         Ast.NodeKind.FieldSelector,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.ConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.WrapperConstantKind.LeftBracket),
         () => parser.readGeneralizedIdentifier(state, parser),
-        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.ConstantKind.RightBracket),
+        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.WrapperConstantKind.RightBracket),
         allowOptional,
     );
 }
@@ -1029,7 +1035,7 @@ export function readFunctionExpression(state: IParserState, parser: IParser<IPar
     const fatArrowConstant: Ast.Constant = readTokenKindAsConstant(
         state,
         TokenKind.FatArrow,
-        Ast.ConstantKind.FatArrow,
+        Ast.MiscConstantKind.FatArrow,
     );
     const expression: Ast.TExpression = parser.readExpression(state, parser);
 
@@ -1061,7 +1067,7 @@ function maybeReadAsNullablePrimitiveType(
         state,
         Ast.NodeKind.AsNullablePrimitiveType,
         () => IParserStateUtils.isOnTokenKind(state, TokenKind.KeywordAs),
-        () => readTokenKindAsConstant(state, TokenKind.KeywordAs, Ast.ConstantKind.As),
+        () => readTokenKindAsConstant(state, TokenKind.KeywordAs, Ast.KeywordConstantKind.As),
         () => parser.readNullablePrimitiveType(state, parser),
     );
 }
@@ -1070,7 +1076,7 @@ export function readAsType(state: IParserState, parser: IParser<IParserState>): 
     return readPairedConstant<Ast.NodeKind.AsType, Ast.TType>(
         state,
         Ast.NodeKind.AsType,
-        () => readTokenKindAsConstant(state, TokenKind.KeywordAs, Ast.ConstantKind.As),
+        () => readTokenKindAsConstant(state, TokenKind.KeywordAs, Ast.KeywordConstantKind.As),
         () => parser.readType(state, parser),
     );
 }
@@ -1083,7 +1089,7 @@ export function readEachExpression(state: IParserState, parser: IParser<IParserS
     return readPairedConstant<Ast.NodeKind.EachExpression, Ast.TExpression>(
         state,
         Ast.NodeKind.EachExpression,
-        () => readTokenKindAsConstant(state, TokenKind.KeywordEach, Ast.ConstantKind.Each),
+        () => readTokenKindAsConstant(state, TokenKind.KeywordEach, Ast.KeywordConstantKind.Each),
         () => parser.readExpression(state, parser),
     );
 }
@@ -1096,7 +1102,7 @@ export function readLetExpression(state: IParserState, parser: IParser<IParserSt
     const nodeKind: Ast.NodeKind.LetExpression = Ast.NodeKind.LetExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const letConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordLet, Ast.ConstantKind.Let);
+    const letConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordLet, Ast.KeywordConstantKind.Let);
     const identifierExpressionPairedExpressions: Ast.ICsvArray<
         Ast.IdentifierPairedExpression
     > = parser.readIdentifierPairedExpressions(
@@ -1105,7 +1111,7 @@ export function readLetExpression(state: IParserState, parser: IParser<IParserSt
         !IParserStateUtils.isNextTokenKind(state, TokenKind.KeywordIn),
         IParserStateUtils.testCsvContinuationLetExpression,
     );
-    const inConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordIn, Ast.ConstantKind.In);
+    const inConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordIn, Ast.KeywordConstantKind.In);
     const expression: Ast.TExpression = parser.readExpression(state, parser);
 
     const astNode: Ast.LetExpression = {
@@ -1129,13 +1135,21 @@ export function readIfExpression(state: IParserState, parser: IParser<IParserSta
     const nodeKind: Ast.NodeKind.IfExpression = Ast.NodeKind.IfExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const ifConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordIf, Ast.ConstantKind.If);
+    const ifConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordIf, Ast.KeywordConstantKind.If);
     const condition: Ast.TExpression = parser.readExpression(state, parser);
 
-    const thenConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordThen, Ast.ConstantKind.Then);
+    const thenConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        TokenKind.KeywordThen,
+        Ast.KeywordConstantKind.Then,
+    );
     const trueExpression: Ast.TExpression = parser.readExpression(state, parser);
 
-    const elseConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordElse, Ast.ConstantKind.Else);
+    const elseConstant: Ast.Constant = readTokenKindAsConstant(
+        state,
+        TokenKind.KeywordElse,
+        Ast.KeywordConstantKind.Else,
+    );
     const falseExpression: Ast.TExpression = parser.readExpression(state, parser);
 
     const astNode: Ast.IfExpression = {
@@ -1162,7 +1176,7 @@ export function readTypeExpression(state: IParserState, parser: IParser<IParserS
         return readPairedConstant<Ast.NodeKind.TypePrimaryType, Ast.TPrimaryType>(
             state,
             Ast.NodeKind.TypePrimaryType,
-            () => readTokenKindAsConstant(state, TokenKind.KeywordType, Ast.ConstantKind.Type),
+            () => readTokenKindAsConstant(state, TokenKind.KeywordType, Ast.KeywordConstantKind.Type),
             () => parser.readPrimaryType(state, parser),
         );
     } else {
@@ -1252,7 +1266,7 @@ export function readFieldSpecificationList(
     const leftBracketConstant: Ast.Constant = readTokenKindAsConstant(
         state,
         TokenKind.LeftBracket,
-        Ast.ConstantKind.LeftBracket,
+        Ast.WrapperConstantKind.LeftBracket,
     );
     const fields: Ast.ICsv<Ast.FieldSpecification>[] = [];
     let continueReadingValues: boolean = true;
@@ -1275,7 +1289,7 @@ export function readFieldSpecificationList(
                     maybeOpenRecordMarkerConstant = readTokenKindAsConstant(
                         state,
                         TokenKind.Ellipsis,
-                        Ast.ConstantKind.Ellipsis,
+                        Ast.MiscConstantKind.Ellipsis,
                     );
                     continueReadingValues = false;
                 }
@@ -1304,7 +1318,7 @@ export function readFieldSpecificationList(
             const maybeCommaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
                 state,
                 TokenKind.Comma,
-                Ast.ConstantKind.Comma,
+                Ast.MiscConstantKind.Comma,
             );
             continueReadingValues = maybeCommaConstant !== undefined;
 
@@ -1343,7 +1357,7 @@ export function readFieldSpecificationList(
     const rightBracketConstant: Ast.Constant = readTokenKindAsConstant(
         state,
         TokenKind.RightBracket,
-        Ast.ConstantKind.RightBracket,
+        Ast.WrapperConstantKind.RightBracket,
     );
 
     const astNode: Ast.FieldSpecificationList = {
@@ -1369,7 +1383,7 @@ function maybeReadFieldTypeSpecification(
     const maybeEqualConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
         state,
         TokenKind.Equal,
-        Ast.ConstantKind.Equal,
+        Ast.MiscConstantKind.Equal,
     );
     if (maybeEqualConstant) {
         const fieldType: Ast.TType = parser.readType(state, parser);
@@ -1403,9 +1417,9 @@ export function readListType(state: IParserState, parser: IParser<IParserState>)
     return readWrapped<Ast.NodeKind.ListType, Ast.TType>(
         state,
         Ast.NodeKind.ListType,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.ConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.WrapperConstantKind.LeftBrace),
         () => parser.readType(state, parser),
-        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.ConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.WrapperConstantKind.RightBrace),
         false,
     );
 }
@@ -1489,7 +1503,7 @@ export function readErrorRaisingExpression(
     return readPairedConstant<Ast.NodeKind.ErrorRaisingExpression, Ast.TExpression>(
         state,
         Ast.NodeKind.ErrorRaisingExpression,
-        () => readTokenKindAsConstant(state, TokenKind.KeywordError, Ast.ConstantKind.Error),
+        () => readTokenKindAsConstant(state, TokenKind.KeywordError, Ast.KeywordConstantKind.Error),
         () => parser.readExpression(state, parser),
     );
 }
@@ -1505,7 +1519,7 @@ export function readErrorHandlingExpression(
     const nodeKind: Ast.NodeKind.ErrorHandlingExpression = Ast.NodeKind.ErrorHandlingExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const tryConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordTry, Ast.ConstantKind.Try);
+    const tryConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.KeywordTry, Ast.KeywordConstantKind.Try);
     const protectedExpression: Ast.TExpression = parser.readExpression(state, parser);
 
     const otherwiseExpressionNodeKind: Ast.NodeKind.OtherwiseExpression = Ast.NodeKind.OtherwiseExpression;
@@ -1516,7 +1530,7 @@ export function readErrorHandlingExpression(
         state,
         otherwiseExpressionNodeKind,
         () => IParserStateUtils.isOnTokenKind(state, TokenKind.KeywordOtherwise),
-        () => readTokenKindAsConstant(state, TokenKind.KeywordOtherwise, Ast.ConstantKind.Otherwise),
+        () => readTokenKindAsConstant(state, TokenKind.KeywordOtherwise, Ast.KeywordConstantKind.Otherwise),
         () => parser.readExpression(state, parser),
     );
 
@@ -1544,7 +1558,7 @@ export function readRecordLiteral(state: IParserState, parser: IParser<IParserSt
     > = readWrapped<Ast.NodeKind.RecordLiteral, Ast.ICsvArray<Ast.GeneralizedIdentifierPairedAnyLiteral>>(
         state,
         Ast.NodeKind.RecordLiteral,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.ConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBracket, Ast.WrapperConstantKind.LeftBracket),
         () =>
             parser.readFieldNamePairedAnyLiterals(
                 state,
@@ -1552,7 +1566,7 @@ export function readRecordLiteral(state: IParserState, parser: IParser<IParserSt
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.ConstantKind.RightBracket),
+        () => readTokenKindAsConstant(state, TokenKind.RightBracket, Ast.WrapperConstantKind.RightBracket),
         false,
     );
     return {
@@ -1593,7 +1607,7 @@ export function readListLiteral(state: IParserState, parser: IParser<IParserStat
     >(
         state,
         Ast.NodeKind.ListLiteral,
-        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.ConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, TokenKind.LeftBrace, Ast.WrapperConstantKind.LeftBrace),
         () =>
             readCsvArray(
                 state,
@@ -1601,7 +1615,7 @@ export function readListLiteral(state: IParserState, parser: IParser<IParserStat
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBrace,
             ),
-        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.ConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, TokenKind.RightBrace, Ast.WrapperConstantKind.RightBrace),
         false,
     );
     return {
@@ -1684,9 +1698,9 @@ function tryReadPrimitiveType(state: IParserState, _parser: IParser<IParserState
                 );
         }
     } else if (IParserStateUtils.isOnTokenKind(state, TokenKind.KeywordType)) {
-        primitiveType = readTokenKindAsConstant(state, TokenKind.KeywordType, Ast.ConstantKind.Type);
+        primitiveType = readTokenKindAsConstant(state, TokenKind.KeywordType, Ast.KeywordConstantKind.Type);
     } else if (IParserStateUtils.isOnTokenKind(state, TokenKind.NullLiteral)) {
-        primitiveType = readTokenKindAsConstant(state, TokenKind.NullLiteral, Ast.ConstantKind.Null);
+        primitiveType = readTokenKindAsConstant(state, TokenKind.NullLiteral, Ast.MiscConstantKind.Null);
     } else {
         const details: {} = { tokenKind: state.maybeCurrentTokenKind };
         IParserStateUtils.applyFastStateBackup(state, stateBackup);
@@ -2000,7 +2014,7 @@ function readCsvArray<T>(
         const maybeCommaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
             state,
             TokenKind.Comma,
-            Ast.ConstantKind.Comma,
+            Ast.MiscConstantKind.Comma,
         );
 
         const element: Ast.TCsv & Ast.ICsv<T & Ast.TCsvType> = {
@@ -2035,7 +2049,7 @@ function readKeyValuePair<Kind, Key, Value>(
     IParserStateUtils.startContext(state, nodeKind);
 
     const key: Key = keyReader();
-    const equalConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.Equal, Ast.ConstantKind.Equal);
+    const equalConstant: Ast.Constant = readTokenKindAsConstant(state, TokenKind.Equal, Ast.MiscConstantKind.Equal);
     const value: Value = valueReader();
 
     const keyValuePair: Ast.IKeyValuePair<Kind, Key, Value> = {
@@ -2100,7 +2114,7 @@ function genericReadParameterList<T>(
     const leftParenthesisConstant: Ast.Constant = readTokenKindAsConstant(
         state,
         TokenKind.LeftParenthesis,
-        Ast.ConstantKind.LeftParenthesis,
+        Ast.WrapperConstantKind.LeftParenthesis,
     );
     let continueReadingValues: boolean = !IParserStateUtils.isOnTokenKind(state, TokenKind.RightParenthesis);
     let reachedOptionalParameter: boolean = false;
@@ -2150,7 +2164,7 @@ function genericReadParameterList<T>(
         const maybeCommaConstant: Ast.Constant | undefined = maybeReadTokenKindAsConstant(
             state,
             TokenKind.Comma,
-            Ast.ConstantKind.Comma,
+            Ast.MiscConstantKind.Comma,
         );
         continueReadingValues = maybeCommaConstant !== undefined;
 
@@ -2177,7 +2191,7 @@ function genericReadParameterList<T>(
     const rightParenthesisConstant: Ast.Constant = readTokenKindAsConstant(
         state,
         TokenKind.RightParenthesis,
-        Ast.ConstantKind.RightParenthesis,
+        Ast.WrapperConstantKind.RightParenthesis,
     );
 
     const astNode: Ast.IParameterList<T & Ast.TParameterType> = {
@@ -2211,7 +2225,7 @@ function readWrapped<Kind, Content>(
         maybeOptionalConstant = maybeReadTokenKindAsConstant(
             state,
             TokenKind.QuestionMark,
-            Ast.ConstantKind.QuestionMark,
+            Ast.MiscConstantKind.QuestionMark,
         );
     }
 

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -429,7 +429,7 @@ export function readEqualityExpression(state: IParserState, parser: IParser<IPar
     return recursiveReadBinOpExpression<
         Ast.NodeKind.EqualityExpression,
         Ast.TEqualityExpression,
-        Ast.EqualityOperator,
+        Ast.EqualityOperatorKind,
         Ast.TEqualityExpression
     >(
         state,
@@ -451,7 +451,7 @@ export function readRelationalExpression(
     return recursiveReadBinOpExpression<
         Ast.NodeKind.RelationalExpression,
         Ast.TArithmeticExpression,
-        Ast.RelationalOperator,
+        Ast.RelationalOperatorKind,
         Ast.TArithmeticExpression
     >(
         state,
@@ -473,7 +473,7 @@ export function readArithmeticExpression(
     return recursiveReadBinOpExpression<
         Ast.NodeKind.ArithmeticExpression,
         Ast.TMetadataExpression,
-        Ast.ArithmeticOperator,
+        Ast.ArithmeticOperatorKind,
         Ast.TMetadataExpression
     >(
         state,
@@ -2265,20 +2265,12 @@ function maybeReadIdentifierConstantAsConstant(
         const nodeKind: Ast.NodeKind.Constant = Ast.NodeKind.Constant;
         IParserStateUtils.startContext(state, nodeKind);
 
-        const maybeConstantKind: Ast.ConstantKind | undefined = AstUtils.maybeConstantKindFromIdentifieConstant(
-            identifierConstant,
-        );
-        if (!maybeConstantKind) {
-            const details: {} = { identifierConstant };
-            throw new CommonError.InvariantError(`couldn't convert IdentifierConstant into ConstantKind`, details);
-        }
-
         readToken(state);
         const astNode: Ast.Constant = {
             ...IParserStateUtils.expectContextNodeMetadata(state),
             kind: nodeKind,
             isLeaf: true,
-            constantKind: maybeConstantKind,
+            constantKind: identifierConstant,
         };
         IParserStateUtils.endContext(state, astNode);
         return astNode;

--- a/src/test/parser/simple.ts
+++ b/src/test/parser/simple.ts
@@ -1595,7 +1595,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.ConstantKind.Plus);
+            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperator.Positive);
         });
     });
 });

--- a/src/test/parser/simple.ts
+++ b/src/test/parser/simple.ts
@@ -124,7 +124,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperator.And);
+            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperatorKind.And);
         });
 
         it(`1 * 2`, () => {
@@ -138,7 +138,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperator.Multiplication);
+            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperatorKind.Multiplication);
         });
 
         it(`1 / 2`, () => {
@@ -152,7 +152,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperator.Division);
+            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperatorKind.Division);
         });
 
         it(`1 + 2`, () => {
@@ -166,7 +166,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperator.Addition);
+            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperatorKind.Addition);
         });
 
         it(`1 - 2`, () => {
@@ -180,7 +180,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperator.Subtraction);
+            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperatorKind.Subtraction);
         });
 
         it(`1 + 2 + 3 + 4`, () => {
@@ -267,7 +267,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.EqualityOperator.EqualTo);
+            expect(operatorNode.constantKind).to.equal(Ast.EqualityOperatorKind.EqualTo);
         });
 
         it(`1 <> 2`, () => {
@@ -281,7 +281,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.EqualityOperator.NotEqualTo);
+            expect(operatorNode.constantKind).to.equal(Ast.EqualityOperatorKind.NotEqualTo);
         });
     });
 
@@ -1333,7 +1333,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperator.GreaterThan);
+            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperatorKind.GreaterThan);
         });
 
         it(`1 >= 2`, () => {
@@ -1347,7 +1347,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperator.GreaterThanEqualTo);
+            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperatorKind.GreaterThanEqualTo);
         });
 
         it(`1 < 2`, () => {
@@ -1361,7 +1361,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperator.LessThan);
+            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperatorKind.LessThan);
         });
 
         it(`1 <= 2`, () => {
@@ -1375,7 +1375,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperator.LessThanEqualTo);
+            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperatorKind.LessThanEqualTo);
         });
     });
 

--- a/src/test/parser/simple.ts
+++ b/src/test/parser/simple.ts
@@ -124,7 +124,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.ArithmeticOperator.And);
+            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperator.And);
         });
 
         it(`1 * 2`, () => {
@@ -138,7 +138,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.ArithmeticOperator.Multiplication);
+            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperator.Multiplication);
         });
 
         it(`1 / 2`, () => {
@@ -152,7 +152,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.ArithmeticOperator.Division);
+            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperator.Division);
         });
 
         it(`1 + 2`, () => {
@@ -166,7 +166,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.ArithmeticOperator.Addition);
+            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperator.Addition);
         });
 
         it(`1 - 2`, () => {
@@ -180,7 +180,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.ArithmeticOperator.Subtraction);
+            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperator.Subtraction);
         });
 
         it(`1 + 2 + 3 + 4`, () => {
@@ -267,7 +267,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.EqualityOperator.EqualTo);
+            expect(operatorNode.constantKind).to.equal(Ast.EqualityOperator.EqualTo);
         });
 
         it(`1 <> 2`, () => {
@@ -281,7 +281,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.EqualityOperator.NotEqualTo);
+            expect(operatorNode.constantKind).to.equal(Ast.EqualityOperator.NotEqualTo);
         });
     });
 
@@ -1333,7 +1333,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.RelationalOperator.GreaterThan);
+            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperator.GreaterThan);
         });
 
         it(`1 >= 2`, () => {
@@ -1347,7 +1347,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.RelationalOperator.GreaterThanEqualTo);
+            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperator.GreaterThanEqualTo);
         });
 
         it(`1 < 2`, () => {
@@ -1361,7 +1361,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.RelationalOperator.LessThan);
+            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperator.LessThan);
         });
 
         it(`1 <= 2`, () => {
@@ -1375,7 +1375,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.RelationalOperator.LessThanEqualTo);
+            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperator.LessThanEqualTo);
         });
     });
 
@@ -1567,7 +1567,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.UnaryOperator.Negative);
+            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperator.Negative);
         });
 
         it(`not 1`, () => {
@@ -1581,7 +1581,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.UnaryOperator.Not);
+            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperator.Not);
         });
 
         it(`+1`, () => {
@@ -1595,7 +1595,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.literal).to.equal(Ast.UnaryOperator.Positive);
+            expect(operatorNode.constantKind).to.equal(Ast.ConstantKind.Plus);
         });
     });
 });


### PR DESCRIPTION
Constant shouldn't be holding a string, instead it should have a kind attribute as there's a finite number of constants possible (note: literals are their own category). This PR refactors Constant by adding a kind attribute, which is ConstantKind redefined as the union of several categories of constants (KeywordConstant, ArithmeticConstant, etc). This assists typing and will make more logical sense for library consumers.