### PR TITLE
Standardize undefined ordering

### DIFF
--- a/src/common/stringUtils.ts
+++ b/src/common/stringUtils.ts
@@ -73,7 +73,7 @@ export function maybeIdentifierLength(text: string, index: number): number | und
     const textLength: number = text.length;
 
     while (continueMatching) {
-        const maybeMatchLength: undefined | number = maybeRegexMatchLength(
+        const maybeMatchLength: number | undefined = maybeRegexMatchLength(
             isOnStartCharacter ? Pattern.IdentifierStartCharacter : Pattern.IdentifierPartCharacters,
             text,
             index,

--- a/src/common/typeScriptTypeUtils.ts
+++ b/src/common/typeScriptTypeUtils.ts
@@ -4,6 +4,6 @@
 // removes `readonly` from T's attributes
 export type StripReadonly<T> = { -readonly [K in keyof T]: T[K] };
 
-export function isDefined<T>(x: undefined | T): x is T {
+export function isDefined<T>(x: T | undefined): x is T {
     return x !== undefined;
 }

--- a/src/inspection/invokeExpression.ts
+++ b/src/inspection/invokeExpression.ts
@@ -8,7 +8,7 @@ import { CommonSettings } from "../settings";
 import { ActiveNode } from "./activeNode";
 import { Position, PositionUtils } from "./position";
 
-export type TriedInvokeExpression = Result<undefined | InvokeExpression, CommonError.CommonError>;
+export type TriedInvokeExpression = Result<InvokeExpression | undefined, CommonError.CommonError>;
 
 export interface InvokeExpression {
     readonly xorNode: TXorNode;
@@ -34,7 +34,7 @@ export function tryInvokeExpression(
 function inspectInvokeExpression(
     nodeIdMapCollection: NodeIdMap.Collection,
     activeNode: ActiveNode,
-): undefined | InvokeExpression {
+): InvokeExpression | undefined {
     const ancestors: ReadonlyArray<TXorNode> = activeNode.ancestry;
     const numAncestors: number = activeNode.ancestry.length;
     const position: Position = activeNode.position;
@@ -73,7 +73,7 @@ function isInvokeExpressionContent(position: Position, xorNode: TXorNode): boole
 
 function maybeInvokeExpressionName(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): string | undefined {
     const invokeExpr: TXorNode = NodeIdMapUtils.expectXorNode(nodeIdMapCollection, nodeId);
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         invokeExpr,
         Ast.NodeKind.InvokeExpression,
     );

--- a/src/inspection/scope/scope.ts
+++ b/src/inspection/scope/scope.ts
@@ -28,7 +28,7 @@ export function tryScope(
     leafNodeIds: ReadonlyArray<number>,
     ancestry: ReadonlyArray<TXorNode>,
     // If a map is given, then it's mutated and returned. Else create and return a new instance.
-    maybeScopeById: undefined | ScopeById,
+    maybeScopeById: ScopeById | undefined,
 ): TriedScope {
     return ResultUtils.ensureResult(settings.localizationTemplates, () =>
         inspectScope(settings, nodeIdMapCollection, leafNodeIds, ancestry, maybeScopeById),
@@ -41,7 +41,7 @@ export function tryScopeForRoot(
     leafNodeIds: ReadonlyArray<number>,
     ancestry: ReadonlyArray<TXorNode>,
     // If a map is given, then it's mutated and returned. Else create and return a new instance.
-    maybeScopeById: undefined | ScopeById,
+    maybeScopeById: ScopeById | undefined,
 ): TriedScopeForRoot {
     if (ancestry.length === 0) {
         throw new CommonError.InvariantError(`ancestry.length should be non-zero`);
@@ -50,7 +50,7 @@ export function tryScopeForRoot(
     const rootId: number = ancestry[0].node.id;
     return ResultUtils.ensureResult(settings.localizationTemplates, () => {
         const inspected: ScopeById = inspectScope(settings, nodeIdMapCollection, leafNodeIds, ancestry, maybeScopeById);
-        const maybeScope: undefined | ScopeItemByKey = inspected.get(rootId);
+        const maybeScope: ScopeItemByKey | undefined = inspected.get(rootId);
         if (maybeScope === undefined) {
             const details: {} = { rootId };
             throw new CommonError.InvariantError(`expected rootId in scope result`, details);
@@ -66,13 +66,13 @@ function inspectScope(
     leafNodeIds: ReadonlyArray<number>,
     ancestry: ReadonlyArray<TXorNode>,
     // If a map is given, then it's mutated and returned. Else create and return a new instance.
-    maybeScopeById: undefined | ScopeById,
+    maybeScopeById: ScopeById | undefined,
 ): ScopeById {
     const rootId: number = ancestry[0].node.id;
 
     let scopeById: ScopeById;
     if (maybeScopeById !== undefined) {
-        const maybeCached: undefined | ScopeItemByKey = maybeScopeById.get(rootId);
+        const maybeCached: ScopeItemByKey | undefined = maybeScopeById.get(rootId);
         if (maybeCached !== undefined) {
             return maybeScopeById;
         }
@@ -145,7 +145,7 @@ function inspectNode(state: ScopeInspectionState, xorNode: TXorNode): void {
 }
 
 function inspectEachExpression(state: ScopeInspectionState, eachExpr: TXorNode): void {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         eachExpr,
         Ast.NodeKind.EachExpression,
     );
@@ -172,7 +172,7 @@ function inspectEachExpression(state: ScopeInspectionState, eachExpr: TXorNode):
 }
 
 function inspectFunctionExpression(state: ScopeInspectionState, fnExpr: TXorNode): void {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         fnExpr,
         Ast.NodeKind.FunctionExpression,
     );
@@ -210,7 +210,7 @@ function inspectFunctionExpression(state: ScopeInspectionState, fnExpr: TXorNode
 }
 
 function inspectLetExpression(state: ScopeInspectionState, letExpr: TXorNode): void {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         letExpr,
         Ast.NodeKind.LetExpression,
     );
@@ -237,7 +237,7 @@ function inspectLetExpression(state: ScopeInspectionState, letExpr: TXorNode): v
 }
 
 function inspectRecordExpressionOrRecordLiteral(state: ScopeInspectionState, record: TXorNode): void {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstAnyNodeKind(record, [
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstAnyNodeKind(record, [
         Ast.NodeKind.RecordExpression,
         Ast.NodeKind.RecordLiteral,
     ]);
@@ -255,7 +255,7 @@ function inspectRecordExpressionOrRecordLiteral(state: ScopeInspectionState, rec
 }
 
 function inspectSection(state: ScopeInspectionState, section: TXorNode): void {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         section,
         Ast.NodeKind.Section,
     );
@@ -310,7 +310,7 @@ function expandScope(
     state: ScopeInspectionState,
     xorNode: TXorNode,
     newEntries: ReadonlyArray<[string, TScopeItem]>,
-    maybeDefaultScope: undefined | ScopeItemByKey,
+    maybeDefaultScope: ScopeItemByKey | undefined,
 ): void {
     const scope: ScopeItemByKey = getOrCreateScope(state, xorNode.node.id, maybeDefaultScope);
     for (const [key, value] of newEntries) {
@@ -323,14 +323,14 @@ function expandChildScope(
     parent: TXorNode,
     childAttributeIds: ReadonlyArray<number>,
     newEntries: ReadonlyArray<[string, TScopeItem]>,
-    maybeDefaultScope: undefined | ScopeItemByKey,
+    maybeDefaultScope: ScopeItemByKey | undefined,
 ): void {
     const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
     const parentId: number = parent.node.id;
 
     // TODO: optimize this
     for (const attributeId of childAttributeIds) {
-        const maybeChild: undefined | TXorNode = NodeIdMapUtils.maybeXorChildByAttributeIndex(
+        const maybeChild: TXorNode | undefined = NodeIdMapUtils.maybeXorChildByAttributeIndex(
             nodeIdMapCollection,
             parentId,
             attributeId,
@@ -346,17 +346,17 @@ function expandChildScope(
 function getOrCreateScope(
     state: ScopeInspectionState,
     nodeId: number,
-    maybeDefaultScope: undefined | ScopeItemByKey,
+    maybeDefaultScope: ScopeItemByKey | undefined,
 ): ScopeItemByKey {
     // If scopeFor has already been called then there should be a nodeId in the deltaScope.
-    const maybeDeltaScope: undefined | ScopeItemByKey = state.deltaScope.get(nodeId);
+    const maybeDeltaScope: ScopeItemByKey | undefined = state.deltaScope.get(nodeId);
     if (maybeDeltaScope !== undefined) {
         return maybeDeltaScope;
     }
 
     // If given a scope with an existing value then assume it's valid.
     // Cache and return.
-    const maybeGivenScope: undefined | ScopeItemByKey = state.givenScope.get(nodeId);
+    const maybeGivenScope: ScopeItemByKey | undefined = state.givenScope.get(nodeId);
     if (maybeGivenScope !== undefined) {
         state.deltaScope.set(nodeId, { ...maybeGivenScope });
         return maybeGivenScope;
@@ -369,7 +369,7 @@ function getOrCreateScope(
     }
 
     // Default to a parent's scope if the node has a parent.
-    const maybeParent: undefined | TXorNode = NodeIdMapUtils.maybeParentXorNode(
+    const maybeParent: TXorNode | undefined = NodeIdMapUtils.maybeParentXorNode(
         state.nodeIdMapCollection,
         nodeId,
         undefined,
@@ -377,14 +377,14 @@ function getOrCreateScope(
     if (maybeParent !== undefined) {
         const parentNodeId: number = maybeParent.node.id;
 
-        const maybeParentDeltaScope: undefined | ScopeItemByKey = state.deltaScope.get(parentNodeId);
+        const maybeParentDeltaScope: ScopeItemByKey | undefined = state.deltaScope.get(parentNodeId);
         if (maybeParentDeltaScope !== undefined) {
             const shallowCopy: ScopeItemByKey = new Map(maybeParentDeltaScope.entries());
             state.deltaScope.set(nodeId, shallowCopy);
             return shallowCopy;
         }
 
-        const maybeParentGivenScope: undefined | ScopeItemByKey = state.givenScope.get(parentNodeId);
+        const maybeParentGivenScope: ScopeItemByKey | undefined = state.givenScope.get(parentNodeId);
         if (maybeParentGivenScope !== undefined) {
             const shallowCopy: ScopeItemByKey = new Map(maybeParentGivenScope.entries());
             state.deltaScope.set(nodeId, shallowCopy);

--- a/src/inspection/type.ts
+++ b/src/inspection/type.ts
@@ -188,7 +188,7 @@ function translateFromChildAttributeIndex(
     parentXorNode: TXorNode,
     attributeIndex: number,
 ): Type.TType {
-    const maybeXorNode: undefined | TXorNode = NodeIdMapUtils.maybeXorChildByAttributeIndex(
+    const maybeXorNode: TXorNode | undefined = NodeIdMapUtils.maybeXorChildByAttributeIndex(
         nodeIdMapCollection,
         parentXorNode.node.id,
         attributeIndex,
@@ -215,12 +215,12 @@ function translateBinOpExpression(
     const parentId: number = xorNode.node.id;
     const children: ReadonlyArray<TXorNode> = NodeIdMapIterator.expectXorChildren(nodeIdMapCollection, parentId);
 
-    const maybeLeft: undefined | TXorNode = children[0];
-    const maybeOperatorKind: undefined | Ast.TBinOpExpressionOperator =
+    const maybeLeft: TXorNode | undefined = children[0];
+    const maybeOperatorKind: Ast.TBinOpExpressionOperator | undefined =
         children[1] === undefined || children[1].kind === XorNodeKind.Context
             ? undefined
             : (children[1].node as Ast.IConstant<Ast.TBinOpExpressionOperator>).constantKind;
-    const maybeRight: undefined | TXorNode = children[2];
+    const maybeRight: TXorNode | undefined = children[2];
 
     // ''
     if (maybeLeft === undefined) {
@@ -236,7 +236,7 @@ function translateBinOpExpression(
         const operatorKind: Ast.TBinOpExpressionOperator = maybeOperatorKind;
 
         const partialLookupKey: string = binOpExpressionPartialLookupKey(leftType.kind, operatorKind);
-        const maybeAllowedTypeKinds: undefined | ReadonlyArray<Type.TypeKind> = BinOpExpressionPartialLookup.get(
+        const maybeAllowedTypeKinds: ReadonlyArray<Type.TypeKind> | undefined = BinOpExpressionPartialLookup.get(
             partialLookupKey,
         );
         if (maybeAllowedTypeKinds === undefined) {
@@ -261,7 +261,7 @@ function translateBinOpExpression(
         const rightType: Type.TType = translateXorNode(nodeIdMapCollection, scopeTypeMap, maybeRight);
 
         const key: string = binOpExpressionLookupKey(leftType.kind, operatorKind, rightType.kind);
-        const maybeResultTypeKind: undefined | Type.TypeKind = BinOpExpressionLookup.get(key);
+        const maybeResultTypeKind: Type.TypeKind | undefined = BinOpExpressionLookup.get(key);
         if (maybeResultTypeKind === undefined) {
             return noneFactory();
         }
@@ -280,7 +280,7 @@ function translateBinOpExpression(
 }
 
 function translateConstant(xorNode: TXorNode): Type.TType {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         xorNode,
         Ast.NodeKind.Constant,
     );
@@ -341,7 +341,7 @@ function translateIfExpression(
     scopeTypeMap: ScopeTypeCacheMap,
     xorNode: TXorNode,
 ): Type.TType {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         xorNode,
         Ast.NodeKind.IfExpression,
     );
@@ -366,7 +366,7 @@ function translateIfExpression(
 }
 
 function translateLiteralExpression(xorNode: TXorNode): Type.TType {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         xorNode,
         Ast.NodeKind.LiteralExpression,
     );
@@ -396,7 +396,7 @@ function translateUnaryExpression(
     scopeTypeMap: ScopeTypeCacheMap,
     xorNode: TXorNode,
 ): Type.TType {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         xorNode,
         Ast.NodeKind.UnaryExpression,
     );
@@ -413,7 +413,7 @@ function translateUnaryExpression(
         return unknownFactory();
     }
 
-    const maybeExpression: undefined | TXorNode = NodeIdMapUtils.maybeXorChildByAttributeIndex(
+    const maybeExpression: TXorNode | undefined = NodeIdMapUtils.maybeXorChildByAttributeIndex(
         nodeIdMapCollection,
         xorNode.node.id,
         1,
@@ -572,7 +572,7 @@ const BinOpExpressionPartialLookup: ReadonlyMap<string, ReadonlyArray<Type.TypeK
                 const potentialNewValue: Type.TypeKind = key.slice(lastDeliminatorIndex + 1) as Type.TypeKind;
 
                 // Add the potentialNewValue if it's a new type.
-                const maybeValues: undefined | ReadonlyArray<Type.TypeKind> = binaryExpressionPartialLookup.get(
+                const maybeValues: ReadonlyArray<Type.TypeKind> | undefined = binaryExpressionPartialLookup.get(
                     partialKey,
                 );
                 if (maybeValues === undefined) {

--- a/src/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -9,7 +9,7 @@ export interface KeyValuePair<T extends Ast.GeneralizedIdentifier | Ast.Identifi
     readonly source: TXorNode;
     readonly key: T;
     readonly keyLiteral: string;
-    readonly maybeValue: undefined | TXorNode;
+    readonly maybeValue: TXorNode | undefined;
 }
 
 export function expectAncestry(nodeIdMapCollection: NodeIdMap.Collection, rootId: number): ReadonlyArray<TXorNode> {
@@ -108,7 +108,7 @@ export function recordKeyValuePairs(
     nodeIdMapCollection: NodeIdMap.Collection,
     record: TXorNode,
 ): ReadonlyArray<KeyValuePair<Ast.GeneralizedIdentifier>> {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstAnyNodeKind(record, [
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstAnyNodeKind(record, [
         Ast.NodeKind.RecordExpression,
         Ast.NodeKind.RecordLiteral,
     ]);
@@ -116,7 +116,7 @@ export function recordKeyValuePairs(
         throw maybeErr;
     }
 
-    const maybeArrayWrapper: undefined | TXorNode = NodeIdMapUtils.maybeWrappedContent(nodeIdMapCollection, record);
+    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeWrappedContent(nodeIdMapCollection, record);
     return maybeArrayWrapper === undefined ? [] : keyValuePairs(nodeIdMapCollection, maybeArrayWrapper);
 }
 
@@ -124,7 +124,7 @@ export function letKeyValuePairs(
     nodeIdMapCollection: NodeIdMap.Collection,
     letExpression: TXorNode,
 ): ReadonlyArray<KeyValuePair<Ast.Identifier>> {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         letExpression,
         Ast.NodeKind.LetExpression,
     );
@@ -132,7 +132,7 @@ export function letKeyValuePairs(
         throw maybeErr;
     }
 
-    const maybeArrayWrapper: undefined | TXorNode = NodeIdMapUtils.maybeXorChildByAttributeIndex(
+    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeXorChildByAttributeIndex(
         nodeIdMapCollection,
         letExpression.node.id,
         1,
@@ -145,7 +145,7 @@ export function sectionMemberKeyValuePairs(
     nodeIdMapCollection: NodeIdMap.Collection,
     section: TXorNode,
 ): ReadonlyArray<KeyValuePair<Ast.Identifier>> {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         section,
         Ast.NodeKind.Section,
     );
@@ -188,7 +188,7 @@ export function sectionMemberKeyValuePairs(
         const keyValuePair: TXorNode = maybeKeyValuePair;
         const keyValuePairNodeId: number = keyValuePair.node.id;
 
-        const maybeKey: undefined | Ast.Identifier = NodeIdMapUtils.maybeAstChildByAttributeIndex(
+        const maybeKey: Ast.Identifier | undefined = NodeIdMapUtils.maybeAstChildByAttributeIndex(
             nodeIdMapCollection,
             keyValuePairNodeId,
             0,
@@ -221,7 +221,7 @@ export function keyValuePairs<T extends Ast.GeneralizedIdentifier | Ast.Identifi
 ): ReadonlyArray<KeyValuePair<T>> {
     const partial: KeyValuePair<T>[] = [];
     for (const keyValuePair of arrayWrapperCsvXorNodes(nodeIdMapCollection, arrayWrapper)) {
-        const maybeKey: undefined | Ast.TNode = NodeIdMapUtils.maybeAstChildByAttributeIndex(
+        const maybeKey: Ast.TNode | undefined = NodeIdMapUtils.maybeAstChildByAttributeIndex(
             nodeIdMapCollection,
             keyValuePair.node.id,
             0,
@@ -252,7 +252,7 @@ export function arrayWrapperCsvXorNodes(
     nodeIdMapCollection: NodeIdMap.Collection,
     arrayWrapper: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         arrayWrapper,
         Ast.NodeKind.ArrayWrapper,
     );
@@ -274,7 +274,7 @@ export function arrayWrapperCsvXorNodes(
                 break;
 
             case XorNodeKind.Context: {
-                const maybeChild: undefined | TXorNode = NodeIdMapUtils.maybeCsvNode(nodeIdMapCollection, csvXorNode);
+                const maybeChild: TXorNode | undefined = NodeIdMapUtils.maybeCsvNode(nodeIdMapCollection, csvXorNode);
                 if (maybeChild !== undefined) {
                     partial.push(maybeChild);
                 }

--- a/src/parser/nodeIdMap/nodeIdMapUtils.ts
+++ b/src/parser/nodeIdMap/nodeIdMapUtils.ts
@@ -473,7 +473,7 @@ export function isTFieldAccessExpression(xorNode: TXorNode): boolean {
     return xorNode.node.kind === Ast.NodeKind.FieldSelector || xorNode.node.kind === Ast.NodeKind.FieldProjection;
 }
 
-export function testAstNodeKind(xorNode: TXorNode, expected: Ast.NodeKind): undefined | CommonError.InvariantError {
+export function testAstNodeKind(xorNode: TXorNode, expected: Ast.NodeKind): CommonError.InvariantError | undefined {
     if (xorNode.node.kind !== expected) {
         const details: {} = {
             expectedNodeKind: expected,
@@ -489,7 +489,7 @@ export function testAstNodeKind(xorNode: TXorNode, expected: Ast.NodeKind): unde
 export function testAstAnyNodeKind(
     xorNode: TXorNode,
     allowedNodeKinds: ReadonlyArray<Ast.NodeKind>,
-): undefined | CommonError.InvariantError {
+): CommonError.InvariantError | undefined {
     if (allowedNodeKinds.indexOf(xorNode.node.kind) !== -1) {
         return undefined;
     }
@@ -535,16 +535,16 @@ export function xorNodeTokenRange(nodeIdMapCollection: Collection, xorNode: TXor
     }
 }
 
-export function recordKey(nodeIdMapCollection: Collection, xorNode: TXorNode): undefined | Ast.GeneralizedIdentifier {
+export function recordKey(nodeIdMapCollection: Collection, xorNode: TXorNode): Ast.GeneralizedIdentifier | undefined {
     return maybeAstChildByAttributeIndex(nodeIdMapCollection, xorNode.node.id, 0, [
         Ast.NodeKind.GeneralizedIdentifier,
     ]) as Ast.GeneralizedIdentifier;
 }
 
-export function maybeWrappedContent(nodeIdMapCollection: Collection, wrapped: TXorNode): undefined | TXorNode {
+export function maybeWrappedContent(nodeIdMapCollection: Collection, wrapped: TXorNode): TXorNode | undefined {
     return maybeXorChildByAttributeIndex(nodeIdMapCollection, wrapped.node.id, 1, [Ast.NodeKind.ArrayWrapper]);
 }
 
-export function maybeCsvNode(nodeIdMapCollection: Collection, csv: TXorNode): undefined | TXorNode {
+export function maybeCsvNode(nodeIdMapCollection: Collection, csv: TXorNode): TXorNode | undefined {
     return maybeXorChildByAttributeIndex(nodeIdMapCollection, csv.node.id, 0, undefined);
 }

--- a/src/task.ts
+++ b/src/task.ts
@@ -13,9 +13,9 @@ import { CommonSettings, LexSettings, ParseSettings } from "./settings";
 export type TriedInspection = Result<InspectionOk, CommonError.CommonError | LexError.LexError | ParseError.ParseError>;
 
 export interface InspectionOk {
-    readonly maybeActiveNode: undefined | ActiveNode;
+    readonly maybeActiveNode: ActiveNode | undefined;
     readonly autocomplete: Inspection.Autocomplete;
-    readonly maybeInvokeExpression: undefined | Inspection.InvokeExpression;
+    readonly maybeInvokeExpression: Inspection.InvokeExpression | undefined;
     readonly scope: Inspection.ScopeItemByKey;
     readonly scopeType: Inspection.ScopeTypeMap;
 }
@@ -90,7 +90,7 @@ export function tryInspection<S extends IParserState = IParserState>(
     }
 
     // We should only get an undefined for activeNode iff the document is empty
-    const maybeActiveNode: undefined | ActiveNode = ActiveNodeUtils.maybeActiveNode(
+    const maybeActiveNode: ActiveNode | undefined = ActiveNodeUtils.maybeActiveNode(
         nodeIdMapCollection,
         leafNodeIds,
         position,
@@ -179,7 +179,7 @@ export function tryLexParseInspection<S extends IParserState = IParserState>(
     position: Inspection.Position,
 ): TriedLexParseInspect<S> {
     const triedLexParse: TriedLexParse<S> = tryLexParse(settings, text);
-    const maybeTriedParse: undefined | TriedParse<S> = maybeTriedParseFromTriedLexParse(triedLexParse);
+    const maybeTriedParse: TriedParse<S> | undefined = maybeTriedParseFromTriedLexParse(triedLexParse);
     // maybeTriedParse is undefined iff maybeLexParse is Err<CommonError | LexError>
     // Err<CommonError | LexError> is a subset of TriedLexParse
     if (maybeTriedParse == undefined) {
@@ -200,7 +200,7 @@ export function tryLexParseInspection<S extends IParserState = IParserState>(
 
 export function maybeTriedParseFromTriedLexParse<S extends IParserState>(
     triedLexParse: TriedLexParse<S>,
-): undefined | TriedParse<S> {
+): TriedParse<S> | undefined {
     let ast: Ast.TDocument;
     let leafNodeIds: ReadonlyArray<number>;
     let nodeIdMapCollection: NodeIdMap.Collection;

--- a/src/test/libraryTest/inspection/autocomplete.ts
+++ b/src/test/libraryTest/inspection/autocomplete.ts
@@ -19,7 +19,7 @@ function expectAutocompleteOk<S extends IParserState>(
     position: Position,
     maybeParseError: ParseError.ParseError<S> | undefined,
 ): ReadonlyArray<Language.KeywordKind> {
-    const maybeActiveNode: undefined | ActiveNode = ActiveNodeUtils.maybeActiveNode(
+    const maybeActiveNode: ActiveNode | undefined = ActiveNodeUtils.maybeActiveNode(
         nodeIdMapCollection,
         leafNodeIds,
         position,

--- a/src/test/libraryTest/inspection/invokeExpression.ts
+++ b/src/test/libraryTest/inspection/invokeExpression.ts
@@ -16,8 +16,8 @@ function expectInvokeExpressionOk(
     nodeIdMapCollection: NodeIdMap.Collection,
     leafNodeIds: ReadonlyArray<number>,
     position: Position,
-): undefined | InvokeExpression {
-    const maybeActiveNode: undefined | ActiveNode = ActiveNodeUtils.maybeActiveNode(
+): InvokeExpression | undefined {
+    const maybeActiveNode: ActiveNode | undefined = ActiveNodeUtils.maybeActiveNode(
         nodeIdMapCollection,
         leafNodeIds,
         position,
@@ -42,7 +42,7 @@ function expectParseOkInvokeExpressionOk<S extends IParserState = IParserState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Position,
-): undefined | InvokeExpression {
+): InvokeExpression | undefined {
     const parseOk: ParseOk<S> = expectParseOk(settings, text);
     return expectInvokeExpressionOk(settings, parseOk.nodeIdMapCollection, parseOk.leafNodeIds, position);
 }
@@ -51,7 +51,7 @@ function expectParseErrInvokeExpressionOk<S extends IParserState = IParserState>
     settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Position,
-): undefined | InvokeExpression {
+): InvokeExpression | undefined {
     const parseError: ParseError.ParseError<S> = expectParseErr(settings, text);
     return expectInvokeExpressionOk(
         settings,
@@ -64,7 +64,7 @@ function expectParseErrInvokeExpressionOk<S extends IParserState = IParserState>
 describe(`subset Inspection - InvokeExpression`, () => {
     it("single invoke expression, no parameters", () => {
         const [text, position]: [string, Inspection.Position] = expectTextWithPosition("Foo(|)");
-        const inspected: undefined | InvokeExpression = expectParseOkInvokeExpressionOk(
+        const inspected: InvokeExpression | undefined = expectParseOkInvokeExpressionOk(
             DefaultSettings,
             text,
             position,
@@ -79,7 +79,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
 
     it("multiple invoke expression, no parameters", () => {
         const [text, position]: [string, Inspection.Position] = expectTextWithPosition("Bar(Foo(|))");
-        const inspected: undefined | InvokeExpression = expectParseOkInvokeExpressionOk(
+        const inspected: InvokeExpression | undefined = expectParseOkInvokeExpressionOk(
             DefaultSettings,
             text,
             position,
@@ -94,7 +94,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
 
     it("single invoke expression - Foo(a|)", () => {
         const [text, position]: [string, Inspection.Position] = expectTextWithPosition("Foo(a|)");
-        const inspected: undefined | InvokeExpression = expectParseOkInvokeExpressionOk(
+        const inspected: InvokeExpression | undefined = expectParseOkInvokeExpressionOk(
             DefaultSettings,
             text,
             position,
@@ -111,7 +111,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
 
     it("single invoke expression - Foo(a|,)", () => {
         const [text, position]: [string, Inspection.Position] = expectTextWithPosition("Foo(a|,)");
-        const inspected: undefined | InvokeExpression = expectParseErrInvokeExpressionOk(
+        const inspected: InvokeExpression | undefined = expectParseErrInvokeExpressionOk(
             DefaultSettings,
             text,
             position,
@@ -128,7 +128,7 @@ describe(`subset Inspection - InvokeExpression`, () => {
 
     it("single invoke expression - Foo(a,|)", () => {
         const [text, position]: [string, Inspection.Position] = expectTextWithPosition("Foo(a,|)");
-        const inspected: undefined | InvokeExpression = expectParseErrInvokeExpressionOk(
+        const inspected: InvokeExpression | undefined = expectParseErrInvokeExpressionOk(
             DefaultSettings,
             text,
             position,

--- a/src/test/libraryTest/inspection/scope.ts
+++ b/src/test/libraryTest/inspection/scope.ts
@@ -34,7 +34,7 @@ interface AbridgedEachScopeItem extends IAbridgedNodeScopeItem {
 interface AbridgedKeyValuePairScopeItem extends IAbridgedNodeScopeItem {
     readonly kind: ScopeItemKind.KeyValuePair;
     readonly keyNodeId: number;
-    readonly maybeValueNodeId: undefined | number;
+    readonly maybeValueNodeId: number | undefined;
 }
 
 interface AbridgedParameterScopeItem extends IAbridgedNodeScopeItem {
@@ -135,7 +135,7 @@ function expectScopeForNodeOk(
     leafNodeIds: ReadonlyArray<number>,
     position: Position,
 ): ScopeItemByKey {
-    const maybeActiveNode: undefined | ActiveNode = ActiveNodeUtils.maybeActiveNode(
+    const maybeActiveNode: ActiveNode | undefined = ActiveNodeUtils.maybeActiveNode(
         nodeIdMapCollection,
         leafNodeIds,
         position,

--- a/src/test/libraryTest/inspection/type.ts
+++ b/src/test/libraryTest/inspection/type.ts
@@ -20,7 +20,7 @@ function expectScopeTypeOk(
     leafNodeIds: ReadonlyArray<number>,
     position: Position,
 ): ScopeTypeMap {
-    const maybeActiveNode: undefined | ActiveNode = ActiveNodeUtils.maybeActiveNode(
+    const maybeActiveNode: ActiveNode | undefined = ActiveNodeUtils.maybeActiveNode(
         nodeIdMapCollection,
         leafNodeIds,
         position,
@@ -50,7 +50,7 @@ function expectScopeTypeOk(
 }
 
 function actualFactoryFn(inspected: ScopeTypeMap): Type.TType {
-    const maybeBar: undefined | Type.TType = inspected.get("__bar");
+    const maybeBar: Type.TType | undefined = inspected.get("__bar");
     if (!(maybeBar !== undefined)) {
         throw new Error(`AssertFailed: maybebar !== undefined`);
     }

--- a/src/type/inspector/functionExpressionInspector.ts
+++ b/src/type/inspector/functionExpressionInspector.ts
@@ -16,14 +16,14 @@ export interface InspectedFunctionParameter {
     readonly name: Ast.Identifier;
     readonly isOptional: boolean;
     readonly isNullable: boolean;
-    readonly maybeType: undefined | Type.TypeKind;
+    readonly maybeType: Type.TypeKind | undefined;
 }
 
 export function inspectFunctionExpression(
     nodeIdMapCollection: NodeIdMap.Collection,
     fnExpr: TXorNode,
 ): InspectedFunctionExpression {
-    const maybeErr: undefined | CommonError.InvariantError = NodeIdMapUtils.testAstNodeKind(
+    const maybeErr: CommonError.InvariantError | undefined = NodeIdMapUtils.testAstNodeKind(
         fnExpr,
         Ast.NodeKind.FunctionExpression,
     );
@@ -35,7 +35,7 @@ export function inspectFunctionExpression(
     // Iterates all parameters as TXorNodes if they exist, otherwise early exists from an empty list.
     for (const parameter of functionParameterXorNodes(nodeIdMapCollection, fnExpr)) {
         // A parameter isn't examinable if it doesn't have an Ast.Identifier for its name.
-        const maybeExaminable: undefined | InspectedFunctionParameter = examineParameter(
+        const maybeExaminable: InspectedFunctionParameter | undefined = examineParameter(
             nodeIdMapCollection,
             parameter,
         );
@@ -44,7 +44,7 @@ export function inspectFunctionExpression(
         }
     }
 
-    const maybeReturnType: undefined | Ast.TNode = NodeIdMapUtils.maybeAstChildByAttributeIndex(
+    const maybeReturnType: Ast.TNode | undefined = NodeIdMapUtils.maybeAstChildByAttributeIndex(
         nodeIdMapCollection,
         fnExpr.node.id,
         1,
@@ -75,7 +75,7 @@ function functionParameterXorNodes(
     nodeIdMapCollection: NodeIdMap.Collection,
     fnExpr: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    const maybeParameterList: undefined | TXorNode = NodeIdMapUtils.maybeXorChildByAttributeIndex(
+    const maybeParameterList: TXorNode | undefined = NodeIdMapUtils.maybeXorChildByAttributeIndex(
         nodeIdMapCollection,
         fnExpr.node.id,
         0,
@@ -84,7 +84,7 @@ function functionParameterXorNodes(
     if (maybeParameterList === undefined) {
         return [];
     }
-    const maybeWrappedContent: undefined | TXorNode = NodeIdMapUtils.maybeWrappedContent(
+    const maybeWrappedContent: TXorNode | undefined = NodeIdMapUtils.maybeWrappedContent(
         nodeIdMapCollection,
         maybeParameterList,
     );
@@ -97,7 +97,7 @@ function functionParameterXorNodes(
 function examineParameter(
     nodeIdMapCollection: NodeIdMap.Collection,
     parameter: TXorNode,
-): undefined | InspectedFunctionParameter {
+): InspectedFunctionParameter | undefined {
     switch (parameter.kind) {
         case XorNodeKind.Ast:
             return examineAstParameter(parameter.node as Ast.IParameter<Ast.AsNullablePrimitiveType>);
@@ -112,7 +112,7 @@ function examineParameter(
 
 function examineAstParameter(node: Ast.IParameter<Ast.AsNullablePrimitiveType>): InspectedFunctionParameter {
     let isNullable: boolean;
-    let maybeType: undefined | Type.TypeKind;
+    let maybeType: Type.TypeKind | undefined;
 
     const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = node.maybeParameterType;
     if (maybeParameterType !== undefined) {
@@ -137,13 +137,13 @@ function examineAstParameter(node: Ast.IParameter<Ast.AsNullablePrimitiveType>):
 function examineContextParameter(
     nodeIdMapCollection: NodeIdMap.Collection,
     parameter: ParseContext.Node,
-): undefined | InspectedFunctionParameter {
+): InspectedFunctionParameter | undefined {
     let name: Ast.Identifier;
     let isOptional: boolean;
     let isNullable: boolean;
-    let maybeType: undefined | Type.TypeKind;
+    let maybeType: Type.TypeKind | undefined;
 
-    const maybeName: undefined | Ast.TNode = NodeIdMapUtils.maybeAstChildByAttributeIndex(
+    const maybeName: Ast.TNode | undefined = NodeIdMapUtils.maybeAstChildByAttributeIndex(
         nodeIdMapCollection,
         parameter.id,
         1,
@@ -154,7 +154,7 @@ function examineContextParameter(
     }
     name = maybeName as Ast.Identifier;
 
-    const maybeOptional: undefined | Ast.TNode = NodeIdMapUtils.maybeAstChildByAttributeIndex(
+    const maybeOptional: Ast.TNode | undefined = NodeIdMapUtils.maybeAstChildByAttributeIndex(
         nodeIdMapCollection,
         parameter.id,
         0,
@@ -162,7 +162,7 @@ function examineContextParameter(
     );
     isOptional = maybeOptional !== undefined;
 
-    const maybeParameterType: undefined | Ast.TNode = NodeIdMapUtils.maybeAstChildByAttributeIndex(
+    const maybeParameterType: Ast.TNode | undefined = NodeIdMapUtils.maybeAstChildByAttributeIndex(
         nodeIdMapCollection,
         parameter.id,
         2,

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -36,7 +36,7 @@ export const enum ExtendedTypeKind {
 
 export interface IType {
     readonly kind: TypeKind;
-    readonly maybeExtendedKind: undefined | ExtendedTypeKind;
+    readonly maybeExtendedKind: ExtendedTypeKind | undefined;
     readonly isNullable: boolean;
 }
 

--- a/src/type/typesUtils.ts
+++ b/src/type/typesUtils.ts
@@ -31,7 +31,7 @@ export function typeKindFromLiteralKind(
 
 export function maybePrimitiveTypeConstantKindFromTypeKind(
     typeKind: Type.TypeKind,
-): undefined | Ast.PrimitiveTypeConstantKind {
+): Ast.PrimitiveTypeConstantKind | undefined {
     switch (typeKind) {
         case Type.TypeKind.Action:
             return Ast.PrimitiveTypeConstantKind.Action;


### PR DESCRIPTION
Previously the code was a mix of `T | undefined` and `undefined | T`. It's now standardized to `T | undefined`.