### PR TITLE
Update en-us.json

### DIFF
--- a/src/localization/templates/en-US.json
+++ b/src/localization/templates/en-US.json
@@ -72,7 +72,7 @@
     "_error_parse_csvContinuation_1_danglingComma.comment": "A common parser error caused by a trailing comma, eg. '{1,2,}'. Expected to be user facing.",
 
     "error_parse_csvContinuation_2_letExpression": "A comma cannot proceed an 'in'",
-    "_error_parse_csvContinuation_2_letExpression.comment": "A common parser error caused by a trailing comma, eg. 'let x = 1, in x'. Expected to be user facing. {Locked=\"'in'\"}",
+    "_error_parse_csvContinuation_2_letExpression.comment": "A common parser error caused by a trailing comma, eg. 'let x = 1, in x'. Expected to be user facing. {Locked=\"in\"}",
 
     "error_parse_expectAnyTokenKind_1_other": "Expected to find one of the following, but a {foundTokenKind} was found instead: {expectedAnyTokenKinds}",
     "_error_parse_expectAnyTokenKind_1_other.comment": "A common parser error where expectedAnyTokenKinds is a csv collection of localized tokenKind strings and foundTokenKind is a localized tokenKind string. Expected to be user facing.",

--- a/src/localization/templates/en-US.json
+++ b/src/localization/templates/en-US.json
@@ -6,7 +6,7 @@
     "_error_common_invariantError_2_noDetails.comment": "A fatal error, such as division by 0. Not intended to be user facing.",
 
     "error_common_unknown": "An unknown error was encountered, innerError: {innerError}",
-    "_error_common_unknown.comment": "A fatal error from unknown causes. Possibly user facing. {Locked=\"innerError\"}",
+    "_error_common_unknown.comment": "A fatal error from unknown causes. The locked string refers to an attribute on an object. Possibly user facing. {Locked=\"innerError\"}",
 
     "error_lex_badLineNumber_1_greaterThanNumLines": "lineNumber is greater than or equal to the number of lines",
     "_error_lex_badLineNumber_1_greaterThanNumLines.comment": "A low level error caused by a library consumer providing a bad number range. Not intended to be user facing",
@@ -21,19 +21,19 @@
     "_error_lex_badRange_2_lineNumberEnd_greaterThanLineNumbers.comment": "A low level error caused by a library consumer providing a bad number range. Not intended to be user facing.",
 
     "error_lex_badRange_3_lineNumberStart_greaterThanLineLength": "start.lineCodeUnit is higher than line's length",
-    "_error_lex_badRange_3_lineNumberStart_greaterThanLineLength.comment": "A low level error caused by a library consumer providing a bad number range. Not intended to be user facing. {Locked=\"start.lineCodeUnit\"}",
+    "_error_lex_badRange_3_lineNumberStart_greaterThanLineLength.comment": "A low level error caused by a library consumer providing a bad number range. The locked string refers to an attribute on an object. Not intended to be user facing. {Locked=\"start.lineCodeUnit\"}",
 
     "error_lex_badRange_4_lineNumberStart_greaterThanLineNumberEnd": "start.lineNumber is larger than end.lineNumber",
-    "_error_lex_badRange_4_lineNumberStart_greaterThanLineNumberEnd.comment": "A low level error caused by a library consumer providing a bad number range. Not intended to be user facing. {Locked=\"start.lineNumber\"}",
+    "_error_lex_badRange_4_lineNumberStart_greaterThanLineNumberEnd.comment": "A low level error caused by a library consumer providing a bad number range. The locked string refers to an attribute on an object. Not intended to be user facing. {Locked=\"start.lineNumber\"}",
 
     "error_lex_badRange_5_lineNumberStart_greaterThanNumLines": "start.lineNumber is higher than State's number of lines",
-    "_error_lex_badRange_5_lineNumberStart_greaterThanNumLines.comment": "A low level error caused by a library consumer providing a bad number range. Not intended to be user facing. {Locked=\"start.lineNumber\"}",
+    "_error_lex_badRange_5_lineNumberStart_greaterThanNumLines.comment": "A low level error caused by a library consumer providing a bad number range. The locked string refers to an attribute on an object. Not intended to be user facing. {Locked=\"start.lineNumber\"}",
 
     "error_lex_badRange_6_lineNumberStart_lessThanZero": "start.lineNumber is less than 0",
-    "_error_lex_badRange_6_lineNumberStart_lessThanZero.comment": "A low level error caused by a library consumer providing a bad number range. Not intended to be user facing. {Locked=\"start.lineNumber\"}",
+    "_error_lex_badRange_6_lineNumberStart_lessThanZero.comment": "A low level error caused by a library consumer providing a bad number range. The locked string refers to an attribute on an object. Not intended to be user facing. {Locked=\"start.lineNumber\"}",
 
     "error_lex_badRange_7_sameLine_codeUnitStartGreaterThanCodeUnitEnd": "Start and end shared the same line, but start.lineCodeUnit was higher than end.lineCodeUnit",
-    "_error_lex_badRange_7_sameLine_codeUnitStartGreaterThanCodeUnitEnd.comment": "A low level error caused by a library consumer providing a bad number range. Not intended to be user facing. {Locked=\"start.lineCodeUnit\"}",
+    "_error_lex_badRange_7_sameLine_codeUnitStartGreaterThanCodeUnitEnd.comment": "A low level error caused by a library consumer providing a bad number range. The locked string refers to an attribute on an object. Not intended to be user facing. {Locked=\"start.lineCodeUnit\"}",
 
     "error_lex_badState": "The lexer encountered an error last run. Either feed the lexer more text or review previous error.",
     "_error_lex_badState.comment": "The text failed to previously lex, and will continue to fail until more text is added. Not intended to be user facing.",
@@ -72,7 +72,7 @@
     "_error_parse_csvContinuation_1_danglingComma.comment": "A common parser error caused by a trailing comma, eg. '{1,2,}'. Expected to be user facing.",
 
     "error_parse_csvContinuation_2_letExpression": "A comma cannot proceed an 'in'",
-    "_error_parse_csvContinuation_2_letExpression.comment": "A common parser error caused by a trailing comma, eg. 'let x = 1, in x'. Expected to be user facing. {Locked=\"in\"}",
+    "_error_parse_csvContinuation_2_letExpression.comment": "A common parser error caused by a trailing comma, eg. 'let x = 1, in x'. The locked string refers to a keyword. Expected to be user facing. {Locked=\"in\"}",
 
     "error_parse_expectAnyTokenKind_1_other": "Expected to find one of the following, but a {foundTokenKind} was found instead: {expectedAnyTokenKinds}",
     "_error_parse_expectAnyTokenKind_1_other.comment": "A common parser error where expectedAnyTokenKinds is a csv collection of localized tokenKind strings and foundTokenKind is a localized tokenKind string. Expected to be user facing.",


### PR DESCRIPTION
Mostly resolving two issues raised by the localization team:

1) They already quote keywords, so `'in'` was changed to `in`.
2) Adding comments when a lock is done on an object attribute.