### PR TITLE
Replace 'T & Type' with <T extends Type>

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,8 +14,6 @@
         "--colors",
         "--timeout",
         "999999",
-        "-g",
-        "WIP",
         "-r",
         "ts-node/register",
         "${workspaceFolder}/src/test/libraryTest/**/*.ts"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,8 @@
         "--colors",
         "--timeout",
         "999999",
+        "-g",
+        "WIP",
         "-r",
         "ts-node/register",
         "${workspaceFolder}/src/test/libraryTest/**/*.ts"

--- a/src/common/traversal.ts
+++ b/src/common/traversal.ts
@@ -9,18 +9,26 @@ import { ResultUtils } from "./result";
 
 export type TriedTraverse<ResultType> = Result<ResultType, CommonError.CommonError>;
 
-export type TVisitNodeFn<State, ResultType, Node, Return> = (state: State & IState<ResultType>, node: Node) => Return;
+export type TVisitNodeFn<State extends IState<ResultType>, ResultType, Node, Return> = (
+    state: State,
+    node: Node,
+) => Return;
 
-export type TVisitChildNodeFn<State, ResultType, Node, Return> = (
-    state: State & IState<ResultType>,
+export type TVisitChildNodeFn<State extends IState<ResultType>, ResultType, Node, Return> = (
+    state: State,
     parent: Node,
     node: Node,
 ) => Return;
 
-export type TEarlyExitFn<State, ResultType, Node> = TVisitNodeFn<State, ResultType, Node, boolean>;
+export type TEarlyExitFn<State extends IState<ResultType>, ResultType, Node> = TVisitNodeFn<
+    State,
+    ResultType,
+    Node,
+    boolean
+>;
 
-export type TExpandNodesFn<State, ResultType, Node, NodesById> = (
-    state: State & IState<ResultType>,
+export type TExpandNodesFn<State extends IState<ResultType>, ResultType, Node, NodesById> = (
+    state: State,
     node: Node,
     collection: NodesById,
 ) => ReadonlyArray<Node>;
@@ -36,8 +44,8 @@ export interface IState<T> {
 }
 
 // sets Node and NodesById for tryTraverse
-export function tryTraverseAst<State, ResultType>(
-    state: State & IState<ResultType>,
+export function tryTraverseAst<State extends IState<ResultType>, ResultType>(
+    state: State,
     nodeIdMapCollection: NodeIdMap.Collection,
     root: Ast.TNode,
     strategy: VisitNodeStrategy,
@@ -57,8 +65,8 @@ export function tryTraverseAst<State, ResultType>(
 }
 
 // sets Node and NodesById for tryTraverse
-export function tryTraverseXor<State, ResultType>(
-    state: State & IState<ResultType>,
+export function tryTraverseXor<State extends IState<ResultType>, ResultType>(
+    state: State,
     nodeIdMapCollection: NodeIdMap.Collection,
     root: TXorNode,
     strategy: VisitNodeStrategy,
@@ -77,8 +85,8 @@ export function tryTraverseXor<State, ResultType>(
     );
 }
 
-export function tryTraverse<State, ResultType, Node, NodesById>(
-    state: State & IState<ResultType>,
+export function tryTraverse<State extends IState<ResultType>, ResultType, Node, NodesById>(
+    state: State,
     nodesById: NodesById,
     root: Node,
     strategy: VisitNodeStrategy,
@@ -101,8 +109,8 @@ export function tryTraverse<State, ResultType, Node, NodesById>(
 }
 
 // a TExpandNodesFn usable by tryTraverseAst which visits all nodes.
-export function expectExpandAllAstChildren<State, ResultType>(
-    _state: State & IState<ResultType>,
+export function expectExpandAllAstChildren<State extends IState<ResultType>, ResultType>(
+    _state: State,
     astNode: Ast.TNode,
     nodeIdMapCollection: NodeIdMap.Collection,
 ): ReadonlyArray<Ast.TNode> {
@@ -117,8 +125,8 @@ export function expectExpandAllAstChildren<State, ResultType>(
 }
 
 // a TExpandNodesFn usable by tryTraverseXor which visits all nodes.
-export function expectExpandAllXorChildren<State, ResultType>(
-    _state: State & IState<ResultType>,
+export function expectExpandAllXorChildren<State extends IState<ResultType>, ResultType>(
+    _state: State,
     xorNode: TXorNode,
     nodeIdMapCollection: NodeIdMap.Collection,
 ): ReadonlyArray<TXorNode> {
@@ -189,8 +197,8 @@ export function maybeExpandXorParent<T>(
     return maybeParent !== undefined ? [maybeParent] : [];
 }
 
-function traverseRecursion<State, ResultType, Node, NodesById>(
-    state: State & IState<ResultType>,
+function traverseRecursion<State extends IState<ResultType>, ResultType, Node, NodesById>(
+    state: State,
     nodesById: NodesById,
     node: Node,
     strategy: VisitNodeStrategy,

--- a/src/inspection/autocomplete.ts
+++ b/src/inspection/autocomplete.ts
@@ -19,7 +19,7 @@ export const StartOfDoctumentKeywords: ReadonlyArray<Language.KeywordKind> = [
     Language.KeywordKind.Section,
 ];
 
-export function tryAutocomplete<S = IParserState>(
+export function tryAutocomplete<S extends IParserState = IParserState>(
     settings: CommonSettings,
     nodeIdMapCollection: NodeIdMap.Collection,
     maybeActiveNode: ActiveNode | undefined,
@@ -33,7 +33,7 @@ export function tryAutocomplete<S = IParserState>(
     );
 }
 
-function inspectAutocomplete<S>(
+function inspectAutocomplete<S extends IParserState = IParserState>(
     nodeIdMapCollection: NodeIdMap.Collection,
     activeNode: ActiveNode,
     maybeParseError: ParseError.ParseError<S> | undefined,

--- a/src/inspection/scope/scope.ts
+++ b/src/inspection/scope/scope.ts
@@ -287,7 +287,7 @@ function inspectSection(state: ScopeInspectionState, section: TXorNode): void {
     }
 }
 
-function inspectKeyValuePairs<T>(
+function inspectKeyValuePairs<T extends Ast.GeneralizedIdentifier | Ast.Identifier>(
     state: ScopeInspectionState,
     parentScope: ScopeItemByKey,
     keyValuePairs: ReadonlyArray<NodeIdMapIterator.KeyValuePair<T>>,

--- a/src/language/ast/ast.ts
+++ b/src/language/ast/ast.ts
@@ -572,7 +572,7 @@ export interface IArrayWrapper<T> extends INode {
     readonly elements: ReadonlyArray<T>;
 }
 
-export interface ICsvArray<T> extends IArrayWrapper<ICsv<T & TCsvType>> {}
+export interface ICsvArray<T extends TCsvType> extends IArrayWrapper<ICsv<T>> {}
 
 export interface ICsv<T> extends INode {
     readonly kind: NodeKind.Csv;
@@ -580,8 +580,8 @@ export interface ICsv<T> extends INode {
     readonly maybeCommaConstant: IConstant<MiscConstantKind.Comma> | undefined;
 }
 
-export interface IKeyValuePair<Kind, Key, Value> extends INode {
-    readonly kind: Kind & TKeyValuePairNodeKind;
+export interface IKeyValuePair<Kind extends TKeyValuePairNodeKind, Key, Value> extends INode {
+    readonly kind: Kind;
     readonly key: Key;
     readonly equalConstant: IConstant<MiscConstantKind.Equal>;
     readonly value: Value;
@@ -589,26 +589,32 @@ export interface IKeyValuePair<Kind, Key, Value> extends INode {
 
 // A [Constant, T] tuple
 // eg. EachExpression is a `each` Constant paired with a TExpression
-export interface IPairedConstant<Kind, ConstantKind, Paired> extends INode {
-    readonly kind: Kind & TPairedConstantNodeKind;
+export interface IPairedConstant<Kind extends TPairedConstantNodeKind, ConstantKind extends TConstantKind, Paired>
+    extends INode {
+    readonly kind: Kind;
     readonly constant: IConstant<ConstantKind>;
     readonly paired: Paired;
 }
 
-export interface IWrapped<Kind, Open, Content, Close> extends INode {
-    readonly kind: Kind & TWrappedNodeKind;
+export interface IWrapped<
+    Kind extends TWrappedNodeKind,
+    Open extends WrapperConstantKind,
+    Content,
+    Close extends WrapperConstantKind
+> extends INode {
+    readonly kind: Kind;
     readonly openWrapperConstant: IConstant<Open>;
     readonly content: Content;
     readonly closeWrapperConstant: IConstant<Close>;
 }
 
-export interface IBraceWrapped<Kind, Content>
+export interface IBraceWrapped<Kind extends TWrappedNodeKind, Content>
     extends IWrapped<Kind, WrapperConstantKind.LeftBrace, Content, WrapperConstantKind.RightBrace> {}
 
-export interface IBracketWrapped<Kind, Content>
+export interface IBracketWrapped<Kind extends TWrappedNodeKind, Content>
     extends IWrapped<Kind, WrapperConstantKind.LeftBracket, Content, WrapperConstantKind.RightBracket> {}
 
-export interface IParenthesisWrapped<Kind, Content>
+export interface IParenthesisWrapped<Kind extends TWrappedNodeKind, Content>
     extends IWrapped<Kind, WrapperConstantKind.LeftParenthesis, Content, WrapperConstantKind.RightParenthesis> {}
 
 // --------------------------------------
@@ -640,8 +646,13 @@ export type TBinOpExpressionSubtype =
     | IBinOpExpression<NodeKind.AsExpression, TNullablePrimitiveType, KeywordConstantKind.As, TNullablePrimitiveType>
     | IBinOpExpression<NodeKind.IsExpression, TNullablePrimitiveType, KeywordConstantKind.Is, TNullablePrimitiveType>;
 
-export interface IBinOpExpression<Kind, Left, OperatorKind, Right> extends INode {
-    readonly kind: Kind & TBinOpExpressionNodeKind;
+export interface IBinOpExpression<
+    Kind extends TBinOpExpressionNodeKind,
+    Left,
+    OperatorKind extends TBinOpExpressionOperator,
+    Right
+> extends INode {
+    readonly kind: Kind;
     readonly left: Left;
     readonly operatorConstant: IConstant<OperatorKind>;
     readonly right:
@@ -708,15 +719,15 @@ export interface IdentifierPairedExpression
 
 export type TParameterType = AsType | AsNullablePrimitiveType | undefined;
 
-export interface IParameterList<T>
-    extends IParenthesisWrapped<NodeKind.ParameterList, ICsvArray<IParameter<T & TParameterType>>> {}
+export interface IParameterList<T extends TParameterType>
+    extends IParenthesisWrapped<NodeKind.ParameterList, ICsvArray<IParameter<T>>> {}
 
-export interface IParameter<T> extends INode {
+export interface IParameter<T extends TParameterType> extends INode {
     readonly kind: NodeKind.Parameter;
     readonly isLeaf: false;
     readonly maybeOptionalConstant: IConstant<IdentifierConstantKind.Optional> | undefined;
     readonly name: Identifier;
-    readonly maybeParameterType: T & TParameterType;
+    readonly maybeParameterType: T;
 }
 
 export interface AsNullablePrimitiveType
@@ -740,10 +751,10 @@ export type TConstantKind =
     | UnaryOperatorKind
     | WrapperConstantKind;
 
-export interface IConstant<C> extends INode {
+export interface IConstant<ConstantKind extends TConstantKind> extends INode {
     readonly kind: NodeKind.Constant;
     readonly isLeaf: true;
-    readonly constantKind: C & TConstantKind;
+    readonly constantKind: ConstantKind;
 }
 
 export type TConstant = IConstant<TConstantKind>;

--- a/src/lexer/lexerSnapshot.ts
+++ b/src/lexer/lexerSnapshot.ts
@@ -302,10 +302,10 @@ function readTextLiteral(
     }
 }
 
-function collectWhileContent<KindVariant>(
+function collectWhileContent<KindVariant extends Language.LineTokenKind>(
     flatTokens: ReadonlyArray<FlatLineToken>,
     tokenStart: FlatLineToken,
-    contentKind: KindVariant & Language.LineTokenKind,
+    contentKind: KindVariant,
 ): FlatLineCollection {
     const collectedTokens: FlatLineToken[] = [];
     const numTokens: number = flatTokens.length;

--- a/src/parser/IParser.ts
+++ b/src/parser/IParser.ts
@@ -5,7 +5,7 @@ import { IParserState, NodeIdMap, ParseError } from ".";
 import { Result } from "../common";
 import { Ast } from "../language";
 
-export type TriedParse<S = IParserState> = Result<ParseOk<S>, ParseError.TParseError<S>>;
+export type TriedParse<S extends IParserState = IParserState> = Result<ParseOk<S>, ParseError.TParseError<S>>;
 
 export const enum ParenthesisDisambiguation {
     FunctionExpression = "FunctionExpression",
@@ -18,279 +18,170 @@ export const enum BracketDisambiguation {
     Record = "Record",
 }
 
-export interface ParseOk<S = IParserState> {
+export interface ParseOk<S extends IParserState = IParserState> {
     readonly ast: Ast.TDocument;
     readonly nodeIdMapCollection: NodeIdMap.Collection;
     readonly leafNodeIds: ReadonlyArray<number>;
-    readonly state: S & IParserState;
+    readonly state: S;
 }
 
-export interface IParser<State = IParserState> {
+export interface IParser<State extends IParserState = IParserState> {
     // 12.1.6 Identifiers
-    readonly readIdentifier: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.Identifier;
-    readonly readGeneralizedIdentifier: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.GeneralizedIdentifier;
-    readonly readKeyword: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.IdentifierExpression;
+    readonly readIdentifier: (state: State, parser: IParser<State>) => Ast.Identifier;
+    readonly readGeneralizedIdentifier: (state: State, parser: IParser<State>) => Ast.GeneralizedIdentifier;
+    readonly readKeyword: (state: State, parser: IParser<State>) => Ast.IdentifierExpression;
 
     // 12.2.1 Documents
-    readonly readDocument: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => TriedParse<State & IParserState>;
+    readonly readDocument: (state: State, parser: IParser<State>) => TriedParse<State>;
 
     // 12.2.2 Section Documents
-    readonly readSectionDocument: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.Section;
-    readonly readSectionMembers: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.IArrayWrapper<Ast.SectionMember>;
-    readonly readSectionMember: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.SectionMember;
+    readonly readSectionDocument: (state: State, parser: IParser<State>) => Ast.Section;
+    readonly readSectionMembers: (state: State, parser: IParser<State>) => Ast.IArrayWrapper<Ast.SectionMember>;
+    readonly readSectionMember: (state: State, parser: IParser<State>) => Ast.SectionMember;
 
     // 12.2.3.1 Expressions
-    readonly readExpression: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.TExpression;
+    readonly readExpression: (state: State, parser: IParser<State>) => Ast.TExpression;
 
     // 12.2.3.2 Logical expressions
-    readonly readLogicalExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.TLogicalExpression;
+    readonly readLogicalExpression: (state: State, parser: IParser<State>) => Ast.TLogicalExpression;
 
     // 12.2.3.3 Is expression
-    readonly readIsExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.TIsExpression;
-    readonly readNullablePrimitiveType: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.TNullablePrimitiveType;
+    readonly readIsExpression: (state: State, parser: IParser<State>) => Ast.TIsExpression;
+    readonly readNullablePrimitiveType: (state: State, parser: IParser<State>) => Ast.TNullablePrimitiveType;
 
     // 12.2.3.4 As expression
-    readonly readAsExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.TAsExpression;
+    readonly readAsExpression: (state: State, parser: IParser<State>) => Ast.TAsExpression;
 
     // 12.2.3.5 Equality expression
-    readonly readEqualityExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.TEqualityExpression;
+    readonly readEqualityExpression: (state: State, parser: IParser<State>) => Ast.TEqualityExpression;
 
     // 12.2.3.6 Relational expression
-    readonly readRelationalExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.TRelationalExpression;
+    readonly readRelationalExpression: (state: State, parser: IParser<State>) => Ast.TRelationalExpression;
 
     // 12.2.3.7 Arithmetic expressions
-    readonly readArithmeticExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.TArithmeticExpression;
+    readonly readArithmeticExpression: (state: State, parser: IParser<State>) => Ast.TArithmeticExpression;
 
     // 12.2.3.8 Metadata expression
-    readonly readMetadataExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.TMetadataExpression;
+    readonly readMetadataExpression: (state: State, parser: IParser<State>) => Ast.TMetadataExpression;
 
     // 12.2.3.9 Unary expression
-    readonly readUnaryExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.TUnaryExpression;
+    readonly readUnaryExpression: (state: State, parser: IParser<State>) => Ast.TUnaryExpression;
 
     // 12.2.3.10 Primary expression
-    readonly readPrimaryExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.TPrimaryExpression;
+    readonly readPrimaryExpression: (state: State, parser: IParser<State>) => Ast.TPrimaryExpression;
     readonly readRecursivePrimaryExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
+        state: State,
+        parser: IParser<State>,
         head: Ast.TPrimaryExpression,
     ) => Ast.RecursivePrimaryExpression;
 
     // 12.2.3.11 Literal expression
-    readonly readLiteralExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.LiteralExpression;
+    readonly readLiteralExpression: (state: State, parser: IParser<State>) => Ast.LiteralExpression;
 
     // 12.2.3.12 Identifier expression
-    readonly readIdentifierExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.IdentifierExpression;
+    readonly readIdentifierExpression: (state: State, parser: IParser<State>) => Ast.IdentifierExpression;
 
     // 12.2.3.14 Parenthesized expression
-    readonly readParenthesizedExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.ParenthesizedExpression;
+    readonly readParenthesizedExpression: (state: State, parser: IParser<State>) => Ast.ParenthesizedExpression;
 
     // 12.2.3.15 Not-implemented expression
-    readonly readNotImplementedExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.NotImplementedExpression;
+    readonly readNotImplementedExpression: (state: State, parser: IParser<State>) => Ast.NotImplementedExpression;
 
     // 12.2.3.16 Invoke expression
-    readonly readInvokeExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.InvokeExpression;
+    readonly readInvokeExpression: (state: State, parser: IParser<State>) => Ast.InvokeExpression;
 
     // 12.2.3.17 List expression
-    readonly readListExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.ListExpression;
-    readonly readListItem: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.TListItem;
+    readonly readListExpression: (state: State, parser: IParser<State>) => Ast.ListExpression;
+    readonly readListItem: (state: State, parser: IParser<State>) => Ast.TListItem;
 
     // 12.2.3.18 Record expression
-    readonly readRecordExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.RecordExpression;
+    readonly readRecordExpression: (state: State, parser: IParser<State>) => Ast.RecordExpression;
 
     // 12.2.3.19 Item access expression
-    readonly readItemAccessExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.ItemAccessExpression;
+    readonly readItemAccessExpression: (state: State, parser: IParser<State>) => Ast.ItemAccessExpression;
 
     // 12.2.3.20 Field access expression
-    readonly readFieldSelection: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.FieldSelector;
-    readonly readFieldProjection: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.FieldProjection;
-    readonly readFieldSelector: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-        allowOptional: boolean,
-    ) => Ast.FieldSelector;
+    readonly readFieldSelection: (state: State, parser: IParser<State>) => Ast.FieldSelector;
+    readonly readFieldProjection: (state: State, parser: IParser<State>) => Ast.FieldProjection;
+    readonly readFieldSelector: (state: State, parser: IParser<State>, allowOptional: boolean) => Ast.FieldSelector;
 
     // 12.2.3.21 Function expression
-    readonly readFunctionExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.FunctionExpression;
+    readonly readFunctionExpression: (state: State, parser: IParser<State>) => Ast.FunctionExpression;
     readonly readParameterList: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
+        state: State,
+        parser: IParser<State>,
     ) => Ast.IParameterList<Ast.AsNullablePrimitiveType | undefined>;
-    readonly readAsType: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.AsType;
+    readonly readAsType: (state: State, parser: IParser<State>) => Ast.AsType;
 
     // 12.2.3.22 Each expression
-    readonly readEachExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.EachExpression;
+    readonly readEachExpression: (state: State, parser: IParser<State>) => Ast.EachExpression;
 
     // 12.2.3.23 Let expression
-    readonly readLetExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.LetExpression;
+    readonly readLetExpression: (state: State, parser: IParser<State>) => Ast.LetExpression;
 
     // 12.2.3.24 If expression
-    readonly readIfExpression: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.IfExpression;
+    readonly readIfExpression: (state: State, parser: IParser<State>) => Ast.IfExpression;
 
     // 12.2.3.25 Type expression
-    readonly readTypeExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.TTypeExpression;
-    readonly readType: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.TType;
-    readonly readPrimaryType: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.TPrimaryType;
-    readonly readRecordType: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.RecordType;
-    readonly readTableType: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.TableType;
+    readonly readTypeExpression: (state: State, parser: IParser<State>) => Ast.TTypeExpression;
+    readonly readType: (state: State, parser: IParser<State>) => Ast.TType;
+    readonly readPrimaryType: (state: State, parser: IParser<State>) => Ast.TPrimaryType;
+    readonly readRecordType: (state: State, parser: IParser<State>) => Ast.RecordType;
+    readonly readTableType: (state: State, parser: IParser<State>) => Ast.TableType;
     readonly readFieldSpecificationList: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
+        state: State,
+        parser: IParser<State>,
         allowOpenMarker: boolean,
         testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
     ) => Ast.FieldSpecificationList;
-    readonly readListType: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.ListType;
-    readonly readFunctionType: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.FunctionType;
-    readonly readParameterSpecificationList: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.IParameterList<Ast.AsType>;
-    readonly readNullableType: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.NullableType;
+    readonly readListType: (state: State, parser: IParser<State>) => Ast.ListType;
+    readonly readFunctionType: (state: State, parser: IParser<State>) => Ast.FunctionType;
+    readonly readParameterSpecificationList: (state: State, parser: IParser<State>) => Ast.IParameterList<Ast.AsType>;
+    readonly readNullableType: (state: State, parser: IParser<State>) => Ast.NullableType;
 
     // 12.2.3.26 Error raising expression
-    readonly readErrorRaisingExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.ErrorRaisingExpression;
+    readonly readErrorRaisingExpression: (state: State, parser: IParser<State>) => Ast.ErrorRaisingExpression;
 
     // 12.2.3.27 Error handling expression
-    readonly readErrorHandlingExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.ErrorHandlingExpression;
+    readonly readErrorHandlingExpression: (state: State, parser: IParser<State>) => Ast.ErrorHandlingExpression;
 
     // 12.2.4 Literal Attributes
-    readonly readRecordLiteral: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.RecordLiteral;
+    readonly readRecordLiteral: (state: State, parser: IParser<State>) => Ast.RecordLiteral;
     readonly readFieldNamePairedAnyLiterals: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
+        state: State,
+        parser: IParser<State>,
         onePairRequired: boolean,
         testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
     ) => Ast.ICsvArray<Ast.GeneralizedIdentifierPairedAnyLiteral>;
-    readonly readListLiteral: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.ListLiteral;
-    readonly readAnyLiteral: (state: State & IParserState, parser: IParser<State & IParserState>) => Ast.TAnyLiteral;
-    readonly readPrimitiveType: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.PrimitiveType;
+    readonly readListLiteral: (state: State, parser: IParser<State>) => Ast.ListLiteral;
+    readonly readAnyLiteral: (state: State, parser: IParser<State>) => Ast.TAnyLiteral;
+    readonly readPrimitiveType: (state: State, parser: IParser<State>) => Ast.PrimitiveType;
 
     // Disambiguation
     readonly disambiguateBracket: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
+        state: State,
+        parser: IParser<State>,
     ) => Result<BracketDisambiguation, ParseError.UnterminatedBracketError>;
     readonly disambiguateParenthesis: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
+        state: State,
+        parser: IParser<State>,
     ) => Result<ParenthesisDisambiguation, ParseError.UnterminatedParenthesesError>;
 
     readonly readIdentifierPairedExpressions: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
+        state: State,
+        parser: IParser<State>,
         onePairRequired: boolean,
         testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
     ) => Ast.ICsvArray<Ast.IdentifierPairedExpression>;
-    readonly readIdentifierPairedExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
-    ) => Ast.IdentifierPairedExpression;
+    readonly readIdentifierPairedExpression: (state: State, parser: IParser<State>) => Ast.IdentifierPairedExpression;
     readonly readGeneralizedIdentifierPairedExpressions: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
+        state: State,
+        parser: IParser<State>,
         onePairRequired: boolean,
         testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
     ) => Ast.ICsvArray<Ast.GeneralizedIdentifierPairedExpression>;
     readonly readGeneralizedIdentifierPairedExpression: (
-        state: State & IParserState,
-        parser: IParser<State & IParserState>,
+        state: State,
+        parser: IParser<State>,
     ) => Ast.GeneralizedIdentifierPairedExpression;
 }

--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -22,8 +22,8 @@ export interface FastStateBackup {
 
 // If you have a custom parser + parser state, then you'll have to create your own newState function.
 // See `benchmark.ts` for an example.
-export function newState<S = IParserState>(
-    settings: ParseSettings<S & IParserState>,
+export function newState<S extends IParserState = IParserState>(
+    settings: ParseSettings<S>,
     lexerSnapshot: LexerSnapshot,
 ): IParserState {
     const maybeCurrentToken: Language.Token | undefined = lexerSnapshot.tokens[0];

--- a/src/parser/error.ts
+++ b/src/parser/error.ts
@@ -6,7 +6,7 @@ import { CommonError, StringUtils } from "../common";
 import { ILocalizationTemplates, Localization } from "../localization";
 import { IParserState } from "./IParserState";
 
-export type TParseError<S = IParserState> = CommonError.CommonError | ParseError<S>;
+export type TParseError<S extends IParserState = IParserState> = CommonError.CommonError | ParseError<S>;
 
 export type TInnerParseError =
     | ExpectedAnyTokenKindError
@@ -29,8 +29,8 @@ export const enum UnterminatedKind {
     Parenthesis = "Parenthesis",
 }
 
-export class ParseError<S = IParserState> extends Error {
-    constructor(readonly innerError: TInnerParseError, readonly state: S & IParserState) {
+export class ParseError<S extends IParserState = IParserState> extends Error {
+    constructor(readonly innerError: TInnerParseError, readonly state: S) {
         super(innerError.message);
     }
 }
@@ -126,7 +126,7 @@ export interface TokenWithColumnNumber {
     readonly columnNumber: number;
 }
 
-export function isTParseError<S = IParserState>(x: any): x is TParseError<S> {
+export function isTParseError<S extends IParserState = IParserState>(x: any): x is TParseError<S> {
     return x instanceof ParseError || x instanceof CommonError.CommonError;
 }
 

--- a/src/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -5,9 +5,9 @@ import { NodeIdMap, NodeIdMapUtils, TXorNode, XorNodeKind } from ".";
 import { CommonError, isNever, MapUtils } from "../../common";
 import { Ast } from "../../language";
 
-export interface KeyValuePair<T> {
+export interface KeyValuePair<T extends Ast.GeneralizedIdentifier | Ast.Identifier> {
     readonly source: TXorNode;
-    readonly key: T & (Ast.GeneralizedIdentifier | Ast.Identifier);
+    readonly key: T;
     readonly keyLiteral: string;
     readonly maybeValue: undefined | TXorNode;
 }
@@ -215,11 +215,11 @@ export function sectionMemberKeyValuePairs(
     return partial;
 }
 
-export function keyValuePairs<T>(
+export function keyValuePairs<T extends Ast.GeneralizedIdentifier | Ast.Identifier>(
     nodeIdMapCollection: NodeIdMap.Collection,
     arrayWrapper: TXorNode,
 ): ReadonlyArray<KeyValuePair<T>> {
-    const partial: KeyValuePair<T & (Ast.GeneralizedIdentifier | Ast.Identifier)>[] = [];
+    const partial: KeyValuePair<T>[] = [];
     for (const keyValuePair of arrayWrapperCsvXorNodes(nodeIdMapCollection, arrayWrapper)) {
         const maybeKey: undefined | Ast.TNode = NodeIdMapUtils.maybeAstChildByAttributeIndex(
             nodeIdMapCollection,
@@ -230,8 +230,7 @@ export function keyValuePairs<T>(
         if (maybeKey === undefined) {
             break;
         }
-        const key: T & (Ast.GeneralizedIdentifier | Ast.Identifier) = maybeKey as T &
-            (Ast.GeneralizedIdentifier | Ast.Identifier);
+        const key: T = maybeKey as T & (Ast.GeneralizedIdentifier | Ast.Identifier);
 
         partial.push({
             source: keyValuePair,

--- a/src/parser/nodeIdMap/xorNode.ts
+++ b/src/parser/nodeIdMap/xorNode.ts
@@ -11,8 +11,8 @@ export const enum XorNodeKind {
 
 export type TXorNode = IXorNode<XorNodeKind.Ast, Ast.TNode> | IXorNode<XorNodeKind.Context, ParseContext.Node>;
 
-export interface IXorNode<Kind, T> {
-    readonly kind: Kind & XorNodeKind;
+export interface IXorNode<Kind extends XorNodeKind, T> {
+    readonly kind: Kind;
     readonly node: T;
 }
 

--- a/src/parser/parsers/combinatorialParser.ts
+++ b/src/parser/parsers/combinatorialParser.ts
@@ -57,9 +57,9 @@ export let CombinatorialParser: IParser<IParserState> = {
     readUnaryExpression,
 };
 
-function readBinOpExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+function readBinOpExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
     nodeKind: Ast.NodeKind,
 ): Ast.TBinOpExpression | Ast.TUnaryExpression | Ast.TNullablePrimitiveType {
     IParserStateUtils.startContext(state, nodeKind);

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -34,9 +34,9 @@ const GeneralizedIdentifierTerminatorTokenKinds: ReadonlyArray<Language.TokenKin
 // ---------- 12.1.6 Identifiers ----------
 // ----------------------------------------
 
-export function readIdentifier<S = IParserState>(
+export function readIdentifier<S extends IParserState = IParserState>(
     state: IParserState,
-    _parser: IParser<S & IParserState>,
+    _parser: IParser<S>,
 ): Ast.Identifier {
     const nodeKind: Ast.NodeKind.Identifier = Ast.NodeKind.Identifier;
     IParserStateUtils.startContext(state, nodeKind);
@@ -54,9 +54,9 @@ export function readIdentifier<S = IParserState>(
 }
 
 // This behavior matches the C# parser and not the language specification.
-export function readGeneralizedIdentifier<S = IParserState>(
-    state: S & IParserState,
-    _parser: IParser<S & IParserState>,
+export function readGeneralizedIdentifier<S extends IParserState = IParserState>(
+    state: S,
+    _parser: IParser<S>,
 ): Ast.GeneralizedIdentifier {
     const nodeKind: Ast.NodeKind.GeneralizedIdentifier = Ast.NodeKind.GeneralizedIdentifier;
     IParserStateUtils.startContext(state, nodeKind);
@@ -97,9 +97,9 @@ export function readGeneralizedIdentifier<S = IParserState>(
     return astNode;
 }
 
-export function readKeyword<S = IParserState>(
+export function readKeyword<S extends IParserState = IParserState>(
     state: IParserState,
-    _parser: IParser<S & IParserState>,
+    _parser: IParser<S>,
 ): Ast.IdentifierExpression {
     const identifierExpressionNodeKind: Ast.NodeKind.IdentifierExpression = Ast.NodeKind.IdentifierExpression;
     IParserStateUtils.startContext(state, identifierExpressionNodeKind);
@@ -134,10 +134,7 @@ export function readKeyword<S = IParserState>(
 // ---------- 12.2.1 Documents ----------
 // --------------------------------------
 
-export function readDocument<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
-): TriedParse<S> {
+export function readDocument<S extends IParserState = IParserState>(state: S, parser: IParser<S>): TriedParse<S> {
     let triedReadDocument: Result<Ast.TDocument, Error>;
 
     // Try parsing as an Expression document first.
@@ -219,10 +216,7 @@ export function readDocument<S = IParserState>(
 // ---------- 12.2.2 Section Documents ----------
 // ----------------------------------------------
 
-export function readSectionDocument<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
-): Ast.Section {
+export function readSectionDocument<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.Section {
     const nodeKind: Ast.NodeKind.Section = Ast.NodeKind.Section;
     IParserStateUtils.startContext(state, nodeKind);
 
@@ -261,9 +255,9 @@ export function readSectionDocument<S = IParserState>(
     return astNode;
 }
 
-export function readSectionMembers<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readSectionMembers<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.IArrayWrapper<Ast.SectionMember> {
     const nodeKind: Ast.NodeKind.ArrayWrapper = Ast.NodeKind.ArrayWrapper;
     IParserStateUtils.startContext(state, nodeKind);
@@ -284,9 +278,9 @@ export function readSectionMembers<S = IParserState>(
     return astNode;
 }
 
-export function readSectionMember<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readSectionMember<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.SectionMember {
     const nodeKind: Ast.NodeKind.SectionMember = Ast.NodeKind.SectionMember;
     IParserStateUtils.startContext(state, nodeKind);
@@ -321,10 +315,7 @@ export function readSectionMember<S = IParserState>(
 // ---------- 12.2.3.1 Expressions ----------
 // ------------------------------------------
 
-export function readExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
-): Ast.TExpression {
+export function readExpression<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TExpression {
     switch (state.maybeCurrentTokenKind) {
         case Language.TokenKind.KeywordEach:
             return parser.readEachExpression(state, parser);
@@ -371,9 +362,9 @@ export function readExpression<S = IParserState>(
 // ---------- 12.2.3.2 Logical expressions ----------
 // --------------------------------------------------
 
-export function readLogicalExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readLogicalExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.TLogicalExpression {
     return recursiveReadBinOpExpression<
         S,
@@ -394,9 +385,9 @@ export function readLogicalExpression<S = IParserState>(
 // ---------- 12.2.3.3 Is expression ----------
 // --------------------------------------------
 
-export function readIsExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readIsExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.TIsExpression {
     return recursiveReadBinOpExpression<
         S,
@@ -415,9 +406,9 @@ export function readIsExpression<S = IParserState>(
 }
 
 // sub-item of 12.2.3.3 Is expression
-export function readNullablePrimitiveType<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readNullablePrimitiveType<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.TNullablePrimitiveType {
     if (IParserStateUtils.isOnConstantKind(state, Ast.IdentifierConstantKind.Nullable)) {
         return readPairedConstant(
@@ -435,9 +426,9 @@ export function readNullablePrimitiveType<S = IParserState>(
 // ---------- 12.2.3.4 As expression ----------
 // --------------------------------------------
 
-export function readAsExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readAsExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.TAsExpression {
     return recursiveReadBinOpExpression<
         S,
@@ -459,9 +450,9 @@ export function readAsExpression<S = IParserState>(
 // ---------- 12.2.3.5 Equality expression ----------
 // --------------------------------------------------
 
-export function readEqualityExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readEqualityExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.TEqualityExpression {
     return recursiveReadBinOpExpression<
         S,
@@ -482,9 +473,9 @@ export function readEqualityExpression<S = IParserState>(
 // ---------- 12.2.3.6 Relational expression ----------
 // ----------------------------------------------------
 
-export function readRelationalExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readRelationalExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.TRelationalExpression {
     return recursiveReadBinOpExpression<
         S,
@@ -505,9 +496,9 @@ export function readRelationalExpression<S = IParserState>(
 // ---------- 12.2.3.7 Arithmetic expressions ----------
 // -----------------------------------------------------
 
-export function readArithmeticExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readArithmeticExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.TArithmeticExpression {
     return recursiveReadBinOpExpression<
         S,
@@ -528,9 +519,9 @@ export function readArithmeticExpression<S = IParserState>(
 // ---------- 12.2.3.8 Metadata expression ----------
 // --------------------------------------------------
 
-export function readMetadataExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readMetadataExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.TMetadataExpression {
     const nodeKind: Ast.NodeKind.MetadataExpression = Ast.NodeKind.MetadataExpression;
     IParserStateUtils.startContext(state, nodeKind);
@@ -567,9 +558,9 @@ export function readMetadataExpression<S = IParserState>(
 // ---------- 12.2.3.9 Unary expression ----------
 // -----------------------------------------------
 
-export function readUnaryExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readUnaryExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.TUnaryExpression {
     let maybeOperator: Ast.UnaryOperatorKind | undefined = AstUtils.maybeUnaryOperatorKindFrom(
         state.maybeCurrentTokenKind,
@@ -616,9 +607,9 @@ export function readUnaryExpression<S = IParserState>(
 // ---------- 12.2.3.10 Primary expression ----------
 // --------------------------------------------------
 
-export function readPrimaryExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readPrimaryExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.TPrimaryExpression {
     let primaryExpression: Ast.TPrimaryExpression | undefined;
     const maybeCurrentTokenKind: Language.TokenKind | undefined = state.maybeCurrentTokenKind;
@@ -673,9 +664,9 @@ export function readPrimaryExpression<S = IParserState>(
     }
 }
 
-export function readRecursivePrimaryExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readRecursivePrimaryExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
     head: Ast.TPrimaryExpression,
 ): Ast.RecursivePrimaryExpression {
     const nodeKind: Ast.NodeKind.RecursivePrimaryExpression = Ast.NodeKind.RecursivePrimaryExpression;
@@ -799,9 +790,9 @@ export function readRecursivePrimaryExpression<S = IParserState>(
 // ---------- 12.2.3.11 Literal expression ----------
 // --------------------------------------------------
 
-export function readLiteralExpression<S = IParserState>(
+export function readLiteralExpression<S extends IParserState = IParserState>(
     state: IParserState,
-    _parser: IParser<S & IParserState>,
+    _parser: IParser<S>,
 ): Ast.LiteralExpression {
     const nodeKind: Ast.NodeKind.LiteralExpression = Ast.NodeKind.LiteralExpression;
     IParserStateUtils.startContext(state, nodeKind);
@@ -852,9 +843,9 @@ export function readLiteralExpression<S = IParserState>(
 // ---------- 12.2.3.16 12.2.3.12 Identifier expression ----------
 // ---------------------------------------------------------------
 
-export function readIdentifierExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readIdentifierExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.IdentifierExpression {
     const nodeKind: Ast.NodeKind.IdentifierExpression = Ast.NodeKind.IdentifierExpression;
     IParserStateUtils.startContext(state, nodeKind);
@@ -881,9 +872,9 @@ export function readIdentifierExpression<S = IParserState>(
 // ---------- 12.2.3.14 Parenthesized expression ----------
 // --------------------------------------------------------
 
-export function readParenthesizedExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readParenthesizedExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.ParenthesizedExpression {
     return readWrapped(
         state,
@@ -905,9 +896,9 @@ export function readParenthesizedExpression<S = IParserState>(
 // ---------- 12.2.3.15 Not-implemented expression ----------
 // ----------------------------------------------------------
 
-export function readNotImplementedExpression<S = IParserState>(
-    state: S & IParserState,
-    _parser: IParser<S & IParserState>,
+export function readNotImplementedExpression<S extends IParserState = IParserState>(
+    state: S,
+    _parser: IParser<S>,
 ): Ast.NotImplementedExpression {
     const nodeKind: Ast.NodeKind.NotImplementedExpression = Ast.NodeKind.NotImplementedExpression;
     IParserStateUtils.startContext(state, nodeKind);
@@ -932,9 +923,9 @@ export function readNotImplementedExpression<S = IParserState>(
 // ---------- 12.2.3.16 Invoke expression ----------
 // -------------------------------------------------
 
-export function readInvokeExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readInvokeExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.InvokeExpression {
     const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(
         state,
@@ -968,9 +959,9 @@ export function readInvokeExpression<S = IParserState>(
 // ---------- 12.2.3.17 List expression ----------
 // -----------------------------------------------
 
-export function readListExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readListExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.ListExpression {
     const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.RightBrace);
     return readWrapped(
@@ -989,10 +980,7 @@ export function readListExpression<S = IParserState>(
     );
 }
 
-export function readListItem<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
-): Ast.TListItem {
+export function readListItem<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TListItem {
     const nodeKind: Ast.NodeKind.RangeExpression = Ast.NodeKind.RangeExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
@@ -1025,9 +1013,9 @@ export function readListItem<S = IParserState>(
 // ---------- 12.2.3.18 Record expression ----------
 // -------------------------------------------------
 
-export function readRecordExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readRecordExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.RecordExpression {
     const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.RightBracket);
     return readWrapped(
@@ -1050,9 +1038,9 @@ export function readRecordExpression<S = IParserState>(
 // ---------- 12.2.3.19 Item access expression ----------
 // ------------------------------------------------------
 
-export function readItemAccessExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readItemAccessExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.ItemAccessExpression {
     return readWrapped(
         state,
@@ -1068,16 +1056,16 @@ export function readItemAccessExpression<S = IParserState>(
 // ---------- 12.2.3.20 Field access expression ----------
 // -------------------------------------------------------
 
-export function readFieldSelection<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readFieldSelection<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.FieldSelector {
     return readFieldSelector(state, parser, true);
 }
 
-export function readFieldProjection<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readFieldProjection<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.FieldProjection {
     return readWrapped(
         state,
@@ -1095,9 +1083,9 @@ export function readFieldProjection<S = IParserState>(
     );
 }
 
-export function readFieldSelector<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readFieldSelector<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
     allowOptional: boolean,
 ): Ast.FieldSelector {
     return readWrapped(
@@ -1114,9 +1102,9 @@ export function readFieldSelector<S = IParserState>(
 // ---------- 12.2.3.21 Function expression ----------
 // ---------------------------------------------------
 
-export function readFunctionExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readFunctionExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.FunctionExpression {
     const nodeKind: Ast.NodeKind.FunctionExpression = Ast.NodeKind.FunctionExpression;
     IParserStateUtils.startContext(state, nodeKind);
@@ -1149,16 +1137,16 @@ export function readFunctionExpression<S = IParserState>(
     return astNode;
 }
 
-export function readParameterList<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readParameterList<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.IParameterList<Ast.AsNullablePrimitiveType | undefined> {
     return genericReadParameterList(state, parser, () => maybeReadAsNullablePrimitiveType(state, parser));
 }
 
-function maybeReadAsNullablePrimitiveType<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+function maybeReadAsNullablePrimitiveType<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.AsNullablePrimitiveType | undefined {
     return maybeReadPairedConstant(
         state,
@@ -1169,7 +1157,7 @@ function maybeReadAsNullablePrimitiveType<S = IParserState>(
     );
 }
 
-export function readAsType<S = IParserState>(state: S & IParserState, parser: IParser<S & IParserState>): Ast.AsType {
+export function readAsType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.AsType {
     return readPairedConstant(
         state,
         Ast.NodeKind.AsType,
@@ -1182,9 +1170,9 @@ export function readAsType<S = IParserState>(state: S & IParserState, parser: IP
 // ---------- 12.2.3.22 Each expression ----------
 // -----------------------------------------------
 
-export function readEachExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readEachExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.EachExpression {
     return readPairedConstant(
         state,
@@ -1198,9 +1186,9 @@ export function readEachExpression<S = IParserState>(
 // ---------- 12.2.3.23 Let expression ----------
 // ----------------------------------------------
 
-export function readLetExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readLetExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.LetExpression {
     const nodeKind: Ast.NodeKind.LetExpression = Ast.NodeKind.LetExpression;
     IParserStateUtils.startContext(state, nodeKind);
@@ -1240,9 +1228,9 @@ export function readLetExpression<S = IParserState>(
 // ---------- 12.2.3.24 If expression ----------
 // ---------------------------------------------
 
-export function readIfExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readIfExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.IfExpression {
     const nodeKind: Ast.NodeKind.IfExpression = Ast.NodeKind.IfExpression;
     IParserStateUtils.startContext(state, nodeKind);
@@ -1287,9 +1275,9 @@ export function readIfExpression<S = IParserState>(
 // ---------- 12.2.3.25 Type expression ----------
 // -----------------------------------------------
 
-export function readTypeExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readTypeExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.TTypeExpression {
     if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.KeywordType)) {
         return readPairedConstant(
@@ -1303,7 +1291,7 @@ export function readTypeExpression<S = IParserState>(
     }
 }
 
-export function readType<S = IParserState>(state: S & IParserState, parser: IParser<S & IParserState>): Ast.TType {
+export function readType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TType {
     const triedReadPrimaryType: TriedReadPrimaryType = tryReadPrimaryType(state, parser);
 
     if (ResultUtils.isOk(triedReadPrimaryType)) {
@@ -1313,10 +1301,7 @@ export function readType<S = IParserState>(state: S & IParserState, parser: IPar
     }
 }
 
-export function readPrimaryType<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
-): Ast.TPrimaryType {
+export function readPrimaryType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TPrimaryType {
     const triedReadPrimaryType: TriedReadPrimaryType = tryReadPrimaryType(state, parser);
 
     if (ResultUtils.isOk(triedReadPrimaryType)) {
@@ -1326,10 +1311,7 @@ export function readPrimaryType<S = IParserState>(
     }
 }
 
-export function readRecordType<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
-): Ast.RecordType {
+export function readRecordType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.RecordType {
     const nodeKind: Ast.NodeKind.RecordType = Ast.NodeKind.RecordType;
     IParserStateUtils.startContext(state, nodeKind);
 
@@ -1350,10 +1332,7 @@ export function readRecordType<S = IParserState>(
     return astNode;
 }
 
-export function readTableType<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
-): Ast.TableType {
+export function readTableType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TableType {
     const nodeKind: Ast.NodeKind.TableType = Ast.NodeKind.TableType;
     IParserStateUtils.startContext(state, nodeKind);
 
@@ -1385,9 +1364,9 @@ export function readTableType<S = IParserState>(
     return astNode;
 }
 
-export function readFieldSpecificationList<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readFieldSpecificationList<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
     allowOpenMarker: boolean,
     testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
 ): Ast.FieldSpecificationList {
@@ -1501,9 +1480,9 @@ export function readFieldSpecificationList<S = IParserState>(
     return astNode;
 }
 
-function maybeReadFieldTypeSpecification<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+function maybeReadFieldTypeSpecification<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.FieldTypeSpecification | undefined {
     const nodeKind: Ast.NodeKind.FieldTypeSpecification = Ast.NodeKind.FieldTypeSpecification;
     IParserStateUtils.startContext(state, nodeKind);
@@ -1544,10 +1523,7 @@ function fieldSpecificationListReadError(state: IParserState, allowOpenMarker: b
     }
 }
 
-export function readListType<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
-): Ast.ListType {
+export function readListType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.ListType {
     return readWrapped(
         state,
         Ast.NodeKind.ListType,
@@ -1558,9 +1534,9 @@ export function readListType<S = IParserState>(
     );
 }
 
-export function readFunctionType<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readFunctionType<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.FunctionType {
     const nodeKind: Ast.NodeKind.FunctionType = Ast.NodeKind.FunctionType;
     IParserStateUtils.startContext(state, nodeKind);
@@ -1584,10 +1560,7 @@ export function readFunctionType<S = IParserState>(
     return astNode;
 }
 
-function tryReadPrimaryType<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
-): TriedReadPrimaryType {
+function tryReadPrimaryType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): TriedReadPrimaryType {
     const isTableTypeNext: boolean =
         IParserStateUtils.isOnConstantKind(state, Ast.PrimitiveTypeConstantKind.Table) &&
         (IParserStateUtils.isNextTokenKind(state, Language.TokenKind.LeftBracket) ||
@@ -1619,16 +1592,16 @@ function tryReadPrimaryType<S = IParserState>(
     }
 }
 
-export function readParameterSpecificationList<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readParameterSpecificationList<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.IParameterList<Ast.AsType> {
     return genericReadParameterList(state, parser, () => parser.readAsType(state, parser));
 }
 
-export function readNullableType<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readNullableType<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.NullableType {
     return readPairedConstant(
         state,
@@ -1642,9 +1615,9 @@ export function readNullableType<S = IParserState>(
 // ---------- 12.2.3.26 Error raising expression ----------
 // --------------------------------------------------------
 
-export function readErrorRaisingExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readErrorRaisingExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.ErrorRaisingExpression {
     return readPairedConstant(
         state,
@@ -1658,9 +1631,9 @@ export function readErrorRaisingExpression<S = IParserState>(
 // ---------- 12.2.3.27 Error handling expression ----------
 // ---------------------------------------------------------
 
-export function readErrorHandlingExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readErrorHandlingExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.ErrorHandlingExpression {
     const nodeKind: Ast.NodeKind.ErrorHandlingExpression = Ast.NodeKind.ErrorHandlingExpression;
     IParserStateUtils.startContext(state, nodeKind);
@@ -1697,9 +1670,9 @@ export function readErrorHandlingExpression<S = IParserState>(
 // ---------- 12.2.4 Literal Attributes ----------
 // -----------------------------------------------
 
-export function readRecordLiteral<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readRecordLiteral<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.RecordLiteral {
     const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.RightBracket);
     const wrappedRead: Ast.IWrapped<
@@ -1727,9 +1700,9 @@ export function readRecordLiteral<S = IParserState>(
     };
 }
 
-export function readFieldNamePairedAnyLiterals<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readFieldNamePairedAnyLiterals<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
     continueReadingValues: boolean,
     testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
 ): Ast.ICsvArray<Ast.GeneralizedIdentifierPairedAnyLiteral> {
@@ -1752,10 +1725,7 @@ export function readFieldNamePairedAnyLiterals<S = IParserState>(
     );
 }
 
-export function readListLiteral<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
-): Ast.ListLiteral {
+export function readListLiteral<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.ListLiteral {
     const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.RightBrace);
     const wrappedRead: Ast.IWrapped<
         Ast.NodeKind.ListLiteral,
@@ -1782,10 +1752,7 @@ export function readListLiteral<S = IParserState>(
     };
 }
 
-export function readAnyLiteral<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
-): Ast.TAnyLiteral {
+export function readAnyLiteral<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TAnyLiteral {
     if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.LeftBracket)) {
         return parser.readRecordLiteral(state, parser);
     } else if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.LeftBrace)) {
@@ -1795,9 +1762,9 @@ export function readAnyLiteral<S = IParserState>(
     }
 }
 
-export function readPrimitiveType<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readPrimitiveType<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.PrimitiveType {
     const triedReadPrimitiveType: TriedReadPrimitiveType = tryReadPrimitiveType(state, parser);
     if (ResultUtils.isOk(triedReadPrimitiveType)) {
@@ -1807,9 +1774,9 @@ export function readPrimitiveType<S = IParserState>(
     }
 }
 
-function tryReadPrimitiveType<S = IParserState>(
-    state: S & IParserState,
-    _parser: IParser<S & IParserState>,
+function tryReadPrimitiveType<S extends IParserState = IParserState>(
+    state: S,
+    _parser: IParser<S>,
 ): TriedReadPrimitiveType {
     const nodeKind: Ast.NodeKind.PrimitiveType = Ast.NodeKind.PrimitiveType;
     IParserStateUtils.startContext(state, nodeKind);
@@ -1898,9 +1865,9 @@ function tryReadPrimitiveType<S = IParserState>(
 // ---------- Disambiguation ----------
 // ------------------------------------
 
-export function disambiguateParenthesis<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function disambiguateParenthesis<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Result<ParenthesisDisambiguation, ParseError.UnterminatedParenthesesError> {
     const initialTokenIndex: number = state.tokenIndex;
     const tokens: ReadonlyArray<Language.Token> = state.lexerSnapshot.tokens;
@@ -1975,9 +1942,9 @@ function unsafeMoveTo(state: IParserState, tokenIndex: number): void {
     }
 }
 
-export function disambiguateBracket<S = IParserState>(
-    state: S & IParserState,
-    _parser: IParser<S & IParserState>,
+export function disambiguateBracket<S extends IParserState = IParserState>(
+    state: S,
+    _parser: IParser<S>,
 ): Result<BracketDisambiguation, ParseError.UnterminatedBracketError> {
     const tokens: ReadonlyArray<Language.Token> = state.lexerSnapshot.tokens;
     let offsetTokenIndex: number = state.tokenIndex + 1;
@@ -2015,9 +1982,9 @@ export function disambiguateBracket<S = IParserState>(
 // ---------- key-value pairs ----------
 // -------------------------------------
 
-export function readIdentifierPairedExpressions<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readIdentifierPairedExpressions<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
     continueReadingValues: boolean,
     testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
 ): Ast.ICsvArray<Ast.IdentifierPairedExpression> {
@@ -2029,9 +1996,9 @@ export function readIdentifierPairedExpressions<S = IParserState>(
     );
 }
 
-export function readGeneralizedIdentifierPairedExpressions<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readGeneralizedIdentifierPairedExpressions<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
     continueReadingValues: boolean,
     testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
 ): Ast.ICsvArray<Ast.GeneralizedIdentifierPairedExpression> {
@@ -2043,9 +2010,9 @@ export function readGeneralizedIdentifierPairedExpressions<S = IParserState>(
     );
 }
 
-export function readGeneralizedIdentifierPairedExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readGeneralizedIdentifierPairedExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.GeneralizedIdentifierPairedExpression {
     return readKeyValuePair<
         S,
@@ -2060,9 +2027,9 @@ export function readGeneralizedIdentifierPairedExpression<S = IParserState>(
     );
 }
 
-export function readIdentifierPairedExpression<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readIdentifierPairedExpression<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.IdentifierPairedExpression {
     return readKeyValuePair<S, Ast.NodeKind.IdentifierPairedExpression, Ast.Identifier, Ast.TExpression>(
         state,
@@ -2081,8 +2048,8 @@ export function readIdentifierPairedExpression<S = IParserState>(
 // The helper function is nearly a copy except it replaces Left and leftReader with Right and rightReader.
 //
 // The reason the code is duplicated across two functions is because I can't think of a cleaner way to do it.
-function recursiveReadBinOpExpression<S, Kind, Left, Operator, Right>(
-    state: S & IParserState,
+function recursiveReadBinOpExpression<S extends IParserState, Kind, Left, Operator, Right>(
+    state: S,
     nodeKind: Kind & Ast.TBinOpExpressionNodeKind,
     leftReader: () => Left,
     maybeOperatorFrom: (
@@ -2129,8 +2096,8 @@ function recursiveReadBinOpExpression<S, Kind, Left, Operator, Right>(
 // Given the string `1 + 2 + 3` the function will recursively parse 2 Ast nodes,
 // where their TokenRange's are represented by brackets:
 // 1 + [2 + [3]]
-function recursiveReadBinOpExpressionHelper<S, Kind, Operator, Right>(
-    state: S & IParserState,
+function recursiveReadBinOpExpressionHelper<S extends IParserState, Kind, Operator, Right>(
+    state: S,
     nodeKind: Kind & Ast.TBinOpExpressionNodeKind,
     maybeOperatorFrom: (
         tokenKind: Language.TokenKind | undefined,
@@ -2172,8 +2139,8 @@ function recursiveReadBinOpExpressionHelper<S, Kind, Operator, Right>(
     return astNode;
 }
 
-function readCsvArray<S, T>(
-    state: S & IParserState,
+function readCsvArray<S extends IParserState, T>(
+    state: S,
     valueReader: () => T & Ast.TCsvType,
     continueReadingValues: boolean,
     testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
@@ -2222,8 +2189,8 @@ function readCsvArray<S, T>(
     return astNode;
 }
 
-function readKeyValuePair<S, Kind, Key, Value>(
-    state: S & IParserState,
+function readKeyValuePair<S extends IParserState, Kind, Key, Value>(
+    state: S,
     nodeKind: Kind & Ast.TKeyValuePairNodeKind,
     keyReader: () => Key,
     valueReader: () => Value,
@@ -2250,8 +2217,8 @@ function readKeyValuePair<S, Kind, Key, Value>(
     return keyValuePair;
 }
 
-function readPairedConstant<S, Kind, ConstantKind, Paired>(
-    state: S & IParserState,
+function readPairedConstant<S extends IParserState, Kind, ConstantKind, Paired>(
+    state: S,
     nodeKind: Kind & Ast.TPairedConstantNodeKind,
     constantReader: () => Ast.TConstant & Ast.IConstant<Ast.TConstantKind & ConstantKind>,
     pairedReader: () => Paired,
@@ -2274,8 +2241,8 @@ function readPairedConstant<S, Kind, ConstantKind, Paired>(
     return pairedConstant;
 }
 
-function maybeReadPairedConstant<S, Kind, ConstantKind, Paired>(
-    state: S & IParserState,
+function maybeReadPairedConstant<S extends IParserState, Kind, ConstantKind, Paired>(
+    state: S,
     nodeKind: Kind & Ast.TPairedConstantNodeKind,
     condition: () => boolean,
     constantReader: () => Ast.TConstant & Ast.IConstant<Ast.TConstantKind & ConstantKind>,
@@ -2289,9 +2256,9 @@ function maybeReadPairedConstant<S, Kind, ConstantKind, Paired>(
     }
 }
 
-function genericReadParameterList<S, T>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+function genericReadParameterList<S extends IParserState, T>(
+    state: S,
+    parser: IParser<S>,
     typeReader: () => T & Ast.TParameterType,
 ): Ast.IParameterList<T> {
     const nodeKind: Ast.NodeKind.ParameterList = Ast.NodeKind.ParameterList;
@@ -2391,8 +2358,8 @@ function genericReadParameterList<S, T>(
     return astNode;
 }
 
-function readWrapped<S, Kind, Open, Content, Close>(
-    state: S & IParserState,
+function readWrapped<S extends IParserState, Kind, Open, Content, Close>(
+    state: S,
     nodeKind: Kind & Ast.TWrappedNodeKind,
     openConstantReader: () => Ast.IConstant<Open>,
     contentReader: () => Content,
@@ -2431,7 +2398,7 @@ function readWrapped<S, Kind, Open, Content, Close>(
 // ---------- Helper functions (read) ----------
 // ---------------------------------------------
 
-export function readToken<S = IParserState>(state: S & IParserState): string {
+export function readToken<S extends IParserState = IParserState>(state: S): string {
     const tokens: ReadonlyArray<Language.Token> = state.lexerSnapshot.tokens;
 
     if (state.tokenIndex >= tokens.length) {
@@ -2455,8 +2422,8 @@ export function readToken<S = IParserState>(state: S & IParserState): string {
     return data;
 }
 
-export function readTokenKindAsConstant<S, T>(
-    state: S & IParserState,
+export function readTokenKindAsConstant<S extends IParserState, T>(
+    state: S,
     tokenKind: Language.TokenKind,
     constantKind: T & Ast.TConstantKind,
 ): Ast.TConstant & Ast.IConstant<T & Ast.TConstantKind> {
@@ -2490,8 +2457,8 @@ export function readTokenKindAsConstant<S, T>(
     return astNode;
 }
 
-export function maybeReadTokenKindAsConstant<S, T>(
-    state: S & IParserState,
+export function maybeReadTokenKindAsConstant<S extends IParserState, T>(
+    state: S,
     tokenKind: Language.TokenKind,
     constantKind: T & Ast.TConstantKind,
 ): (Ast.TConstant & Ast.IConstant<T & Ast.TConstantKind>) | undefined {
@@ -2535,8 +2502,8 @@ function readTokenKind(state: IParserState, tokenKind: Language.TokenKind): stri
     return readToken(state);
 }
 
-function readConstantKind<S, C>(
-    state: S & IParserState,
+function readConstantKind<S extends IParserState, C>(
+    state: S,
     constantKind: C & Ast.TConstantKind,
 ): Ast.TConstant & Ast.IConstant<C> {
     const maybeConstant: (Ast.TConstant & Ast.IConstant<C>) | undefined = maybeReadConstantKind(state, constantKind);
@@ -2548,8 +2515,8 @@ function readConstantKind<S, C>(
     return maybeConstant;
 }
 
-function maybeReadConstantKind<S, C>(
-    state: S & IParserState,
+function maybeReadConstantKind<S extends IParserState, C>(
+    state: S,
     constantKind: C & Ast.TConstantKind,
 ): (Ast.TConstant & Ast.IConstant<C>) | undefined {
     if (IParserStateUtils.isOnConstantKind(state, constantKind)) {
@@ -2571,9 +2538,9 @@ function maybeReadConstantKind<S, C>(
     }
 }
 
-function maybeReadLiteralAttributes<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+function maybeReadLiteralAttributes<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
 ): Ast.RecordLiteral | undefined {
     if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.LeftBracket)) {
         return parser.readRecordLiteral(state, parser);
@@ -2587,9 +2554,9 @@ function maybeReadLiteralAttributes<S = IParserState>(
 // ---------- Helper functions (disambiguation) ----------
 // -------------------------------------------------------
 
-export function readBracketDisambiguation<S = IParserState>(
-    state: S & IParserState,
-    parser: IParser<S & IParserState>,
+export function readBracketDisambiguation<S extends IParserState = IParserState>(
+    state: S,
+    parser: IParser<S>,
     allowedVariants: ReadonlyArray<BracketDisambiguation>,
 ): Ast.FieldProjection | Ast.FieldSelector | Ast.RecordExpression {
     const triedDisambiguation: Result<
@@ -2625,20 +2592,20 @@ export function readBracketDisambiguation<S = IParserState>(
 // ---------- Helper functions (test functions) ----------
 // -------------------------------------------------------
 
-function testCsvContinuationDanglingCommaForBrace<S = IParserState>(
-    state: S & IParserState,
+function testCsvContinuationDanglingCommaForBrace<S extends IParserState = IParserState>(
+    state: S,
 ): ParseError.ExpectedCsvContinuationError | undefined {
     return IParserStateUtils.testCsvContinuationDanglingComma(state, Language.TokenKind.RightBrace);
 }
 
-function testCsvContinuationDanglingCommaForBracket<S = IParserState>(
-    state: S & IParserState,
+function testCsvContinuationDanglingCommaForBracket<S extends IParserState = IParserState>(
+    state: S,
 ): ParseError.ExpectedCsvContinuationError | undefined {
     return IParserStateUtils.testCsvContinuationDanglingComma(state, Language.TokenKind.RightBracket);
 }
 
-function testCsvContinuationDanglingCommaForParenthesis<S = IParserState>(
-    state: S & IParserState,
+function testCsvContinuationDanglingCommaForParenthesis<S extends IParserState = IParserState>(
+    state: S,
 ): ParseError.ExpectedCsvContinuationError | undefined {
     return IParserStateUtils.testCsvContinuationDanglingComma(state, Language.TokenKind.RightParenthesis);
 }

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -2217,15 +2217,20 @@ function readKeyValuePair<S extends IParserState, Kind, Key, Value>(
     return keyValuePair;
 }
 
-function readPairedConstant<S extends IParserState, Kind, ConstantKind, Paired>(
+function readPairedConstant<
+    S extends IParserState,
+    Kind extends Ast.TPairedConstantNodeKind,
+    ConstantKind extends Ast.TConstantKind,
+    Paired
+>(
     state: S,
-    nodeKind: Kind & Ast.TPairedConstantNodeKind,
-    constantReader: () => Ast.TConstant & Ast.IConstant<Ast.TConstantKind & ConstantKind>,
+    nodeKind: Kind,
+    constantReader: () => Ast.TConstant & Ast.IConstant<ConstantKind>,
     pairedReader: () => Paired,
 ): Ast.IPairedConstant<Kind, ConstantKind, Paired> {
     IParserStateUtils.startContext(state, nodeKind);
 
-    const constant: Ast.TConstant & Ast.IConstant<Ast.TConstantKind & ConstantKind> = constantReader();
+    const constant: Ast.TConstant & Ast.IConstant<ConstantKind> = constantReader();
     const paired: Paired = pairedReader();
 
     const pairedConstant: Ast.IPairedConstant<Kind, ConstantKind, Paired> = {
@@ -2241,11 +2246,16 @@ function readPairedConstant<S extends IParserState, Kind, ConstantKind, Paired>(
     return pairedConstant;
 }
 
-function maybeReadPairedConstant<S extends IParserState, Kind, ConstantKind, Paired>(
+function maybeReadPairedConstant<
+    S extends IParserState,
+    Kind extends Ast.TPairedConstantNodeKind,
+    ConstantKind extends Ast.TConstantKind,
+    Paired
+>(
     state: S,
-    nodeKind: Kind & Ast.TPairedConstantNodeKind,
+    nodeKind: Kind,
     condition: () => boolean,
-    constantReader: () => Ast.TConstant & Ast.IConstant<Ast.TConstantKind & ConstantKind>,
+    constantReader: () => Ast.TConstant & Ast.IConstant<ConstantKind>,
     pairedReader: () => Paired,
 ): Ast.IPairedConstant<Kind, ConstantKind, Paired> | undefined {
     if (condition()) {

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -20,7 +20,12 @@ type TriedReadPrimitiveType = Result<
     ParseError.ExpectedAnyTokenKindError | ParseError.InvalidPrimitiveTypeError | CommonError.InvariantError
 >;
 
-interface WrappedRead<Kind, Open, Content, Close> extends Ast.IWrapped<Kind, Open, Content, Close> {
+interface WrappedRead<
+    Kind extends Ast.TWrappedNodeKind,
+    Open extends Ast.WrapperConstantKind,
+    Content,
+    Close extends Ast.WrapperConstantKind
+> extends Ast.IWrapped<Kind, Open, Content, Close> {
     readonly maybeOptionalConstant: Ast.IConstant<Ast.MiscConstantKind.QuestionMark> | undefined;
 }
 
@@ -2371,7 +2376,13 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
     return astNode;
 }
 
-function readWrapped<S extends IParserState, Kind extends Ast.TWrappedNodeKind, Open, Content, Close>(
+function readWrapped<
+    S extends IParserState,
+    Kind extends Ast.TWrappedNodeKind,
+    Open extends Ast.WrapperConstantKind,
+    Content,
+    Close extends Ast.WrapperConstantKind
+>(
     state: S,
     nodeKind: Kind,
     openConstantReader: () => Ast.IConstant<Open>,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,12 +12,12 @@ export interface CommonSettings {
 // tslint:disable-next-line: no-empty-interface
 export interface LexSettings extends CommonSettings {}
 
-export interface ParseSettings<S = IParserState> extends CommonSettings {
-    readonly parser: IParser<S & IParserState>;
-    readonly newParserState: (parseSettings: ParseSettings<S>, lexerSnapshot: LexerSnapshot) => S & IParserState;
+export interface ParseSettings<S extends IParserState = IParserState> extends CommonSettings {
+    readonly parser: IParser<S>;
+    readonly newParserState: (parseSettings: ParseSettings<S>, lexerSnapshot: LexerSnapshot) => S;
 }
 
-export type Settings<S = IParserState> = LexSettings & ParseSettings<S>;
+export type Settings<S extends IParserState = IParserState> = LexSettings & ParseSettings<S>;
 
 export const DefaultSettings: Settings = {
     parser: Parser.CombinatorialParser,

--- a/src/task.ts
+++ b/src/task.ts
@@ -20,18 +20,21 @@ export interface InspectionOk {
     readonly scopeType: Inspection.ScopeTypeMap;
 }
 
-export type TriedLexParse<S = IParserState> = Result<LexParseOk<S>, LexError.TLexError | ParseError.TParseError<S>>;
+export type TriedLexParse<S extends IParserState = IParserState> = Result<
+    LexParseOk<S>,
+    LexError.TLexError | ParseError.TParseError<S>
+>;
 
-export type TriedLexParseInspect<S = IParserState> = Result<
+export type TriedLexParseInspect<S extends IParserState = IParserState> = Result<
     LexParseInspectOk<S>,
     CommonError.CommonError | LexError.LexError | ParseError.ParseError
 >;
 
-export interface LexParseOk<S = IParserState> extends ParseOk<S> {
+export interface LexParseOk<S extends IParserState = IParserState> extends ParseOk<S> {
     readonly lexerSnapshot: LexerSnapshot;
 }
 
-export interface LexParseInspectOk<S = IParserState> extends InspectionOk {
+export interface LexParseInspectOk<S extends IParserState = IParserState> extends InspectionOk {
     readonly triedParse: TriedParse<S>;
 }
 
@@ -48,13 +51,16 @@ export function tryLex(settings: LexSettings, text: string): TriedLexerSnapshot 
     return LexerSnapshot.tryFrom(state);
 }
 
-export function tryParse<S = IParserState>(settings: ParseSettings<S>, lexerSnapshot: LexerSnapshot): TriedParse<S> {
-    const parser: IParser<S & IParserState> = settings.parser;
-    const parserState: S & IParserState = settings.newParserState(settings, lexerSnapshot);
+export function tryParse<S extends IParserState = IParserState>(
+    settings: ParseSettings<S>,
+    lexerSnapshot: LexerSnapshot,
+): TriedParse<S> {
+    const parser: IParser<S> = settings.parser;
+    const parserState: S = settings.newParserState(settings, lexerSnapshot);
     return parser.readDocument(parserState, parser);
 }
 
-export function tryInspection<S = IParserState>(
+export function tryInspection<S extends IParserState = IParserState>(
     settings: CommonSettings,
     triedParse: TriedParse<S>,
     position: Inspection.Position,
@@ -146,7 +152,7 @@ export function tryInspection<S = IParserState>(
     });
 }
 
-export function tryLexParse<S = IParserState>(
+export function tryLexParse<S extends IParserState = IParserState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
 ): TriedLexParse<S> {
@@ -167,7 +173,7 @@ export function tryLexParse<S = IParserState>(
     }
 }
 
-export function tryLexParseInspection<S = IParserState>(
+export function tryLexParseInspection<S extends IParserState = IParserState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Inspection.Position,
@@ -192,11 +198,13 @@ export function tryLexParseInspection<S = IParserState>(
     });
 }
 
-export function maybeTriedParseFromTriedLexParse<S>(triedLexParse: TriedLexParse<S>): undefined | TriedParse<S> {
+export function maybeTriedParseFromTriedLexParse<S extends IParserState>(
+    triedLexParse: TriedLexParse<S>,
+): undefined | TriedParse<S> {
     let ast: Ast.TDocument;
     let leafNodeIds: ReadonlyArray<number>;
     let nodeIdMapCollection: NodeIdMap.Collection;
-    let state: S & IParserState;
+    let state: S;
 
     if (ResultUtils.isErr(triedLexParse)) {
         if (

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -29,8 +29,8 @@ export function expectTextWithPosition(text: string): [string, Inspection.Positi
     return [text.replace("|", ""), position];
 }
 
-export function expectLexParseOk<S = IParserState>(
-    settings: LexSettings & ParseSettings<S & IParserState>,
+export function expectLexParseOk<S extends IParserState = IParserState>(
+    settings: LexSettings & ParseSettings<S>,
     text: string,
 ): Task.LexParseOk<S> {
     const triedLexParse: Task.TriedLexParse<S> = Task.tryLexParse(settings, text);
@@ -40,8 +40,8 @@ export function expectLexParseOk<S = IParserState>(
     return triedLexParse.value;
 }
 
-export function expectParseErr<S = IParserState>(
-    settings: LexSettings & ParseSettings<S & IParserState>,
+export function expectParseErr<S extends IParserState = IParserState>(
+    settings: LexSettings & ParseSettings<S>,
     text: string,
 ): ParseError.ParseError<S> {
     const triedParse: TriedParse<S> = expectTriedParse(settings, text);
@@ -56,8 +56,8 @@ export function expectParseErr<S = IParserState>(
     return triedParse.error;
 }
 
-export function expectParseOk<S = IParserState>(
-    settings: LexSettings & ParseSettings<S & IParserState>,
+export function expectParseOk<S extends IParserState = IParserState>(
+    settings: LexSettings & ParseSettings<S>,
     text: string,
 ): ParseOk<S> {
     const triedParse: TriedParse<S> = expectTriedParse(settings, text);
@@ -69,8 +69,8 @@ export function expectParseOk<S = IParserState>(
 
 // I only care about errors coming from the parse stage.
 // If I use tryLexParse I might get a CommonError which could have come either from lexing or parsing.
-function expectTriedParse<S = IParserState>(
-    settings: LexSettings & ParseSettings<S & IParserState>,
+function expectTriedParse<S extends IParserState = IParserState>(
+    settings: LexSettings & ParseSettings<S>,
     text: string,
 ): TriedParse<S> {
     const lexerState: Lexer.State = Lexer.stateFrom(settings, text);
@@ -85,6 +85,6 @@ function expectTriedParse<S = IParserState>(
     }
     const lexerSnapshot: LexerSnapshot = triedSnapshot.value;
 
-    const parserState: S & IParserState = settings.newParserState(settings, lexerSnapshot);
+    const parserState: S = settings.newParserState(settings, lexerSnapshot);
     return settings.parser.readDocument(parserState, settings.parser);
 }

--- a/src/test/fileUtils.ts
+++ b/src/test/fileUtils.ts
@@ -43,7 +43,7 @@ export function writeContents(filePath: string, contents: string): void {
     });
 }
 
-export function tryLexParse<S = IParserState>(
+export function tryLexParse<S extends IParserState = IParserState>(
     settings: LexSettings & ParseSettings<S>,
     filePath: string,
 ): Task.TriedLexParse<S> {

--- a/src/test/libraryTest/inspection/autocomplete.ts
+++ b/src/test/libraryTest/inspection/autocomplete.ts
@@ -12,7 +12,7 @@ import { IParserState, NodeIdMap, ParseError, ParseOk } from "../../../parser";
 import { CommonSettings, DefaultSettings, LexSettings, ParseSettings } from "../../../settings";
 import { expectParseErr, expectParseOk, expectTextWithPosition } from "../../common";
 
-function expectAutocompleteOk<S>(
+function expectAutocompleteOk<S extends IParserState>(
     settings: CommonSettings,
     nodeIdMapCollection: NodeIdMap.Collection,
     leafNodeIds: ReadonlyArray<number>,
@@ -40,8 +40,8 @@ function expectAutocompleteOk<S>(
     return triedInspect.value;
 }
 
-function expectParseOkAutocompleteOk<S = IParserState>(
-    settings: LexSettings & ParseSettings<S & IParserState>,
+function expectParseOkAutocompleteOk<S extends IParserState = IParserState>(
+    settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Position,
 ): ReadonlyArray<Language.KeywordKind> {
@@ -49,8 +49,8 @@ function expectParseOkAutocompleteOk<S = IParserState>(
     return expectAutocompleteOk(settings, parseOk.nodeIdMapCollection, parseOk.leafNodeIds, position, undefined);
 }
 
-function expectParseErrAutocompleteOk<S = IParserState>(
-    settings: LexSettings & ParseSettings<S & IParserState>,
+function expectParseErrAutocompleteOk<S extends IParserState = IParserState>(
+    settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Position,
 ): ReadonlyArray<Language.KeywordKind> {

--- a/src/test/libraryTest/inspection/invokeExpression.ts
+++ b/src/test/libraryTest/inspection/invokeExpression.ts
@@ -38,8 +38,8 @@ function expectInvokeExpressionOk(
     return triedInspect.value;
 }
 
-function expectParseOkInvokeExpressionOk<S = IParserState>(
-    settings: LexSettings & ParseSettings<S & IParserState>,
+function expectParseOkInvokeExpressionOk<S extends IParserState = IParserState>(
+    settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Position,
 ): undefined | InvokeExpression {
@@ -47,8 +47,8 @@ function expectParseOkInvokeExpressionOk<S = IParserState>(
     return expectInvokeExpressionOk(settings, parseOk.nodeIdMapCollection, parseOk.leafNodeIds, position);
 }
 
-function expectParseErrInvokeExpressionOk<S = IParserState>(
-    settings: LexSettings & ParseSettings<S & IParserState>,
+function expectParseErrInvokeExpressionOk<S extends IParserState = IParserState>(
+    settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Position,
 ): undefined | InvokeExpression {

--- a/src/test/libraryTest/inspection/scope.ts
+++ b/src/test/libraryTest/inspection/scope.ts
@@ -152,8 +152,8 @@ function expectScopeForNodeOk(
     return triedScopeInspection.value;
 }
 
-export function expectParseOkScopeOk<S = IParserState>(
-    settings: LexSettings & ParseSettings<S & IParserState>,
+export function expectParseOkScopeOk<S extends IParserState = IParserState>(
+    settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Position,
 ): ScopeItemByKey {
@@ -161,8 +161,8 @@ export function expectParseOkScopeOk<S = IParserState>(
     return expectScopeForNodeOk(settings, parseOk.nodeIdMapCollection, parseOk.leafNodeIds, position);
 }
 
-export function expectParseErrScopeOk<S = IParserState>(
-    settings: LexSettings & ParseSettings<S & IParserState>,
+export function expectParseErrScopeOk<S extends IParserState = IParserState>(
+    settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Position,
 ): ScopeItemByKey {

--- a/src/test/libraryTest/inspection/type.ts
+++ b/src/test/libraryTest/inspection/type.ts
@@ -55,8 +55,8 @@ function expectScopeTypeOk(
     return triedScopeType.value;
 }
 
-function expectParseOkScopeTypeOk<S = IParserState>(
-    settings: LexSettings & ParseSettings<S & IParserState>,
+function expectParseOkScopeTypeOk<S extends IParserState = IParserState>(
+    settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Position,
 ): ScopeTypeMap {

--- a/src/test/libraryTest/parser/children.ts
+++ b/src/test/libraryTest/parser/children.ts
@@ -14,7 +14,7 @@ interface ChildIdsByIdEntry {
     readonly kind: Ast.NodeKind;
 }
 
-function acutalFactoryFn<S = IParserState>(lexParseOk: Task.LexParseOk<S>): ChildIdsByIdEntry[] {
+function acutalFactoryFn<S extends IParserState = IParserState>(lexParseOk: Task.LexParseOk<S>): ChildIdsByIdEntry[] {
     const actual: ChildIdsByIdEntry[] = [];
     const astNodeById: NodeIdMap.AstNodeById = lexParseOk.nodeIdMapCollection.astNodeById;
 

--- a/src/test/resourceTest/benchmarkParser.ts
+++ b/src/test/resourceTest/benchmarkParser.ts
@@ -285,8 +285,8 @@ export const BenchmarkParser: IParser<BenchmarkState> = {
         traceFunction(state, parser, state.baseParser.readGeneralizedIdentifierPairedExpression),
 };
 
-export function newBenchmarkState<S = IParserState>(
-    parseSettings: ParseSettings<S & IParserState>,
+export function newBenchmarkState<S extends IParserState = IParserState>(
+    parseSettings: ParseSettings<S>,
     lexerSnapshot: LexerSnapshot,
     baseParser: IParser<IParserState>,
 ): BenchmarkState {
@@ -309,7 +309,10 @@ function traceFunction<T>(
     return result;
 }
 
-function functionEntry<S, T>(state: BenchmarkState, fn: (state: S, parser: IParser<S>) => T): number {
+function functionEntry<S extends IParserState, T>(
+    state: BenchmarkState,
+    fn: (state: S, parser: IParser<S>) => T,
+): number {
     const tokenPosition: Language.TokenPosition = state.maybeCurrentToken!.positionStart;
     const id: number = state.functionTimestampCounter;
     state.functionTimestampCounter += 1;

--- a/src/test/resourceTest/lexParse.ts
+++ b/src/test/resourceTest/lexParse.ts
@@ -1,7 +1,7 @@
 import "mocha";
 import { Task } from "../..";
 import { ResultUtils } from "../../common";
-import { IParser, Parser } from "../../parser";
+import { IParser, IParserState, Parser } from "../../parser";
 import { DefaultSettings, Settings } from "../../settings";
 
 import * as path from "path";
@@ -27,7 +27,7 @@ function testNameFromFilePath(filePath: string): string {
     return filePath.replace(path.dirname(__filename), ".");
 }
 
-function parseAllFiles<S>(settings: Settings<S>, parserName: string): void {
+function parseAllFiles<S extends IParserState>(settings: Settings<S>, parserName: string): void {
     describe(`Run ${parserName} on lexParseResources directory`, () => {
         const fileDirectory: string = path.join(path.dirname(__filename), "lexParseResources");
 


### PR DESCRIPTION
In many places generic typing was updated.

```
// old
function<T>(something: T & TStricterType) { ... }

// new
funciton<T extends TStricterType>(something: T) { ... }
```

The first approach is much slower and is more noisy/verbose when you needed to refer to the generic type multiple times.

// master
| Key                        | Value   |
| Key                        | Value   |
|----------------------------|---------|
| Files:                     | 214     |
| Lines:                     | 71608   |
| Nodes:                     | 305682  |
| Identifiers:               | 110209  |
| Symbols:                   | 115606  |
| Types:                     | 49385   |
| Memory used:               | 199976K |
| Assignability cache size:  | 122421  |
| Identity cache size:       | 671     |
| Subtype cache size:        | 904     |
| Strict subtype cache size: | 2782    |
| I/O Read time:             | 0.03s   |
| Parse time:                | 0.68s   |
| Program time:              | 0.84s   |
| Bind time:                 | 0.45s   |
| Check time:                | 13.23s  |
| transformTime time:        | 0.24s   |
| commentTime time:          | 0.04s   |
| printTime time:            | 0.49s   |
| Emit time:                 | 0.49s   |
| Source Map time:           | 0.02s   |
| I/O Write time:            | 0.03s   |
| Total time:                | 15.02s  |

// PR, notice the check time change
| Key                        | Value   |
|----------------------------|---------|
| Files:                     | 214     |
| Lines:                     | 71389   |
| Nodes:                     | 304271  |
| Identifiers:               | 109738  |
| Symbols:                   | 109386  |
| Types:                     | 43588   |
| Memory used:               | 184211K |
| Assignability cache size:  | 53084   |
| Identity cache size:       | 197     |
| Subtype cache size:        | 899     |
| Strict subtype cache size: | 2779    |
| I/O Read time:             | 0.03s   |
| Parse time:                | 0.55s   |
| Program time:              | 0.69s   |
| Bind time:                 | 0.39s   |
| Check time:                | 2.54s   |
| transformTime time:        | 0.09s   |
| Total time:                | 3.62s   |

