### PR TITLE
Split ParserContext

### DIFF
--- a/src/common/traversal.ts
+++ b/src/common/traversal.ts
@@ -3,7 +3,7 @@
 
 import { CommonError, isNever, Result } from ".";
 import { ILocalizationTemplates } from "../localization";
-import { Ast, NodeIdMap, NodeIdMapUtils, ParserContext, TXorNode, XorNodeKind } from "../parser";
+import { Ast, NodeIdMap, NodeIdMapUtils, ParseContext, TXorNode, XorNodeKind } from "../parser";
 import { ResultUtils } from "./result";
 
 export type TriedTraverse<ResultType> = Result<ResultType, CommonError.CommonError>;
@@ -135,7 +135,7 @@ export function expectExpandAllXorChildren<State, ResultType>(
         }
         case XorNodeKind.Context: {
             const result: TXorNode[] = [];
-            const contextNode: ParserContext.Node = xorNode.node;
+            const contextNode: ParseContext.Node = xorNode.node;
             const maybeChildIds: ReadonlyArray<number> | undefined = nodeIdMapCollection.childIdsById.get(
                 contextNode.id,
             );
@@ -153,11 +153,11 @@ export function expectExpandAllXorChildren<State, ResultType>(
                         continue;
                     }
 
-                    const maybeContextChild: ParserContext.Node | undefined = nodeIdMapCollection.contextNodeById.get(
+                    const maybeContextChild: ParseContext.Node | undefined = nodeIdMapCollection.contextNodeById.get(
                         childId,
                     );
                     if (maybeContextChild) {
-                        const contextChild: ParserContext.Node = maybeContextChild;
+                        const contextChild: ParseContext.Node = maybeContextChild;
                         result.push({
                             kind: XorNodeKind.Context,
                             node: contextChild,

--- a/src/inspection/activeNode/activeNodeUtils.ts
+++ b/src/inspection/activeNode/activeNodeUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { CommonError } from "../../common";
-import { Ast, AstUtils, NodeIdMap, NodeIdMapUtils, ParserContext, TXorNode, XorNodeKind } from "../../parser";
+import { Ast, AstUtils, NodeIdMap, NodeIdMapUtils, ParseContext, TXorNode, XorNodeKind } from "../../parser";
 import { Position, PositionUtils } from "../position";
 import { ActiveNode } from "./activeNode";
 
@@ -31,7 +31,7 @@ export function maybeActiveNode(
     leafNodeIds: ReadonlyArray<number>,
 ): ActiveNode | undefined {
     const astSearch: AstNodeSearch = positionAstSearch(position, nodeIdMapCollection, leafNodeIds);
-    const maybeContextSearch: ParserContext.Node | undefined = positionContextSearch(astSearch, nodeIdMapCollection);
+    const maybeContextSearch: ParseContext.Node | undefined = positionContextSearch(astSearch, nodeIdMapCollection);
 
     let maybeLeaf: TXorNode | undefined;
     if (astSearch.maybeShiftedNode !== undefined) {
@@ -311,13 +311,13 @@ function positionAstSearch(
 function positionContextSearch(
     astNodeSearch: AstNodeSearch,
     nodeIdMapCollection: NodeIdMap.Collection,
-): ParserContext.Node | undefined {
+): ParseContext.Node | undefined {
     if (astNodeSearch.maybeNode === undefined) {
         return undefined;
     }
     const tokenIndexLowBound: number = astNodeSearch.maybeNode.tokenRange.tokenIndexStart;
 
-    let maybeCurrent: ParserContext.Node | undefined = undefined;
+    let maybeCurrent: ParseContext.Node | undefined = undefined;
     for (const candidate of nodeIdMapCollection.contextNodeById.values()) {
         if (candidate.maybeTokenStart) {
             if (candidate.tokenIndexStart < tokenIndexLowBound) {

--- a/src/inspection/identifier.ts
+++ b/src/inspection/identifier.ts
@@ -3,7 +3,7 @@
 
 import { InspectionUtils } from ".";
 import { CommonError, isNever, Result, ResultKind } from "../common";
-import { Ast, NodeIdMap, NodeIdMapUtils, ParserContext, TXorNode, XorNodeKind } from "../parser";
+import { Ast, NodeIdMap, NodeIdMapUtils, ParseContext, TXorNode, XorNodeKind } from "../parser";
 import { InspectionSettings } from "../settings";
 import { ActiveNode, ActiveNodeUtils } from "./activeNode";
 import { Position, PositionUtils } from "./position";
@@ -557,7 +557,7 @@ function addAstToScopeIfNew(state: IdentifierState, key: string, astNode: Ast.TN
     });
 }
 
-function addContextToScopeIfNew(state: IdentifierState, key: string, contextNode: ParserContext.Node): void {
+function addContextToScopeIfNew(state: IdentifierState, key: string, contextNode: ParseContext.Node): void {
     addToScopeIfNew(state, key, {
         kind: XorNodeKind.Context,
         node: contextNode,

--- a/src/inspection/position/positionUtils.ts
+++ b/src/inspection/position/positionUtils.ts
@@ -3,7 +3,7 @@
 
 import { isNever } from "../../common";
 import { Token, TokenPosition } from "../../lexer";
-import { Ast, NodeIdMap, NodeIdMapUtils, ParserContext, TXorNode, XorNodeKind } from "../../parser";
+import { Ast, NodeIdMap, NodeIdMapUtils, ParseContext, TXorNode, XorNodeKind } from "../../parser";
 import { Position } from "./position";
 
 export function isBeforeXorNode(position: Position, xorNode: TXorNode, isBoundIncluded: boolean): boolean {
@@ -94,7 +94,7 @@ export function isAfterXorNode(
 
 export function isBeforeContextNode(
     position: Position,
-    contextNode: ParserContext.Node,
+    contextNode: ParseContext.Node,
     isBoundIncluded: boolean,
 ): boolean {
     const maybeTokenStart: Token | undefined = contextNode.maybeTokenStart;
@@ -109,7 +109,7 @@ export function isBeforeContextNode(
 export function isInContextNode(
     position: Position,
     nodeIdMapCollection: NodeIdMap.Collection,
-    contextNode: ParserContext.Node,
+    contextNode: ParseContext.Node,
     isLowerBoundIncluded: boolean,
     isHigherBoundIncluded: boolean,
 ): boolean {
@@ -119,7 +119,7 @@ export function isInContextNode(
     );
 }
 
-export function isOnContextNodeStart(position: Position, contextNode: ParserContext.Node): boolean {
+export function isOnContextNodeStart(position: Position, contextNode: ParseContext.Node): boolean {
     return contextNode.maybeTokenStart !== undefined
         ? isOnTokenPosition(position, contextNode.maybeTokenStart.positionStart)
         : false;
@@ -127,7 +127,7 @@ export function isOnContextNodeStart(position: Position, contextNode: ParserCont
 
 export function isOnContextNodeEnd(
     position: Position,
-    contextNode: ParserContext.Node,
+    contextNode: ParseContext.Node,
     nodeIdMapCollection: NodeIdMap.Collection,
 ): boolean {
     const maybeLeaf: Ast.TNode | undefined = NodeIdMapUtils.maybeRightMostLeaf(nodeIdMapCollection, contextNode.id);
@@ -141,7 +141,7 @@ export function isOnContextNodeEnd(
 export function isAfterContextNode(
     position: Position,
     nodeIdMapCollection: NodeIdMap.Collection,
-    contextNode: ParserContext.Node,
+    contextNode: ParseContext.Node,
     isBoundIncluded: boolean,
 ): boolean {
     const maybeLeaf: Ast.TNode | undefined = NodeIdMapUtils.maybeRightMostLeaf(nodeIdMapCollection, contextNode.id);

--- a/src/parser/IParserState/IParserState.ts
+++ b/src/parser/IParserState/IParserState.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ParserContext } from "..";
+import { ParseContext } from "..";
 import { LexerSnapshot, Token, TokenKind } from "../../lexer";
 import { ILocalizationTemplates } from "../../localization";
 
@@ -11,6 +11,6 @@ export interface IParserState {
     tokenIndex: number;
     maybeCurrentToken: Token | undefined;
     maybeCurrentTokenKind: TokenKind | undefined;
-    contextState: ParserContext.State;
-    maybeCurrentContextNode: ParserContext.Node | undefined;
+    contextState: ParseContext.State;
+    maybeCurrentContextNode: ParseContext.Node | undefined;
 }

--- a/src/parser/context/context.ts
+++ b/src/parser/context/context.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Ast, NodeIdMap } from "../";
+import { Token } from "../../lexer";
+
+// Parsing use to be one giant evaluation, leading to an all-or-nothing outcome which was unsuitable for a
+// document that was being live edited.
+//
+// Take the scenario where a user is in the process of adding another element to a ListExpression.
+// Once a comma is typed the parser would error out as it also expects the yet untyped element.
+// Under the one giant evaluation model there was no way to propagate what was parsed up to that point.
+//
+// Context is used as a workbook for Ast.TNodes that have started evaluation but haven't yet finished.
+// It starts out empty, with no children belonging to it.
+// Most (all non-leaf) Ast.TNode's require several sub-Ast.TNodes to be evaluated as well.
+// For each sub-Ast.TNode that begins evaluation another Context is created and linked as a child of the original.
+// This means if a Ast.TNode has N attributes of type Ast.TNode, then the Ast.TNode is fully evaluated there should be N
+// child contexts created belonging under the original Context.
+// Once the Ast.TNode evaluation is complete the result is saved on the Context under its maybeAstNode attribute.
+//
+// Back to the scenario listed above, where the user has entered `{1,}`, you could examine the context state to find:
+//  An incomplete ListExpression context with 3 children
+//  With the first child being an evaluated Ast.TNode of NodeKind.Constant: `{`
+//  With the second child being an evaluated Ast.TNode of NodeKind.Csv: `1,`
+//  With the third child being a yet-to-be evaluated Context of NodeKind.Csv
+
+export interface State {
+    readonly root: Root;
+    readonly nodeIdMapCollection: NodeIdMap.Collection;
+    idCounter: number;
+    leafNodeIds: number[];
+}
+
+export interface Root {
+    maybeNode: Node | undefined;
+}
+
+export interface Node {
+    readonly id: number;
+    readonly kind: Ast.NodeKind;
+    readonly tokenIndexStart: number;
+    readonly maybeTokenStart: Token | undefined;
+    // Incremented for each child context created with the Node as its parent,
+    // and decremented for each child context deleted.
+    attributeCounter: number;
+    maybeAttributeIndex: number | undefined;
+    isClosed: boolean;
+}

--- a/src/parser/context/contextUtils.ts
+++ b/src/parser/context/contextUtils.ts
@@ -4,8 +4,8 @@
 import { Ast, NodeIdMap } from "..";
 import { CommonError, TypeUtils } from "../../common";
 import { Token } from "../../lexer";
-import { Node, State } from "../context";
 import { NodeIdMapUtils, TXorNode } from "../nodeIdMap";
+import { Node, State } from "./context";
 
 export function newState(): State {
     return {

--- a/src/parser/context/contextUtils.ts
+++ b/src/parser/context/contextUtils.ts
@@ -1,54 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, NodeIdMap } from ".";
-import { CommonError, TypeUtils } from "../common";
-import { Token } from "../lexer";
-import { NodeIdMapUtils, TXorNode } from "./nodeIdMap";
-
-// Parsing use to be one giant evaluation, leading to an all-or-nothing outcome which was unsuitable for a
-// document that was being live edited.
-//
-// Take the scenario where a user is in the process of adding another element to a ListExpression.
-// Once a comma is typed the parser would error out as it also expects the yet untyped element.
-// Under the one giant evaluation model there was no way to propagate what was parsed up to that point.
-//
-// Context is used as a workbook for Ast.TNodes that have started evaluation but haven't yet finished.
-// It starts out empty, with no children belonging to it.
-// Most (all non-leaf) Ast.TNode's require several sub-Ast.TNodes to be evaluated as well.
-// For each sub-Ast.TNode that begins evaluation another Context is created and linked as a child of the original.
-// This means if a Ast.TNode has N attributes of type Ast.TNode, then the Ast.TNode is fully evaluated there should be N
-// child contexts created belonging under the original Context.
-// Once the Ast.TNode evaluation is complete the result is saved on the Context under its maybeAstNode attribute.
-//
-// Back to the scenario listed above, where the user has entered `{1,}`, you could examine the context state to find:
-//  An incomplete ListExpression context with 3 children
-//  With the first child being an evaluated Ast.TNode of NodeKind.Constant: `{`
-//  With the second child being an evaluated Ast.TNode of NodeKind.Csv: `1,`
-//  With the third child being a yet-to-be evaluated Context of NodeKind.Csv
-
-export interface State {
-    readonly root: Root;
-    readonly nodeIdMapCollection: NodeIdMap.Collection;
-    idCounter: number;
-    leafNodeIds: number[];
-}
-
-export interface Root {
-    maybeNode: Node | undefined;
-}
-
-export interface Node {
-    readonly id: number;
-    readonly kind: Ast.NodeKind;
-    readonly tokenIndexStart: number;
-    readonly maybeTokenStart: Token | undefined;
-    // Incremented for each child context created with the Node as its parent,
-    // and decremented for each child context deleted.
-    attributeCounter: number;
-    maybeAttributeIndex: number | undefined;
-    isClosed: boolean;
-}
+import { Ast, NodeIdMap } from "..";
+import { CommonError, TypeUtils } from "../../common";
+import { Token } from "../../lexer";
+import { Node, State } from "../context";
+import { NodeIdMapUtils, TXorNode } from "../nodeIdMap";
 
 export function newState(): State {
     return {

--- a/src/parser/context/index.ts
+++ b/src/parser/context/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as ParseContext from "./context";
+import * as ParseContextUtils from "./contextUtils";
+
+export { ParseContext, ParseContextUtils };

--- a/src/parser/error.ts
+++ b/src/parser/error.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ParserContext } from ".";
+import { ParseContext } from ".";
 import { CommonError, StringUtils } from "../common";
 import { Token, TokenKind } from "../lexer/token";
 import { ILocalizationTemplates, Localization } from "../localization";
@@ -30,7 +30,7 @@ export const enum UnterminatedKind {
 }
 
 export class ParseError extends Error {
-    constructor(readonly innerError: TInnerParseError, readonly context: ParserContext.State) {
+    constructor(readonly innerError: TInnerParseError, readonly context: ParseContext.State) {
         super(innerError.message);
     }
 }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as ParserContext from "./context";
 import * as ParseError from "./error";
 import * as Parser from "./parsers";
 
 export * from "./ast";
+export * from "./context";
 export * from "./IParser";
 export * from "./IParserState";
 export * from "./nodeIdMap";
-export { ParseError, Parser, ParserContext };
+export { ParseError, Parser };

--- a/src/parser/nodeIdMap/nodeIdMap.ts
+++ b/src/parser/nodeIdMap/nodeIdMap.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, ParserContext } from "..";
+import { Ast, ParseContext } from "..";
 
 export type AstNodeById = NumberMap<Ast.TNode>;
 
-export type ContextNodeById = NumberMap<ParserContext.Node>;
+export type ContextNodeById = NumberMap<ParseContext.Node>;
 
 export type ParentIdById = NumberMap<number>;
 

--- a/src/parser/nodeIdMap/nodeIdMapUtils.ts
+++ b/src/parser/nodeIdMap/nodeIdMapUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, ParserContext } from "..";
+import { Ast, ParseContext } from "..";
 import { CommonError, isNever } from "../../common";
 import { TokenRange } from "../../lexer";
 import { AstNodeById, ChildIdsById, Collection, ContextNodeById } from "./nodeIdMap";
@@ -14,7 +14,7 @@ export function xorNodeFromAst(node: Ast.TNode): TXorNode {
     };
 }
 
-export function xorNodeFromContext(node: ParserContext.Node): TXorNode {
+export function xorNodeFromContext(node: ParseContext.Node): TXorNode {
     return {
         kind: XorNodeKind.Context,
         node,
@@ -31,9 +31,9 @@ export function maybeXorNode(nodeIdMapCollection: Collection, nodeId: number): T
         };
     }
 
-    const maybeContextNode: ParserContext.Node | undefined = nodeIdMapCollection.contextNodeById.get(nodeId);
+    const maybeContextNode: ParseContext.Node | undefined = nodeIdMapCollection.contextNodeById.get(nodeId);
     if (maybeContextNode) {
-        const contextNode: ParserContext.Node = maybeContextNode;
+        const contextNode: ParseContext.Node = maybeContextNode;
         return {
             kind: XorNodeKind.Context,
             node: contextNode,
@@ -81,7 +81,7 @@ export function maybeParentXorNode(
         return xorNodeFromAst(maybeAstNode);
     }
 
-    const maybeContextNode: ParserContext.Node | undefined = maybeParentContextNode(
+    const maybeContextNode: ParseContext.Node | undefined = maybeParentContextNode(
         nodeIdMapCollection,
         childId,
         maybeAllowedNodeKinds,
@@ -120,17 +120,17 @@ export function maybeParentContextNode(
     nodeIdMapCollection: Collection,
     childId: number,
     maybeAllowedNodeKinds: ReadonlyArray<Ast.NodeKind> | undefined = undefined,
-): ParserContext.Node | undefined {
+): ParseContext.Node | undefined {
     const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(childId);
     if (maybeParentId === undefined) {
         return undefined;
     }
-    const maybeParent: ParserContext.Node | undefined = nodeIdMapCollection.contextNodeById.get(maybeParentId);
+    const maybeParent: ParseContext.Node | undefined = nodeIdMapCollection.contextNodeById.get(maybeParentId);
 
     if (maybeParent === undefined) {
         return undefined;
     }
-    const parent: ParserContext.Node = maybeParent;
+    const parent: ParseContext.Node = maybeParent;
 
     if (maybeAllowedNodeKinds !== undefined && maybeAllowedNodeKinds.indexOf(parent.kind) === -1) {
         return undefined;
@@ -221,7 +221,7 @@ export function maybeContextChildByAttributeIndex(
     parentId: number,
     attributeIndex: number,
     maybeChildNodeKinds: ReadonlyArray<Ast.NodeKind> | undefined,
-): ParserContext.Node | undefined {
+): ParseContext.Node | undefined {
     const maybeNode: TXorNode | undefined = maybeXorChildByAttributeIndex(
         nodeIdMapCollection,
         parentId,
@@ -288,8 +288,8 @@ export function expectAstNode(astNodeById: AstNodeById, nodeId: number): Ast.TNo
     return expectInMap<Ast.TNode>(astNodeById, nodeId, "astNodeById");
 }
 
-export function expectContextNode(contextNodeById: ContextNodeById, nodeId: number): ParserContext.Node {
-    return expectInMap<ParserContext.Node>(contextNodeById, nodeId, "contextNodeById");
+export function expectContextNode(contextNodeById: ContextNodeById, nodeId: number): ParseContext.Node {
+    return expectInMap<ParseContext.Node>(contextNodeById, nodeId, "contextNodeById");
 }
 
 export function expectXorNode(nodeIdMapCollection: Collection, nodeId: number): TXorNode {
@@ -375,8 +375,8 @@ export function expectContextChildByAttributeIndex(
     parentId: number,
     attributeIndex: number,
     maybeChildNodeKinds: ReadonlyArray<Ast.NodeKind> | undefined,
-): ParserContext.Node {
-    const maybeNode: ParserContext.Node | undefined = maybeContextChildByAttributeIndex(
+): ParseContext.Node {
+    const maybeNode: ParseContext.Node | undefined = maybeContextChildByAttributeIndex(
         nodeIdMapCollection,
         parentId,
         attributeIndex,
@@ -566,7 +566,7 @@ export function xorNodeTokenRange(nodeIdMapCollection: Collection, xorNode: TXor
         }
 
         case XorNodeKind.Context: {
-            const contextNode: ParserContext.Node = xorNode.node;
+            const contextNode: ParseContext.Node = xorNode.node;
             let tokenIndexEnd: number;
 
             const maybeRightMostChild: Ast.TNode | undefined = maybeRightMostLeaf(nodeIdMapCollection, xorNode.node.id);

--- a/src/parser/nodeIdMap/xorNode.ts
+++ b/src/parser/nodeIdMap/xorNode.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, ParserContext } from "..";
+import { Ast, ParseContext } from "..";
 
 export const enum XorNodeKind {
     Ast = "Ast",
     Context = "Context",
 }
 
-export type TXorNode = IXorNode<XorNodeKind.Ast, Ast.TNode> | IXorNode<XorNodeKind.Context, ParserContext.Node>;
+export type TXorNode = IXorNode<XorNodeKind.Ast, Ast.TNode> | IXorNode<XorNodeKind.Context, ParseContext.Node>;
 
 export interface IXorNode<Kind, T> {
     readonly kind: Kind & XorNodeKind;

--- a/src/parser/parsers/combinatorialParser.ts
+++ b/src/parser/parsers/combinatorialParser.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Naive } from ".";
-import { Ast, AstUtils, NodeIdMap, ParserContext } from "..";
+import { Ast, AstUtils, NodeIdMap, ParseContextUtils } from "..";
 import { ArrayUtils, CommonError, isNever, TypeUtils } from "../../common";
 import { TokenKind, TokenRange } from "../../lexer";
 import { BracketDisambiguation, IParser } from "../IParser";
@@ -245,7 +245,7 @@ function readBinOpExpression(
             }
         }
 
-        const newBinOpExpressionId: number = ParserContext.nextId(state.contextState);
+        const newBinOpExpressionId: number = ParseContextUtils.nextId(state.contextState);
         const left: TypeUtils.StripReadonly<Ast.TBinOpExpression | Ast.TUnaryExpression | Ast.TNullablePrimitiveType> =
             expressions[minPrecedenceIndex];
         const operator: Ast.TBinOpExpressionOperator = operators[minPrecedenceIndex];

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, AstUtils, NodeIdMap, ParseError, ParserContext } from "..";
+import { Ast, AstUtils, NodeIdMap, ParseContext, ParseContextUtils, ParseError } from "..";
 import { CommonError, isNever, Result, ResultUtils, TypeUtils } from "../../common";
 import { LexerSnapshot, Token, TokenKind } from "../../lexer";
 import { BracketDisambiguation, IParser, ParenthesisDisambiguation, TriedParse } from "../IParser";
@@ -143,11 +143,11 @@ export function readDocument(state: IParserState, parser: IParser<IParserState>)
         // Fast backup deletes context state, but we want to preserve it for the case
         // where both parsing an expression and section document error out.
         const expressionErrorStateBackup: IParserStateUtils.FastStateBackup = IParserStateUtils.fastStateBackup(state);
-        const expressionErrorContextState: ParserContext.State = state.contextState;
+        const expressionErrorContextState: ParseContext.State = state.contextState;
 
         // Reset the parser's state.
         state.tokenIndex = 0;
-        state.contextState = ParserContext.newState();
+        state.contextState = ParseContextUtils.newState();
         state.maybeCurrentContextNode = undefined;
 
         if (state.lexerSnapshot.tokens.length) {
@@ -196,7 +196,7 @@ export function readDocument(state: IParserState, parser: IParser<IParserState>)
         );
     }
 
-    const contextState: ParserContext.State = state.contextState;
+    const contextState: ParseContext.State = state.contextState;
     return ResultUtils.okFactory({
         ast: document,
         nodeIdMapCollection: contextState.nodeIdMapCollection,
@@ -639,7 +639,7 @@ export function readRecursivePrimaryExpression(
     if (state.maybeCurrentContextNode === undefined) {
         throw new CommonError.InvariantError(`maybeCurrentContextNode should be truthy`);
     }
-    const currentContextNode: ParserContext.Node = state.maybeCurrentContextNode;
+    const currentContextNode: ParseContext.Node = state.maybeCurrentContextNode;
 
     const maybeHeadParentId: number | undefined = nodeIdMapCollection.parentIdById.get(head.id);
     if (maybeHeadParentId !== undefined) {
@@ -674,7 +674,7 @@ export function readRecursivePrimaryExpression(
 
     // Update start positions for recursive primary expression context
     const recursiveTokenIndexStart: number = head.tokenRange.tokenIndexStart;
-    const mutableContext: TypeUtils.StripReadonly<ParserContext.Node> = currentContextNode;
+    const mutableContext: TypeUtils.StripReadonly<ParseContext.Node> = currentContextNode;
     // UNSAFE MARKER
     //
     // Purpose of code block:

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -12,7 +12,7 @@ import {
     NodeIdMap,
     ParseError,
     ParseOk,
-    ParserContext,
+    ParseContext,
     TriedParse,
 } from "./parser";
 import { InspectionSettings, LexSettings, ParseSettings, Settings } from "./settings";
@@ -68,7 +68,7 @@ export function tryInspection(
             maybeParseError = triedParse.error;
         }
 
-        const context: ParserContext.State = triedParse.error.context;
+        const context: ParseContext.State = triedParse.error.context;
         leafNodeIds = context.leafNodeIds;
         nodeIdMapCollection = context.nodeIdMapCollection;
     } else {


### PR DESCRIPTION
To better match coding style I've split up ParserContext into ParseContext and ParseContextUtils.