### PR TITLE
Remove Operator generic from IBinOpExpression

### DIFF
--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -176,7 +176,7 @@ export function isOnTokenKind(
     return isTokenKind(state, tokenKind, tokenIndex);
 }
 
-export function isOnIdentifierConstant(state: IParserState, identifierConstant: Ast.IdentifierConstant): boolean {
+export function isOnIdentifierConstant(state: IParserState, identifierConstant: Ast.IdentifierConstantKind): boolean {
     if (isOnTokenKind(state, TokenKind.Identifier)) {
         const currentToken: Token = state.lexerSnapshot.tokens[state.tokenIndex];
         if (currentToken === undefined || currentToken.data === undefined) {

--- a/src/parser/ast/ast.ts
+++ b/src/parser/ast/ast.ts
@@ -306,12 +306,7 @@ export type TArithmeticExpression = ArithmeticExpression | TMetadataExpression;
 export type TMetadataExpression = MetadataExpression | TUnaryExpression;
 
 export interface MetadataExpression
-    extends IBinOpExpression<
-        NodeKind.MetadataExpression,
-        TUnaryExpression,
-        KeywordConstantKind.Meta,
-        TUnaryExpression
-    > {}
+    extends IBinOpExpression<NodeKind.MetadataExpression, TUnaryExpression, TUnaryExpression> {}
 
 // -----------------------------------------------
 // ---------- 12.2.3.9 Unary expression ----------
@@ -324,12 +319,6 @@ export interface UnaryExpression extends INode {
     readonly isLeaf: false;
     readonly operators: IArrayWrapper<Constant>;
     readonly typeExpression: TTypeExpression;
-}
-
-export const enum UnaryOperator {
-    Positive = "+",
-    Negative = "-",
-    Not = "not",
 }
 
 // --------------------------------------------------
@@ -356,15 +345,6 @@ export interface LiteralExpression extends INode {
     readonly isLeaf: true;
     readonly literal: string;
     readonly literalKind: LiteralKind;
-}
-
-export const enum LiteralKind {
-    Logical = "Logical",
-    Null = "Null",
-    Numeric = "Numeric",
-    Str = "Str",
-    Record = "Record",
-    List = "List",
 }
 
 // -----------------------------------------------------
@@ -629,74 +609,44 @@ export type TBinOpExpression =
     | RelationalExpression
     | TBinOpExpressionSubtype;
 
-// The following types are needed for recursiveReadBinOpExpressionHelper,
-// and are created by converting IBinOpExpression<A, B, C, D> to IBinOpExpression<A, D, C, D>.
-export type TBinOpExpressionSubtype =
-    | IBinOpExpression<NodeKind.AsExpression, TNullablePrimitiveType, KeywordConstantKind.As, TNullablePrimitiveType>
-    | IBinOpExpression<NodeKind.IsExpression, TNullablePrimitiveType, KeywordConstantKind.Is, TNullablePrimitiveType>;
-
-export interface IBinOpExpression<Kind, Left, Operator, Right> extends INode {
-    readonly kind: Kind & TBinOpExpressionNodeKind;
-    readonly left: Left;
-    readonly operator: Operator;
-    readonly operatorConstant: Constant;
-    readonly right:
-        | Left
-        | Right
-        | IBinOpExpression<Kind, Left, Operator, Right>
-        | IBinOpExpression<Kind, Right, Operator, Right>;
-}
-
-export interface ArithmeticExpression
-    extends IBinOpExpression<
-        NodeKind.ArithmeticExpression,
-        TArithmeticExpression,
-        ArithmeticOperatorKind,
-        TArithmeticExpression
-    > {}
-
-export interface AsExpression
-    extends IBinOpExpression<
-        NodeKind.AsExpression,
-        TEqualityExpression,
-        KeywordConstantKind.As,
-        TNullablePrimitiveType
-    > {}
-
-export interface EqualityExpression
-    extends IBinOpExpression<
-        NodeKind.EqualityExpression,
-        TEqualityExpression,
-        EqualityOperatorKind,
-        TEqualityExpression
-    > {}
-
-export interface IsExpression
-    extends IBinOpExpression<NodeKind.IsExpression, TAsExpression, KeywordConstantKind.Is, TNullablePrimitiveType> {}
-
-export interface LogicalExpression
-    extends IBinOpExpression<NodeKind.LogicalExpression, TLogicalExpression, LogicalOperator, TLogicalExpression> {}
-
-export interface RelationalExpression
-    extends IBinOpExpression<
-        NodeKind.RelationalExpression,
-        TRelationalExpression,
-        RelationalOperatorKind,
-        TRelationalExpression
-    > {}
-
-// ------------------------------------------------
-// ---------- IBinOpExpression Operators ----------
-// ------------------------------------------------
-
 export type TBinOpExpressionOperator =
     | ArithmeticOperatorKind
     | EqualityOperatorKind
-    | LogicalOperator
+    | LogicalOperatorKind
     | RelationalOperatorKind
     | KeywordConstantKind.As
     | KeywordConstantKind.Is
     | KeywordConstantKind.Meta;
+
+// The following types are needed for recursiveReadBinOpExpressionHelper,
+// and are created by converting IBinOpExpression<A, B, C, D> to IBinOpExpression<A, D, C, D>.
+export type TBinOpExpressionSubtype =
+    | IBinOpExpression<NodeKind.AsExpression, TNullablePrimitiveType, TNullablePrimitiveType>
+    | IBinOpExpression<NodeKind.IsExpression, TNullablePrimitiveType, TNullablePrimitiveType>;
+
+export interface IBinOpExpression<Kind, Left, Right> extends INode {
+    readonly kind: Kind & TBinOpExpressionNodeKind;
+    readonly left: Left;
+    readonly operatorConstant: Constant;
+    readonly right: Left | Right | IBinOpExpression<Kind, Left, Right> | IBinOpExpression<Kind, Right, Right>;
+}
+
+export interface ArithmeticExpression
+    extends IBinOpExpression<NodeKind.ArithmeticExpression, TArithmeticExpression, TArithmeticExpression> {}
+
+export interface AsExpression
+    extends IBinOpExpression<NodeKind.AsExpression, TEqualityExpression, TNullablePrimitiveType> {}
+
+export interface EqualityExpression
+    extends IBinOpExpression<NodeKind.EqualityExpression, TEqualityExpression, TEqualityExpression> {}
+
+export interface IsExpression extends IBinOpExpression<NodeKind.IsExpression, TAsExpression, TNullablePrimitiveType> {}
+
+export interface LogicalExpression
+    extends IBinOpExpression<NodeKind.LogicalExpression, TLogicalExpression, TLogicalExpression> {}
+
+export interface RelationalExpression
+    extends IBinOpExpression<NodeKind.RelationalExpression, TRelationalExpression, TRelationalExpression> {}
 
 // ------------------------------------------
 // ---------- Key value pair nodes ----------
@@ -736,15 +686,30 @@ export interface AsNullablePrimitiveType
 
 export interface AsType extends IPairedConstant<NodeKind.AsType, TType> {}
 
-// ----------------------------------------
-// ---------- Re-used interfaces ----------
-// ----------------------------------------
+// ------------------------------
+// ---------- Constant ----------
+// ------------------------------
+
+export type TConstantKind =
+    | MiscConstantKind
+    | WrapperConstantKind
+    | KeywordConstantKind
+    | IdentifierConstantKind
+    | ArithmeticOperatorKind
+    | EqualityOperatorKind
+    | LogicalOperatorKind
+    | RelationalOperatorKind
+    | UnaryOperatorKind;
 
 export interface Constant extends INode {
     readonly kind: NodeKind.Constant;
     readonly isLeaf: true;
     readonly constantKind: TConstantKind;
 }
+
+// ----------------------------------------
+// ---------- Re-used interfaces ----------
+// ----------------------------------------
 
 export interface FieldSpecification extends INode {
     readonly kind: NodeKind.FieldSpecification;
@@ -780,17 +745,6 @@ export interface Identifier extends INode {
 // ---------------------------------
 // ---------- const enums ----------
 // ---------------------------------
-
-export type TConstantKind =
-    | MiscConstantKind
-    | WrapperConstantKind
-    | KeywordConstantKind
-    | IdentifierConstant
-    | ArithmeticOperatorKind
-    | EqualityOperatorKind
-    | LogicalOperator
-    | RelationalOperatorKind
-    | UnaryOperator;
 
 export const enum MiscConstantKind {
     // TokenKind
@@ -837,7 +791,7 @@ export const enum KeywordConstantKind {
     Type = "type",
 }
 
-export const enum IdentifierConstant {
+export const enum IdentifierConstantKind {
     Action = "action",
     Any = "any",
     AnyNonNull = "anynonnull",
@@ -872,7 +826,7 @@ export const enum EqualityOperatorKind {
     NotEqualTo = "<>",
 }
 
-export const enum LogicalOperator {
+export const enum LogicalOperatorKind {
     And = "and",
     Or = "or",
 }
@@ -882,4 +836,19 @@ export const enum RelationalOperatorKind {
     LessThanEqualTo = "<=",
     GreaterThan = ">",
     GreaterThanEqualTo = ">=",
+}
+
+export const enum UnaryOperatorKind {
+    Positive = "+",
+    Negative = "-",
+    Not = "not",
+}
+
+export const enum LiteralKind {
+    Logical = "Logical",
+    Null = "Null",
+    Numeric = "Numeric",
+    Str = "Str",
+    Record = "Record",
+    List = "List",
 }

--- a/src/parser/ast/astUtils.ts
+++ b/src/parser/ast/astUtils.ts
@@ -5,14 +5,14 @@ import { CommonError, isNever } from "../../common";
 import { TokenKind } from "../../lexer";
 import * as Ast from "./ast";
 
-export function maybeUnaryOperatorKindFrom(maybeTokenKind: TokenKind | undefined): Ast.UnaryOperator | undefined {
+export function maybeUnaryOperatorKindFrom(maybeTokenKind: TokenKind | undefined): Ast.UnaryOperatorKind | undefined {
     switch (maybeTokenKind) {
         case TokenKind.Plus:
-            return Ast.UnaryOperator.Positive;
+            return Ast.UnaryOperatorKind.Positive;
         case TokenKind.Minus:
-            return Ast.UnaryOperator.Negative;
+            return Ast.UnaryOperatorKind.Negative;
         case TokenKind.KeywordNot:
-            return Ast.UnaryOperator.Not;
+            return Ast.UnaryOperatorKind.Not;
         default:
             return undefined;
     }
@@ -50,18 +50,20 @@ export function maybeEqualityOperatorKindFrom(
     }
 }
 
-export function maybeLogicalOperatorKindFrom(maybeTokenKind: TokenKind | undefined): Ast.LogicalOperator | undefined {
+export function maybeLogicalOperatorKindFrom(
+    maybeTokenKind: TokenKind | undefined,
+): Ast.LogicalOperatorKind | undefined {
     switch (maybeTokenKind) {
         case TokenKind.KeywordAnd:
-            return Ast.LogicalOperator.And;
+            return Ast.LogicalOperatorKind.And;
         case TokenKind.KeywordOr:
-            return Ast.LogicalOperator.Or;
+            return Ast.LogicalOperatorKind.Or;
         default:
             return undefined;
     }
 }
 
-export function maybeRelationalOperatorFrom(
+export function maybeRelationalOperatorKindFrom(
     maybeTokenKind: TokenKind | undefined,
 ): Ast.RelationalOperatorKind | undefined {
     switch (maybeTokenKind) {
@@ -102,9 +104,9 @@ export function maybeBinOpExpressionOperatorKindFrom(
 
         // LogicalOperator
         case TokenKind.KeywordAnd:
-            return Ast.LogicalOperator.And;
+            return Ast.LogicalOperatorKind.And;
         case TokenKind.KeywordOr:
-            return Ast.LogicalOperator.Or;
+            return Ast.LogicalOperatorKind.Or;
 
         // RelationalOperator
         case TokenKind.LessThan:
@@ -129,7 +131,7 @@ export function maybeBinOpExpressionOperatorKindFrom(
     }
 }
 
-export function maybeBinOpExpressionOperatorPrecedence(operator: Ast.TBinOpExpressionOperator): number {
+export function binOpExpressionOperatorPrecedence(operator: Ast.TBinOpExpressionOperator): number {
     switch (operator) {
         case Ast.KeywordConstantKind.Meta:
             return 110;
@@ -159,10 +161,10 @@ export function maybeBinOpExpressionOperatorPrecedence(operator: Ast.TBinOpExpre
         case Ast.KeywordConstantKind.Is:
             return 50;
 
-        case Ast.LogicalOperator.And:
+        case Ast.LogicalOperatorKind.And:
             return 40;
 
-        case Ast.LogicalOperator.Or:
+        case Ast.LogicalOperatorKind.Or:
             return 30;
 
         default:
@@ -194,26 +196,26 @@ export function maybeLiteralKindFrom(maybeTokenKind: TokenKind | undefined): Ast
 
 export function isIdentifierConstant(
     maybeIdentifierConstant: string,
-): maybeIdentifierConstant is Ast.IdentifierConstant {
+): maybeIdentifierConstant is Ast.IdentifierConstantKind {
     switch (maybeIdentifierConstant) {
-        case Ast.IdentifierConstant.Any:
-        case Ast.IdentifierConstant.AnyNonNull:
-        case Ast.IdentifierConstant.Binary:
-        case Ast.IdentifierConstant.Date:
-        case Ast.IdentifierConstant.DateTime:
-        case Ast.IdentifierConstant.DateTimeZone:
-        case Ast.IdentifierConstant.Duration:
-        case Ast.IdentifierConstant.Function:
-        case Ast.IdentifierConstant.List:
-        case Ast.IdentifierConstant.Logical:
-        case Ast.IdentifierConstant.None:
-        case Ast.IdentifierConstant.Nullable:
-        case Ast.IdentifierConstant.Number:
-        case Ast.IdentifierConstant.Optional:
-        case Ast.IdentifierConstant.Record:
-        case Ast.IdentifierConstant.Table:
-        case Ast.IdentifierConstant.Text:
-        case Ast.IdentifierConstant.Time:
+        case Ast.IdentifierConstantKind.Any:
+        case Ast.IdentifierConstantKind.AnyNonNull:
+        case Ast.IdentifierConstantKind.Binary:
+        case Ast.IdentifierConstantKind.Date:
+        case Ast.IdentifierConstantKind.DateTime:
+        case Ast.IdentifierConstantKind.DateTimeZone:
+        case Ast.IdentifierConstantKind.Duration:
+        case Ast.IdentifierConstantKind.Function:
+        case Ast.IdentifierConstantKind.List:
+        case Ast.IdentifierConstantKind.Logical:
+        case Ast.IdentifierConstantKind.None:
+        case Ast.IdentifierConstantKind.Nullable:
+        case Ast.IdentifierConstantKind.Number:
+        case Ast.IdentifierConstantKind.Optional:
+        case Ast.IdentifierConstantKind.Record:
+        case Ast.IdentifierConstantKind.Table:
+        case Ast.IdentifierConstantKind.Text:
+        case Ast.IdentifierConstantKind.Time:
             return true;
         default:
             return false;
@@ -241,7 +243,7 @@ export function isPairedWrapperConstantKinds(x: Ast.TConstantKind, y: Ast.TConst
         return false;
     }
 
-    // If given x === ')' and y === '(' then swap positions.
+    // If given x === ')' and y === '(', then swap positions.
     const low: Ast.TConstantKind = x < y ? x : y;
     const high: Ast.TConstantKind = low === x ? y : x;
 

--- a/src/parser/parsers/combinatorialParser.ts
+++ b/src/parser/parsers/combinatorialParser.ts
@@ -238,7 +238,7 @@ function readBinOpExpression(
         let minPrecedence: number = Number.MAX_SAFE_INTEGER;
 
         for (let index: number = 0; index < operators.length; index += 1) {
-            const currentPrecedence: number = AstUtils.maybeBinOpExpressionOperatorPrecedence(operators[index]);
+            const currentPrecedence: number = AstUtils.binOpExpressionOperatorPrecedence(operators[index]);
             if (minPrecedence > currentPrecedence) {
                 minPrecedence = currentPrecedence;
                 minPrecedenceIndex = index;
@@ -349,8 +349,8 @@ function binOpExpressionNodeKindFrom(operator: Ast.TBinOpExpressionOperator): As
         case Ast.KeywordConstantKind.Is:
             return Ast.NodeKind.IsExpression;
 
-        case Ast.LogicalOperator.And:
-        case Ast.LogicalOperator.Or:
+        case Ast.LogicalOperatorKind.And:
+        case Ast.LogicalOperatorKind.Or:
             return Ast.NodeKind.LogicalExpression;
 
         default:

--- a/src/test/parser/simple.ts
+++ b/src/test/parser/simple.ts
@@ -1567,7 +1567,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperator.Negative);
+            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperatorKind.Negative);
         });
 
         it(`not 1`, () => {
@@ -1581,7 +1581,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperator.Not);
+            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperatorKind.Not);
         });
 
         it(`+1`, () => {
@@ -1595,7 +1595,7 @@ describe("Parser.AbridgedNode", () => {
             expectAbridgeNodes(text, expected);
 
             const operatorNode: Ast.Constant = expectNthNodeOfKind<Ast.Constant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperator.Positive);
+            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperatorKind.Positive);
         });
     });
 });


### PR DESCRIPTION
Now that ConstantKind has been updated (#91 ) it's easier to handle constants. We can now drop the Operator generic (operatorKind) from IBinOpExpression.