### PR TITLE
Add recursive members to scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.1.49",
+    "version": "0.1.50",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",
@@ -15,7 +15,7 @@
         "lint": "npm run lint:prettier && npm run lint:tslint",
         "lint:prettier": ".\\node_modules\\.bin\\prettier --config \".prettierrc\" --list-different src\\**\\*.ts",
         "lint:tslint": ".\\node_modules\\.bin\\tslint src/*.ts",
-        "prepublishOnly": "git clean -xdf && npm install && npm run check && npm run build && npm run test && npm run test:resources"
+        "prepublishOnly": "git clean -xdf && npm install && npm run lint && npm run build && npm run test && npm run test:resources"
     },
     "homepage": "https://github.com/microsoft/powerquery-parser#readme",
     "repository": {

--- a/src/inspection/scope/scopeItem.ts
+++ b/src/inspection/scope/scopeItem.ts
@@ -21,6 +21,7 @@ export const enum ScopeItemKind {
 
 export interface IScopeItem {
     readonly kind: ScopeItemKind;
+    readonly recursive: boolean;
 }
 
 export interface EachScopeItem extends IScopeItem {

--- a/src/test/libraryTest/inspection/scope.ts
+++ b/src/test/libraryTest/inspection/scope.ts
@@ -22,6 +22,7 @@ type AbridgedNodeScope = ReadonlyArray<TAbridgedNodeScopeItem>;
 
 interface IAbridgedNodeScopeItem {
     readonly identifier: string;
+    readonly recursive: boolean;
     readonly kind: ScopeItemKind;
 }
 
@@ -59,6 +60,7 @@ function abridgedScopeItemFrom(identifier: string, scopeItem: Inspection.TScopeI
         case ScopeItemKind.Each:
             return {
                 identifier,
+                recursive: scopeItem.recursive,
                 kind: scopeItem.kind,
                 eachExpressionNodeId: scopeItem.eachExpression.node.id,
             };
@@ -66,6 +68,7 @@ function abridgedScopeItemFrom(identifier: string, scopeItem: Inspection.TScopeI
         case ScopeItemKind.KeyValuePair:
             return {
                 identifier,
+                recursive: scopeItem.recursive,
                 kind: scopeItem.kind,
                 keyNodeId: scopeItem.key.id,
                 maybeValueNodeId: scopeItem.maybeValue !== undefined ? scopeItem.maybeValue.node.id : undefined,
@@ -74,6 +77,7 @@ function abridgedScopeItemFrom(identifier: string, scopeItem: Inspection.TScopeI
         case ScopeItemKind.Parameter:
             return {
                 identifier,
+                recursive: scopeItem.recursive,
                 kind: scopeItem.kind,
                 nameNodeId: scopeItem.name.id,
                 isNullable: scopeItem.isNullable,
@@ -84,6 +88,7 @@ function abridgedScopeItemFrom(identifier: string, scopeItem: Inspection.TScopeI
         case ScopeItemKind.SectionMember:
             return {
                 identifier,
+                recursive: scopeItem.recursive,
                 kind: scopeItem.kind,
                 keyNodeId: scopeItem.key.id,
             };
@@ -91,6 +96,7 @@ function abridgedScopeItemFrom(identifier: string, scopeItem: Inspection.TScopeI
         case ScopeItemKind.Undefined:
             return {
                 identifier,
+                recursive: scopeItem.recursive,
                 kind: scopeItem.kind,
                 nodeId: scopeItem.xorNode.node.id,
             };
@@ -195,6 +201,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "_",
+                        recursive: false,
                         kind: ScopeItemKind.Each,
                         eachExpressionNodeId: 1,
                     },
@@ -207,6 +214,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "_",
+                        recursive: false,
                         kind: ScopeItemKind.Each,
                         eachExpressionNodeId: 1,
                     },
@@ -219,6 +227,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "_",
+                        recursive: false,
                         kind: ScopeItemKind.Each,
                         eachExpressionNodeId: 3,
                     },
@@ -239,6 +248,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const expected: AbridgedNodeScope = [
                     {
                         identifier: "_",
+                        recursive: false,
                         kind: ScopeItemKind.Each,
                         eachExpressionNodeId: 1,
                     },
@@ -272,6 +282,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "x",
                         kind: ScopeItemKind.Parameter,
+                        recursive: false,
                         nameNodeId: 7,
                         isNullable: true,
                         isOptional: false,
@@ -280,6 +291,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "y",
                         kind: ScopeItemKind.Parameter,
+                        recursive: false,
                         nameNodeId: 11,
                         isNullable: true,
                         isOptional: false,
@@ -315,6 +327,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "x",
                         kind: ScopeItemKind.Parameter,
+                        recursive: false,
                         nameNodeId: 7,
                         isNullable: true,
                         isOptional: false,
@@ -323,6 +336,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "y",
                         kind: ScopeItemKind.Parameter,
+                        recursive: false,
                         nameNodeId: 11,
                         isNullable: true,
                         isOptional: false,
@@ -342,12 +356,14 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "x",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 6,
                         maybeValueNodeId: 9,
                     },
                     {
                         identifier: "y",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 13,
                         maybeValueNodeId: 16,
                     },
@@ -371,7 +387,15 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
             it(`[a=1|]`, () => {
                 const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`[a=1|]`);
-                const expected: AbridgedNodeScope = [];
+                const expected: AbridgedNodeScope = [
+                    {
+                        identifier: "a",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 7,
+                        maybeValueNodeId: 10,
+                    },
+                ];
                 expectDeepEqual(expectParseOkScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
             });
 
@@ -381,8 +405,16 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "a",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 7,
                         maybeValueNodeId: 10,
+                    },
+                    {
+                        identifier: "b",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 14,
+                        maybeValueNodeId: 17,
                     },
                 ];
                 expectDeepEqual(expectParseOkScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
@@ -394,12 +426,21 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "a",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 7,
                         maybeValueNodeId: 10,
                     },
                     {
+                        identifier: "b",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 14,
+                        maybeValueNodeId: 17,
+                    },
+                    {
                         identifier: "c",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 21,
                         maybeValueNodeId: 24,
                     },
@@ -415,7 +456,15 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
             it(`[a=[|b=1]]`, () => {
                 const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`[a=[|b=1]]`);
-                const expected: AbridgedNodeScope = [];
+                const expected: AbridgedNodeScope = [
+                    {
+                        identifier: "a",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 7,
+                        maybeValueNodeId: 10,
+                    },
+                ];
                 expectDeepEqual(expectParseOkScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
             });
         });
@@ -435,13 +484,29 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
             it(`[a=|1`, () => {
                 const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`[a=|1`);
-                const expected: AbridgedNodeScope = [];
+                const expected: AbridgedNodeScope = [
+                    {
+                        identifier: "a",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 7,
+                        maybeValueNodeId: 9,
+                    },
+                ];
                 expectDeepEqual(expectParseErrScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
             });
 
             it(`[a=1|`, () => {
                 const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`[a=1|`);
-                const expected: AbridgedNodeScope = [];
+                const expected: AbridgedNodeScope = [
+                    {
+                        identifier: "a",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 7,
+                        maybeValueNodeId: 9,
+                    },
+                ];
                 expectDeepEqual(expectParseErrScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
             });
 
@@ -451,8 +516,16 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "a",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 7,
                         maybeValueNodeId: 9,
+                    },
+                    {
+                        identifier: "b",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 13,
+                        maybeValueNodeId: 15,
                     },
                 ];
                 expectDeepEqual(expectParseErrScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
@@ -464,12 +537,21 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "a",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 7,
                         maybeValueNodeId: 9,
                     },
                     {
+                        identifier: "b",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 13,
+                        maybeValueNodeId: 15,
+                    },
+                    {
                         identifier: "c",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 19,
                         maybeValueNodeId: 21,
                     },
@@ -479,13 +561,36 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
             it(`[a=[|b=1`, () => {
                 const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`[a=[|b=1`);
-                const expected: AbridgedNodeScope = [];
+                const expected: AbridgedNodeScope = [
+                    {
+                        identifier: "a",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 7,
+                        maybeValueNodeId: 9,
+                    },
+                ];
                 expectDeepEqual(expectParseErrScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
             });
 
             it(`[a=[b=|`, () => {
                 const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`[a=[b=|`);
-                const expected: AbridgedNodeScope = [];
+                const expected: AbridgedNodeScope = [
+                    {
+                        identifier: "a",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 7,
+                        maybeValueNodeId: 9,
+                    },
+                    {
+                        identifier: "b",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 14,
+                        maybeValueNodeId: 16,
+                    },
+                ];
                 expectDeepEqual(expectParseErrScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
             });
         });
@@ -505,8 +610,15 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 );
                 const expected: AbridgedNodeScope = [
                     {
+                        identifier: "x",
+                        kind: ScopeItemKind.SectionMember,
+                        recursive: true,
+                        keyNodeId: 8,
+                    },
+                    {
                         identifier: "y",
                         kind: ScopeItemKind.SectionMember,
+                        recursive: false,
                         keyNodeId: 15,
                     },
                 ];
@@ -521,7 +633,14 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "x",
                         kind: ScopeItemKind.SectionMember,
+                        recursive: false,
                         keyNodeId: 8,
+                    },
+                    {
+                        identifier: "y",
+                        kind: ScopeItemKind.SectionMember,
+                        recursive: true,
+                        keyNodeId: 15,
                     },
                 ];
                 expectDeepEqual(expectParseOkScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
@@ -543,16 +662,25 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "x",
                         kind: ScopeItemKind.SectionMember,
+                        recursive: false,
                         keyNodeId: 8,
                     },
                     {
                         identifier: "y",
                         kind: ScopeItemKind.SectionMember,
+                        recursive: false,
                         keyNodeId: 15,
+                    },
+                    {
+                        identifier: "z",
+                        kind: ScopeItemKind.SectionMember,
+                        recursive: true,
+                        keyNodeId: 22,
                     },
                     {
                         identifier: "a",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 29,
                         maybeValueNodeId: 32,
                     },
@@ -576,8 +704,15 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 );
                 const expected: AbridgedNodeScope = [
                     {
+                        identifier: "x",
+                        kind: ScopeItemKind.SectionMember,
+                        recursive: true,
+                        keyNodeId: 8,
+                    },
+                    {
                         identifier: "y",
                         kind: ScopeItemKind.SectionMember,
+                        recursive: false,
                         keyNodeId: 15,
                     },
                 ];
@@ -592,7 +727,14 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "x",
                         kind: ScopeItemKind.SectionMember,
+                        recursive: false,
                         keyNodeId: 8,
+                    },
+                    {
+                        identifier: "y",
+                        kind: ScopeItemKind.SectionMember,
+                        recursive: true,
+                        keyNodeId: 15,
                     },
                 ];
                 expectDeepEqual(expectParseErrScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
@@ -606,7 +748,14 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "x",
                         kind: ScopeItemKind.SectionMember,
+                        recursive: false,
                         keyNodeId: 8,
+                    },
+                    {
+                        identifier: "y",
+                        kind: ScopeItemKind.SectionMember,
+                        recursive: true,
+                        keyNodeId: 15,
                     },
                 ];
                 expectDeepEqual(expectParseErrScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
@@ -620,6 +769,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "a",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 6,
                         maybeValueNodeId: 9,
                     },
@@ -633,6 +783,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "a",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 6,
                         maybeValueNodeId: 9,
                     },
@@ -642,7 +793,15 @@ describe(`subset Inspection - Scope - Identifier`, () => {
 
             it(`let a = |1 in x`, () => {
                 const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`let a = |1 in x`);
-                const expected: AbridgedNodeScope = [];
+                const expected: AbridgedNodeScope = [
+                    {
+                        identifier: "a",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 6,
+                        maybeValueNodeId: 9,
+                    },
+                ];
                 expectDeepEqual(expectParseOkScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
             });
 
@@ -654,12 +813,14 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "a",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 6,
                         maybeValueNodeId: 9,
                     },
                     {
                         identifier: "b",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 13,
                         maybeValueNodeId: 16,
                     },
@@ -673,8 +834,16 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 );
                 const expected: AbridgedNodeScope = [
                     {
+                        identifier: "a",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 6,
+                        maybeValueNodeId: 9,
+                    },
+                    {
                         identifier: "b",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 13,
                         maybeValueNodeId: 16,
                     },
@@ -690,6 +859,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "p1",
                         kind: ScopeItemKind.Parameter,
+                        recursive: false,
                         nameNodeId: 7,
                         isNullable: true,
                         isOptional: false,
@@ -698,6 +868,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "p2",
                         kind: ScopeItemKind.Parameter,
+                        recursive: false,
                         nameNodeId: 11,
                         isNullable: true,
                         isOptional: false,
@@ -706,14 +877,23 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "a",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 19,
                         maybeValueNodeId: 22,
                     },
                     {
                         identifier: "b",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 26,
                         maybeValueNodeId: 29,
+                    },
+                    {
+                        identifier: "c",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 33,
+                        maybeValueNodeId: 36,
                     },
                 ];
                 expectDeepEqual(expectParseOkScopeOk(DefaultSettings, text, position), expected, actualScopeFactoryFn);
@@ -727,18 +907,21 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "eggs",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 6,
                         maybeValueNodeId: 8,
                     },
                     {
                         identifier: "foo",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 23,
                         maybeValueNodeId: 26,
                     },
                     {
                         identifier: "bar",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 30,
                         maybeValueNodeId: 33,
                     },
@@ -752,20 +935,30 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 );
                 const expected: AbridgedNodeScope = [
                     {
+                        identifier: "eggs",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 6,
+                        maybeValueNodeId: 8,
+                    },
+                    {
                         identifier: "foo",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 23,
                         maybeValueNodeId: 26,
                     },
                     {
                         identifier: "bar",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 30,
                         maybeValueNodeId: 33,
                     },
                     {
                         identifier: "ham",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 13,
                         maybeValueNodeId: 16,
                     },
@@ -781,6 +974,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "a",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 6,
                         maybeValueNodeId: 9,
                     },
@@ -794,12 +988,14 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "a",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 6,
                         maybeValueNodeId: 9,
                     },
                     {
                         identifier: "b",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 13,
                         maybeValueNodeId: 16,
                     },
@@ -811,8 +1007,16 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`let a = 1|, b = 2 in `);
                 const expected: AbridgedNodeScope = [
                     {
+                        identifier: "a",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 6,
+                        maybeValueNodeId: 9,
+                    },
+                    {
                         identifier: "b",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 13,
                         maybeValueNodeId: 16,
                     },
@@ -826,8 +1030,16 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 );
                 const expected: AbridgedNodeScope = [
                     {
+                        identifier: "x",
+                        kind: ScopeItemKind.KeyValuePair,
+                        recursive: true,
+                        keyNodeId: 6,
+                        maybeValueNodeId: 9,
+                    },
+                    {
                         identifier: "y",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 16,
                         maybeValueNodeId: 19,
                     },
@@ -843,6 +1055,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     {
                         identifier: "x",
                         kind: ScopeItemKind.KeyValuePair,
+                        recursive: false,
                         keyNodeId: 6,
                         maybeValueNodeId: 9,
                     },
@@ -861,6 +1074,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 {
                     identifier: "a",
                     kind: ScopeItemKind.Parameter,
+                    recursive: false,
                     nameNodeId: 7,
                     isNullable: true,
                     isOptional: false,
@@ -869,6 +1083,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 {
                     identifier: "b",
                     kind: ScopeItemKind.Parameter,
+                    recursive: false,
                     nameNodeId: 11,
                     isNullable: false,
                     isOptional: false,
@@ -877,6 +1092,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 {
                     identifier: "c",
                     kind: ScopeItemKind.Parameter,
+                    recursive: false,
                     nameNodeId: 19,
                     isNullable: true,
                     isOptional: false,
@@ -885,6 +1101,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 {
                     identifier: "d",
                     kind: ScopeItemKind.Parameter,
+                    recursive: false,
                     nameNodeId: 30,
                     isNullable: true,
                     isOptional: true,
@@ -893,6 +1110,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                 {
                     identifier: "e",
                     kind: ScopeItemKind.Parameter,
+                    recursive: false,
                     nameNodeId: 35,
                     isNullable: false,
                     isOptional: true,


### PR DESCRIPTION
Eventually we want to support recursive identifiers (`"@Foo"`). This adds the new flag `recursive` to IScopeItem and changes the return of ScopeMap. Take the following query: `let x = 1, y = 2|`

Previously there was one scope item, 'x'
Now there are two scope items, 'x' (recursive: false) and 'y' (recursive: true)

Note that the recursive flag is of course context dependent. The following query has (recursive: false for 'y'): `let x = 1|, y = 2`