### PR TITLE
Add helper PrimitiveType helper fn to AstUtils

### DIFF
--- a/src/parser/ast/astUtils.ts
+++ b/src/parser/ast/astUtils.ts
@@ -194,6 +194,31 @@ export function maybeLiteralKindFrom(maybeTokenKind: TokenKind | undefined): Ast
     }
 }
 
+export function primitiveTypeConstantKindFrom(
+    node: Ast.AsNullablePrimitiveType | Ast.NullablePrimitiveType | Ast.PrimitiveType,
+): Ast.PrimitiveTypeConstantKind {
+    switch (node.kind) {
+        case Ast.NodeKind.AsNullablePrimitiveType:
+            switch (node.paired.kind) {
+                case Ast.NodeKind.NullablePrimitiveType:
+                    return node.paired.paired.primitiveType.constantKind;
+                case Ast.NodeKind.PrimitiveType:
+                    return node.paired.primitiveType.constantKind;
+                default:
+                    throw isNever(node.paired);
+            }
+
+        case Ast.NodeKind.NullablePrimitiveType:
+            return node.paired.primitiveType.constantKind;
+
+        case Ast.NodeKind.PrimitiveType:
+            return node.primitiveType.constantKind;
+
+        default:
+            throw isNever(node);
+    }
+}
+
 export function isPrimitiveTypeConstantKind(
     maybePrimitiveTypeConstantKind: string,
 ): maybePrimitiveTypeConstantKind is Ast.PrimitiveTypeConstantKind {

--- a/src/parser/ast/astUtils.ts
+++ b/src/parser/ast/astUtils.ts
@@ -199,14 +199,7 @@ export function primitiveTypeConstantKindFrom(
 ): Ast.PrimitiveTypeConstantKind {
     switch (node.kind) {
         case Ast.NodeKind.AsNullablePrimitiveType:
-            switch (node.paired.kind) {
-                case Ast.NodeKind.NullablePrimitiveType:
-                    return node.paired.paired.primitiveType.constantKind;
-                case Ast.NodeKind.PrimitiveType:
-                    return node.paired.primitiveType.constantKind;
-                default:
-                    throw isNever(node.paired);
-            }
+            return primitiveTypeConstantKindFrom(node.paired);
 
         case Ast.NodeKind.NullablePrimitiveType:
             return node.paired.primitiveType.constantKind;


### PR DESCRIPTION
A simple helper function to extract PrimitiveTypeConstantKind out of nodes.