### PR TITLE
Move XorNode into its own file

### DIFF
--- a/src/inspection/activeNode/activeNode.ts
+++ b/src/inspection/activeNode/activeNode.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, NodeIdMap } from "../../parser";
+import { Ast, TXorNode } from "../../parser";
 import { Position } from "../position";
 
 // An ActiveNode represents the context a text editor user expects their cursor to be in.
@@ -14,7 +14,7 @@ export interface ActiveNode {
     readonly position: Position;
     // A full parental ancestry of the root.
     // [root, parent of root, parent of parent of root, ...].
-    readonly ancestry: ReadonlyArray<NodeIdMap.TXorNode>;
+    readonly ancestry: ReadonlyArray<TXorNode>;
     // A cache of an evaluation that otherwise would need to be re-evaluated.
     // If ActiveNode's leaf is an identifier then store the indirection to it as an Ast node.
     readonly maybeIdentifierUnderPosition: Ast.Identifier | Ast.GeneralizedIdentifier | undefined;

--- a/src/inspection/activeNode/activeNodeUtils.ts
+++ b/src/inspection/activeNode/activeNodeUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { CommonError } from "../../common";
-import { Ast, AstUtils, NodeIdMap, NodeIdMapUtils, ParserContext } from "../../parser";
+import { Ast, AstUtils, NodeIdMap, NodeIdMapUtils, ParserContext, TXorNode, XorNodeKind } from "../../parser";
 import { Position, PositionUtils } from "../position";
 import { ActiveNode } from "./activeNode";
 
@@ -33,7 +33,7 @@ export function maybeActiveNode(
     const astSearch: AstNodeSearch = positionAstSearch(position, nodeIdMapCollection, leafNodeIds);
     const maybeContextSearch: ParserContext.Node | undefined = positionContextSearch(astSearch, nodeIdMapCollection);
 
-    let maybeLeaf: NodeIdMap.TXorNode | undefined;
+    let maybeLeaf: TXorNode | undefined;
     if (astSearch.maybeShiftedNode !== undefined) {
         maybeLeaf = NodeIdMapUtils.xorNodeFromAst(astSearch.maybeShiftedNode);
     } else if (astSearch.maybeNode !== undefined && isAnchorNode(position, astSearch.maybeNode)) {
@@ -49,7 +49,7 @@ export function maybeActiveNode(
     if (maybeLeaf === undefined) {
         return undefined;
     }
-    const leaf: NodeIdMap.TXorNode = maybeLeaf;
+    const leaf: TXorNode = maybeLeaf;
 
     return {
         position,
@@ -58,12 +58,12 @@ export function maybeActiveNode(
     };
 }
 
-export function expectRoot(activeNode: ActiveNode): NodeIdMap.TXorNode {
-    const ancestry: ReadonlyArray<NodeIdMap.TXorNode> = activeNode.ancestry;
+export function expectRoot(activeNode: ActiveNode): TXorNode {
+    const ancestry: ReadonlyArray<TXorNode> = activeNode.ancestry;
     return ancestry[ancestry.length - 1];
 }
 
-export function expectLeaf(activeNode: ActiveNode): NodeIdMap.TXorNode {
+export function expectLeaf(activeNode: ActiveNode): TXorNode {
     return activeNode.ancestry[0];
 }
 
@@ -72,8 +72,8 @@ export function maybePreviousXorNode(
     ancestorIndex: number,
     n: number = 1,
     maybeNodeKinds: ReadonlyArray<Ast.NodeKind> | undefined = undefined,
-): NodeIdMap.TXorNode | undefined {
-    const maybeXorNode: NodeIdMap.TXorNode | undefined = activeNode.ancestry[ancestorIndex - n];
+): TXorNode | undefined {
+    const maybeXorNode: TXorNode | undefined = activeNode.ancestry[ancestorIndex - n];
     if (maybeXorNode !== undefined && maybeNodeKinds !== undefined) {
         return maybeNodeKinds.indexOf(maybeXorNode.node.kind) !== -1 ? maybeXorNode : undefined;
     } else {
@@ -81,11 +81,7 @@ export function maybePreviousXorNode(
     }
 }
 
-export function maybeNextXorNode(
-    activeNode: ActiveNode,
-    ancestorIndex: number,
-    n: number = 1,
-): NodeIdMap.TXorNode | undefined {
+export function maybeNextXorNode(activeNode: ActiveNode, ancestorIndex: number, n: number = 1): TXorNode | undefined {
     return activeNode.ancestry[ancestorIndex + n];
 }
 
@@ -94,12 +90,12 @@ export function expectPreviousXorNode(
     ancestorIndex: number,
     n: number = 1,
     maybeAllowedNodeKinds: ReadonlyArray<Ast.NodeKind> | undefined = undefined,
-): NodeIdMap.TXorNode {
-    const maybeXorNode: NodeIdMap.TXorNode | undefined = maybePreviousXorNode(activeNode, ancestorIndex, n);
+): TXorNode {
+    const maybeXorNode: TXorNode | undefined = maybePreviousXorNode(activeNode, ancestorIndex, n);
     if (maybeXorNode === undefined) {
         throw new CommonError.InvariantError("no previous node");
     }
-    const xorNode: NodeIdMap.TXorNode = maybeXorNode;
+    const xorNode: TXorNode = maybeXorNode;
 
     if (maybeAllowedNodeKinds !== undefined) {
         const details: {} = {
@@ -126,12 +122,12 @@ export function expectNextXorNode(
     ancestorIndex: number,
     n: number = 1,
     maybeAllowedNodeKinds: ReadonlyArray<Ast.NodeKind> | undefined = undefined,
-): NodeIdMap.TXorNode {
-    const maybeXorNode: NodeIdMap.TXorNode | undefined = maybeNextXorNode(activeNode, ancestorIndex, n);
+): TXorNode {
+    const maybeXorNode: TXorNode | undefined = maybeNextXorNode(activeNode, ancestorIndex, n);
     if (maybeXorNode === undefined) {
         throw new CommonError.InvariantError("no next node");
     }
-    const xorNode: NodeIdMap.TXorNode = maybeXorNode;
+    const xorNode: TXorNode = maybeXorNode;
 
     if (maybeAllowedNodeKinds !== undefined) {
         const details: {} = {
@@ -340,9 +336,9 @@ function positionContextSearch(
 function maybeIdentifierUnderPosition(
     position: Position,
     nodeIdMapCollection: NodeIdMap.Collection,
-    leaf: NodeIdMap.TXorNode,
+    leaf: TXorNode,
 ): Ast.Identifier | Ast.GeneralizedIdentifier | undefined {
-    if (leaf.kind !== NodeIdMap.XorNodeKind.Ast) {
+    if (leaf.kind !== XorNodeKind.Ast) {
         return undefined;
     }
 

--- a/src/inspection/inspectionUtils.ts
+++ b/src/inspection/inspectionUtils.ts
@@ -1,5 +1,5 @@
 import { CommonError } from "../common";
-import { Ast, NodeIdMap } from "../parser";
+import { Ast, TXorNode } from "../parser";
 import { ActiveNode, ActiveNodeUtils } from "./activeNode";
 
 export interface InspectionState {
@@ -23,7 +23,7 @@ export function isInKeyValuePairAssignment(state: InspectionState): boolean {
         n = 3;
     }
 
-    const maybeKeyValuePair: NodeIdMap.TXorNode | undefined = ActiveNodeUtils.maybePreviousXorNode(
+    const maybeKeyValuePair: TXorNode | undefined = ActiveNodeUtils.maybePreviousXorNode(
         state.activeNode,
         state.nodeIndex,
         n,
@@ -37,16 +37,16 @@ export function isInKeyValuePairAssignment(state: InspectionState): boolean {
     if (maybeKeyValuePair === undefined) {
         return false;
     }
-    const keyValuePair: NodeIdMap.TXorNode = maybeKeyValuePair;
+    const keyValuePair: TXorNode = maybeKeyValuePair;
 
-    const ancestry: ReadonlyArray<NodeIdMap.TXorNode> = state.activeNode.ancestry;
+    const ancestry: ReadonlyArray<TXorNode> = state.activeNode.ancestry;
 
     const keyValuePairAncestryIndex: number = ancestry.indexOf(keyValuePair);
     if (keyValuePairAncestryIndex === -1) {
         throw new CommonError.InvariantError("xorNode isn't in ancestry");
     }
 
-    const maybeChild: NodeIdMap.TXorNode | undefined = ancestry[keyValuePairAncestryIndex - 1];
+    const maybeChild: TXorNode | undefined = ancestry[keyValuePairAncestryIndex - 1];
     if (maybeChild === undefined) {
         const details: {} = { keyValuePairId: keyValuePair.node.id };
         throw new CommonError.InvariantError("expected xorNode to have a child", details);

--- a/src/inspection/position/positionUtils.ts
+++ b/src/inspection/position/positionUtils.ts
@@ -3,15 +3,15 @@
 
 import { isNever } from "../../common";
 import { Token, TokenPosition } from "../../lexer";
-import { Ast, NodeIdMap, NodeIdMapUtils, ParserContext } from "../../parser";
+import { Ast, NodeIdMap, NodeIdMapUtils, ParserContext, TXorNode, XorNodeKind } from "../../parser";
 import { Position } from "./position";
 
-export function isBeforeXorNode(position: Position, xorNode: NodeIdMap.TXorNode, isBoundIncluded: boolean): boolean {
+export function isBeforeXorNode(position: Position, xorNode: TXorNode, isBoundIncluded: boolean): boolean {
     switch (xorNode.kind) {
-        case NodeIdMap.XorNodeKind.Ast:
+        case XorNodeKind.Ast:
             return isBeforeAstNode(position, xorNode.node, isBoundIncluded);
 
-        case NodeIdMap.XorNodeKind.Context:
+        case XorNodeKind.Context:
             return isBeforeContextNode(position, xorNode.node, isBoundIncluded);
 
         default:
@@ -22,15 +22,15 @@ export function isBeforeXorNode(position: Position, xorNode: NodeIdMap.TXorNode,
 export function isInXorNode(
     position: Position,
     nodeIdMapCollection: NodeIdMap.Collection,
-    xorNode: NodeIdMap.TXorNode,
+    xorNode: TXorNode,
     isLowerBoundIncluded: boolean,
     isUpperBoundIncluded: boolean,
 ): boolean {
     switch (xorNode.kind) {
-        case NodeIdMap.XorNodeKind.Ast:
+        case XorNodeKind.Ast:
             return isInAstNode(position, xorNode.node, isLowerBoundIncluded, isUpperBoundIncluded);
 
-        case NodeIdMap.XorNodeKind.Context:
+        case XorNodeKind.Context:
             return isInContextNode(
                 position,
                 nodeIdMapCollection,
@@ -44,12 +44,12 @@ export function isInXorNode(
     }
 }
 
-export function isOnXorNodeStart(position: Position, xorNode: NodeIdMap.TXorNode): boolean {
+export function isOnXorNodeStart(position: Position, xorNode: TXorNode): boolean {
     switch (xorNode.kind) {
-        case NodeIdMap.XorNodeKind.Ast:
+        case XorNodeKind.Ast:
             return isOnAstNodeStart(position, xorNode.node);
 
-        case NodeIdMap.XorNodeKind.Context:
+        case XorNodeKind.Context:
             return isOnContextNodeStart(position, xorNode.node);
 
         default:
@@ -59,14 +59,14 @@ export function isOnXorNodeStart(position: Position, xorNode: NodeIdMap.TXorNode
 
 export function isOnXorNodeEnd(
     position: Position,
-    xorNode: NodeIdMap.TXorNode,
+    xorNode: TXorNode,
     nodeIdMapCollection: NodeIdMap.Collection,
 ): boolean {
     switch (xorNode.kind) {
-        case NodeIdMap.XorNodeKind.Ast:
+        case XorNodeKind.Ast:
             return isOnAstNodeEnd(position, xorNode.node);
 
-        case NodeIdMap.XorNodeKind.Context:
+        case XorNodeKind.Context:
             return isOnContextNodeEnd(position, xorNode.node, nodeIdMapCollection);
 
         default:
@@ -77,14 +77,14 @@ export function isOnXorNodeEnd(
 export function isAfterXorNode(
     position: Position,
     nodeIdMapCollection: NodeIdMap.Collection,
-    xorNode: NodeIdMap.TXorNode,
+    xorNode: TXorNode,
     isBoundIncluded: boolean,
 ): boolean {
     switch (xorNode.kind) {
-        case NodeIdMap.XorNodeKind.Ast:
+        case XorNodeKind.Ast:
             return isAfterAstNode(position, xorNode.node, isBoundIncluded);
 
-        case NodeIdMap.XorNodeKind.Context:
+        case XorNodeKind.Context:
             return isAfterContextNode(position, nodeIdMapCollection, xorNode.node, isBoundIncluded);
 
         default:

--- a/src/inspection/positionIdentifier.ts
+++ b/src/inspection/positionIdentifier.ts
@@ -1,4 +1,4 @@
-import { Ast, NodeIdMap } from "../parser";
+import { Ast, TXorNode } from "../parser";
 
 export type TPositionIdentifier = LocalIdentifier | UndefinedIdentifier;
 
@@ -14,7 +14,7 @@ export interface IPositionIdentifier {
 
 export interface LocalIdentifier extends IPositionIdentifier {
     readonly kind: PositionIdentifierKind.Local;
-    readonly definition: NodeIdMap.TXorNode;
+    readonly definition: TXorNode;
 }
 
 export interface UndefinedIdentifier extends IPositionIdentifier {

--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -385,6 +385,10 @@ export function testNoMoreTokens(state: IParserState): ParseError.UnusedTokensRe
     }
 }
 
+// -------------------------------------
+// ---------- Error factories ----------
+// -------------------------------------
+
 export function unterminatedParenthesesError(state: IParserState): ParseError.UnterminatedParenthesesError {
     const token: Token = expectTokenAt(state, state.tokenIndex);
     return new ParseError.UnterminatedParenthesesError(
@@ -402,6 +406,10 @@ export function unterminatedBracketError(state: IParserState): ParseError.Unterm
         state.lexerSnapshot.graphemePositionStartFrom(token),
     );
 }
+
+// ---------------------------------------------
+// ---------- Column number factories ----------
+// ---------------------------------------------
 
 export function maybeCurrentTokenWithColumnNumber(state: IParserState): ParseError.TokenWithColumnNumber | undefined {
     return maybeTokenWithColumnNumber(state, state.tokenIndex);

--- a/src/parser/context.ts
+++ b/src/parser/context.ts
@@ -4,7 +4,7 @@
 import { Ast, NodeIdMap } from ".";
 import { CommonError, TypeUtils } from "../common";
 import { Token } from "../lexer";
-import { NodeIdMapUtils } from "./nodeIdMap";
+import { NodeIdMapUtils, TXorNode } from "./nodeIdMap";
 
 // Parsing use to be one giant evaluation, leading to an all-or-nothing outcome which was unsuitable for a
 // document that was being live edited.
@@ -258,7 +258,7 @@ export function deleteContext(state: State, nodeId: number): Node | undefined {
         }
 
         // The child Node inherits the attributeIndex.
-        const childXorNode: NodeIdMap.TXorNode = NodeIdMapUtils.expectXorNode(state.nodeIdMapCollection, childId);
+        const childXorNode: TXorNode = NodeIdMapUtils.expectXorNode(state.nodeIdMapCollection, childId);
         const mutableChildXorNode: TypeUtils.StripReadonly<Ast.TNode | Node> = childXorNode.node;
         mutableChildXorNode.maybeAttributeIndex = contextNode.maybeAttributeIndex;
     }

--- a/src/parser/nodeIdMap/index.ts
+++ b/src/parser/nodeIdMap/index.ts
@@ -2,3 +2,4 @@ import * as NodeIdMap from "./nodeIdMap";
 import * as NodeIdMapUtils from "./nodeIdMapUtils";
 
 export { NodeIdMap, NodeIdMapUtils };
+export * from "./xorNode";

--- a/src/parser/nodeIdMap/nodeIdMap.ts
+++ b/src/parser/nodeIdMap/nodeIdMap.ts
@@ -3,11 +3,6 @@
 
 import { Ast, ParserContext } from "..";
 
-export const enum XorNodeKind {
-    Ast = "Ast",
-    Context = "Context",
-}
-
 export type AstNodeById = NumberMap<Ast.TNode>;
 
 export type ContextNodeById = NumberMap<ParserContext.Node>;
@@ -15,18 +10,6 @@ export type ContextNodeById = NumberMap<ParserContext.Node>;
 export type ParentIdById = NumberMap<number>;
 
 export type ChildIdsById = NumberMap<ReadonlyArray<number>>;
-
-export type TXorNode = IXorNode<XorNodeKind.Ast, Ast.TNode> | IXorNode<XorNodeKind.Context, ParserContext.Node>;
-
-export interface IXorNode<Kind, T> {
-    readonly kind: Kind & XorNodeKind;
-    readonly node: T;
-}
-
-export interface XorNodeTokenRange {
-    readonly tokenIndexStart: number;
-    readonly tokenIndexEnd: number;
-}
 
 export interface Collection {
     readonly astNodeById: AstNodeById;

--- a/src/parser/nodeIdMap/nodeIdMapUtils.ts
+++ b/src/parser/nodeIdMap/nodeIdMapUtils.ts
@@ -4,15 +4,8 @@
 import { Ast, ParserContext } from "..";
 import { CommonError, isNever } from "../../common";
 import { TokenRange } from "../../lexer";
-import {
-    AstNodeById,
-    ChildIdsById,
-    Collection,
-    ContextNodeById,
-    TXorNode,
-    XorNodeKind,
-    XorNodeTokenRange,
-} from "./nodeIdMap";
+import { AstNodeById, ChildIdsById, Collection, ContextNodeById } from "./nodeIdMap";
+import { TXorNode, XorNodeKind, XorNodeTokenRange } from "./xorNode";
 
 export function xorNodeFromAst(node: Ast.TNode): TXorNode {
     return {

--- a/src/parser/nodeIdMap/xorNode.ts
+++ b/src/parser/nodeIdMap/xorNode.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Ast, ParserContext } from "..";
+
+export const enum XorNodeKind {
+    Ast = "Ast",
+    Context = "Context",
+}
+
+export type TXorNode = IXorNode<XorNodeKind.Ast, Ast.TNode> | IXorNode<XorNodeKind.Context, ParserContext.Node>;
+
+export interface IXorNode<Kind, T> {
+    readonly kind: Kind & XorNodeKind;
+    readonly node: T;
+}
+
+export interface XorNodeTokenRange {
+    readonly tokenIndexStart: number;
+    readonly tokenIndexEnd: number;
+}

--- a/src/test/inspection/abridgedPositionIdentifier.ts
+++ b/src/test/inspection/abridgedPositionIdentifier.ts
@@ -7,7 +7,7 @@ import { Inspection } from "../..";
 import { isNever, ResultUtils } from "../../common";
 import { PositionIdentifierKind, TPositionIdentifier } from "../../inspection";
 import { Token, TokenPosition } from "../../lexer";
-import { NodeIdMap } from "../../parser";
+import { TXorNode, XorNodeKind } from "../../parser";
 import { expectParseErrInspection, expectParseOkInspection, expectTextWithPosition } from "./common";
 
 type TAbridgedPositionIdentifier = AbridgedLocalIdentifier | AbridgedUndefinedIdentifier;
@@ -51,15 +51,15 @@ function abridgedMaybeIdentifierUnderPositionFrom(
 
     switch (positionIdentifier.kind) {
         case PositionIdentifierKind.Local: {
-            const definition: NodeIdMap.TXorNode = positionIdentifier.definition;
+            const definition: TXorNode = positionIdentifier.definition;
 
             let maybeDefinitionPositionStart: TokenPosition | undefined;
             switch (definition.kind) {
-                case NodeIdMap.XorNodeKind.Ast:
+                case XorNodeKind.Ast:
                     maybeDefinitionPositionStart = definition.node.tokenRange.positionStart;
                     break;
 
-                case NodeIdMap.XorNodeKind.Context: {
+                case XorNodeKind.Context: {
                     const maybeTokenStart: Token | undefined = definition.node.maybeTokenStart;
                     if (maybeTokenStart !== undefined) {
                         const tokenStart: Token = maybeTokenStart;

--- a/src/test/inspection/identifierInspectedVisitedNode.ts
+++ b/src/test/inspection/identifierInspectedVisitedNode.ts
@@ -6,7 +6,7 @@ import "mocha";
 import { Inspection } from "../..";
 import { isNever, ResultKind } from "../../common";
 import { Token } from "../../lexer";
-import { Ast, NodeIdMap } from "../../parser";
+import { Ast, TXorNode, XorNodeKind } from "../../parser";
 import { expectParseErrInspection, expectParseOkInspection, expectTextWithPosition } from "./common";
 
 interface AbridgedTravelPathNode {
@@ -20,15 +20,15 @@ function abrigedTravelPathFrom(inspected: Inspection.Inspected): ReadonlyArray<A
         return [];
     }
 
-    return inspected.maybeActiveNode.ancestry.map((xorNode: NodeIdMap.TXorNode) => {
+    return inspected.maybeActiveNode.ancestry.map((xorNode: TXorNode) => {
         let maybePositionStartCodeUnit: number | undefined;
 
         switch (xorNode.kind) {
-            case NodeIdMap.XorNodeKind.Ast:
+            case XorNodeKind.Ast:
                 maybePositionStartCodeUnit = xorNode.node.tokenRange.positionStart.codeUnit;
                 break;
 
-            case NodeIdMap.XorNodeKind.Context:
+            case XorNodeKind.Context:
                 const maybeTokenStart: Token | undefined = xorNode.node.maybeTokenStart;
                 maybePositionStartCodeUnit =
                     maybeTokenStart !== undefined ? maybeTokenStart.positionStart.codeUnit : undefined;
@@ -69,8 +69,8 @@ function expectNumOfNodeKind(inspected: Inspection.Inspected, expectedKind: Ast.
     if (inspected.maybeActiveNode === undefined) {
         actualNum = -1;
     } else {
-        const nodesOfKind: ReadonlyArray<NodeIdMap.TXorNode> = inspected.maybeActiveNode.ancestry.filter(
-            (xorNode: NodeIdMap.TXorNode) => xorNode.node.kind === expectedKind,
+        const nodesOfKind: ReadonlyArray<TXorNode> = inspected.maybeActiveNode.ancestry.filter(
+            (xorNode: TXorNode) => xorNode.node.kind === expectedKind,
         );
         actualNum = nodesOfKind.length;
     }
@@ -81,11 +81,7 @@ function expectNumOfNodeKind(inspected: Inspection.Inspected, expectedKind: Ast.
     );
 }
 
-function expectNthOfNodeKind<T>(
-    inspected: Inspection.Inspected,
-    nodeKind: Ast.NodeKind,
-    nth: number,
-): T & NodeIdMap.TXorNode {
+function expectNthOfNodeKind<T>(inspected: Inspection.Inspected, nodeKind: Ast.NodeKind, nth: number): T & TXorNode {
     if (nth <= 0) {
         throw new Error("nth must be > 0");
     } else if (inspected.maybeActiveNode === undefined) {
@@ -97,7 +93,7 @@ function expectNthOfNodeKind<T>(
         if (xorNode.node.kind === nodeKind) {
             nthFound += 1;
             if (nth === nthFound) {
-                return (xorNode as unknown) as T & NodeIdMap.TXorNode;
+                return (xorNode as unknown) as T & TXorNode;
             }
         }
     }
@@ -279,11 +275,7 @@ describe(`Inspection`, () => {
             expectNumOfNodeKind(inspected, Ast.NodeKind.InvokeExpression, 1);
 
             expect(inspected.maybeInvokeExpression!).not.equal(undefined, "at least one InvokeExpression was found");
-            const firstInvokeExprNode: NodeIdMap.TXorNode = expectNthOfNodeKind(
-                inspected,
-                Ast.NodeKind.InvokeExpression,
-                1,
-            );
+            const firstInvokeExprNode: TXorNode = expectNthOfNodeKind(inspected, Ast.NodeKind.InvokeExpression, 1);
             expect(inspected.maybeInvokeExpression!.xorNode.node.id).to.equal(firstInvokeExprNode.node.id);
             const inspectedInvokeExpr: Inspection.InspectedInvokeExpression = inspected.maybeInvokeExpression!;
 
@@ -296,11 +288,7 @@ describe(`Inspection`, () => {
             expectNumOfNodeKind(inspected, Ast.NodeKind.InvokeExpression, 2);
 
             expect(inspected.maybeInvokeExpression!).not.equal(undefined, "at least one InvokeExpression was found");
-            const firstInvokeExprNode: NodeIdMap.TXorNode = expectNthOfNodeKind(
-                inspected,
-                Ast.NodeKind.InvokeExpression,
-                1,
-            );
+            const firstInvokeExprNode: TXorNode = expectNthOfNodeKind(inspected, Ast.NodeKind.InvokeExpression, 1);
             expect(inspected.maybeInvokeExpression!.xorNode.node.id).to.equal(firstInvokeExprNode.node.id);
             const inspectedInvokeExpr: Inspection.InspectedInvokeExpression = inspected.maybeInvokeExpression!;
 
@@ -313,11 +301,7 @@ describe(`Inspection`, () => {
             expectNumOfNodeKind(inspected, Ast.NodeKind.InvokeExpression, 1);
 
             expect(inspected.maybeInvokeExpression!).not.equal(undefined, "at least one InvokeExpression was found");
-            const firstInvokeExprNode: NodeIdMap.TXorNode = expectNthOfNodeKind(
-                inspected,
-                Ast.NodeKind.InvokeExpression,
-                1,
-            );
+            const firstInvokeExprNode: TXorNode = expectNthOfNodeKind(inspected, Ast.NodeKind.InvokeExpression, 1);
             expect(inspected.maybeInvokeExpression!.xorNode.node.id).to.equal(firstInvokeExprNode.node.id);
             const inspectedInvokeExpr: Inspection.InspectedInvokeExpression = inspected.maybeInvokeExpression!;
 
@@ -333,11 +317,7 @@ describe(`Inspection`, () => {
             expectNumOfNodeKind(inspected, Ast.NodeKind.InvokeExpression, 1);
 
             expect(inspected.maybeInvokeExpression!).not.equal(undefined, "at least one InvokeExpression was found");
-            const firstInvokeExprNode: NodeIdMap.TXorNode = expectNthOfNodeKind(
-                inspected,
-                Ast.NodeKind.InvokeExpression,
-                1,
-            );
+            const firstInvokeExprNode: TXorNode = expectNthOfNodeKind(inspected, Ast.NodeKind.InvokeExpression, 1);
             expect(inspected.maybeInvokeExpression!.xorNode.node.id).to.equal(firstInvokeExprNode.node.id);
             const inspectedInvokeExpr: Inspection.InspectedInvokeExpression = inspected.maybeInvokeExpression!;
 
@@ -353,11 +333,7 @@ describe(`Inspection`, () => {
             expectNumOfNodeKind(inspected, Ast.NodeKind.InvokeExpression, 1);
 
             expect(inspected.maybeInvokeExpression!).not.equal(undefined, "at least one InvokeExpression was found");
-            const firstInvokeExprNode: NodeIdMap.TXorNode = expectNthOfNodeKind(
-                inspected,
-                Ast.NodeKind.InvokeExpression,
-                1,
-            );
+            const firstInvokeExprNode: TXorNode = expectNthOfNodeKind(inspected, Ast.NodeKind.InvokeExpression, 1);
             expect(inspected.maybeInvokeExpression!.xorNode.node.id).to.equal(firstInvokeExprNode.node.id);
             const inspectedInvokeExpr: Inspection.InspectedInvokeExpression = inspected.maybeInvokeExpression!;
 


### PR DESCRIPTION
Typing `NodeIdMap.TXorNode` is kind of a pain, especially since library consumers would have to write `PQP.NodeIdMap.TXorNode`, so it's getting split into its own file.