### PR TITLE
Issue142 - Scoping to Specific Language Components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.1.50",
+    "version": "0.1.51",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/parser/IParser.ts
+++ b/src/parser/IParser.ts
@@ -26,6 +26,8 @@ export interface ParseOk<S extends IParserState = IParserState> {
 }
 
 export interface IParser<State extends IParserState = IParserState> {
+    readonly read: (state: State, parser: IParser<State>) => TriedParse<State>;
+
     // 12.1.6 Identifiers
     readonly readIdentifier: (state: State, parser: IParser<State>) => Ast.Identifier;
     readonly readGeneralizedIdentifier: (state: State, parser: IParser<State>) => Ast.GeneralizedIdentifier;

--- a/src/parser/IParser/IParser.ts
+++ b/src/parser/IParser/IParser.ts
@@ -20,8 +20,6 @@ export const enum BracketDisambiguation {
 
 export interface ParseOk<S extends IParserState = IParserState> {
     readonly ast: Ast.TNode;
-    readonly nodeIdMapCollection: NodeIdMap.Collection;
-    readonly leafNodeIds: ReadonlyArray<number>;
     readonly state: S;
 }
 

--- a/src/parser/IParser/IParser.ts
+++ b/src/parser/IParser/IParser.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IParserState, NodeIdMap, ParseError } from "..";
+import { IParserState, ParseError } from "..";
 import { Result } from "../../common";
 import { Ast } from "../../language";
 

--- a/src/parser/IParser/IParser.ts
+++ b/src/parser/IParser/IParser.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IParserState, NodeIdMap, ParseError } from ".";
-import { Result } from "../common";
-import { Ast } from "../language";
+import { IParserState, NodeIdMap, ParseError } from "..";
+import { Result } from "../../common";
+import { Ast } from "../../language";
 
 export type TriedParse<S extends IParserState = IParserState> = Result<ParseOk<S>, ParseError.TParseError<S>>;
 
@@ -19,14 +19,14 @@ export const enum BracketDisambiguation {
 }
 
 export interface ParseOk<S extends IParserState = IParserState> {
-    readonly ast: Ast.TDocument;
+    readonly ast: Ast.TNode;
     readonly nodeIdMapCollection: NodeIdMap.Collection;
     readonly leafNodeIds: ReadonlyArray<number>;
     readonly state: S;
 }
 
 export interface IParser<State extends IParserState = IParserState> {
-    readonly read: (state: State, parser: IParser<State>) => TriedParse<State>;
+    readonly read: (state: State, parser: IParser<State>) => Ast.TNode;
 
     // 12.1.6 Identifiers
     readonly readIdentifier: (state: State, parser: IParser<State>) => Ast.Identifier;

--- a/src/parser/IParser/IParser.ts
+++ b/src/parser/IParser/IParser.ts
@@ -34,7 +34,7 @@ export interface IParser<State extends IParserState = IParserState> {
     readonly readKeyword: (state: State, parser: IParser<State>) => Ast.IdentifierExpression;
 
     // 12.2.1 Documents
-    readonly readDocument: (state: State, parser: IParser<State>) => TriedParse<State>;
+    readonly readDocument: (state: State, parser: IParser<State>) => Ast.TDocument;
 
     // 12.2.2 Section Documents
     readonly readSectionDocument: (state: State, parser: IParser<State>) => Ast.Section;

--- a/src/parser/IParser/IParserUtils.ts
+++ b/src/parser/IParser/IParserUtils.ts
@@ -11,7 +11,7 @@ export function tryRead<State extends IParserState = IParserState>(
     state: State,
     parser: IParser<State>,
 ): TriedParse<State> {
-    let node: Ast.TNode = parser.read(state, parser);
+    let node: Ast.TNode;
 
     try {
         node = parser.read(state, parser);

--- a/src/parser/IParser/IParserUtils.ts
+++ b/src/parser/IParser/IParserUtils.ts
@@ -16,7 +16,13 @@ export function tryRead<State extends IParserState = IParserState>(
     try {
         node = parser.read(state, parser);
     } catch (err) {
-        return ResultUtils.errFactory(CommonError.ensureCommonError(state.localizationTemplates, err));
+        let convertedError: ParseError.TParseError<State>;
+        if (ParseError.isTInnerParseError(err)) {
+            convertedError = new ParseError.ParseError(err, state);
+        } else {
+            convertedError = CommonError.ensureCommonError(state.localizationTemplates, err);
+        }
+        return ResultUtils.errFactory(convertedError);
     }
 
     const maybeCommonErr: CommonError.InvariantError | undefined = IParserStateUtils.testNoOpenContext(state);

--- a/src/parser/IParser/IParserUtils.ts
+++ b/src/parser/IParser/IParserUtils.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ParseError } from "..";
+import { CommonError, ResultUtils } from "../../common";
+import { Ast } from "../../language";
+import { IParserState, IParserStateUtils } from "../IParserState";
+import { IParser, TriedParse } from "./IParser";
+
+export function tryRead<State extends IParserState = IParserState>(
+    state: State,
+    parser: IParser<State>,
+): TriedParse<State> {
+    let node: Ast.TNode = parser.read(state, parser);
+
+    try {
+        node = parser.read(state, parser);
+    } catch (err) {
+        return ResultUtils.errFactory(CommonError.ensureCommonError(state.localizationTemplates, err));
+    }
+
+    const maybeCommonErr: CommonError.InvariantError | undefined = IParserStateUtils.testNoOpenContext(state);
+    if (maybeCommonErr) {
+        throw maybeCommonErr;
+    }
+
+    const maybeLeftoverErr: ParseError.UnusedTokensRemainError | undefined = IParserStateUtils.testNoMoreTokens(state);
+    if (maybeLeftoverErr) {
+        throw maybeLeftoverErr;
+    }
+
+    return ResultUtils.okFactory({
+        ast: node,
+        nodeIdMapCollection: state.contextState.nodeIdMapCollection,
+        leafNodeIds: state.contextState.leafNodeIds,
+        state,
+    });
+}

--- a/src/parser/IParser/index.ts
+++ b/src/parser/IParser/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as IParserUtils from "./IParserUtils";
+
+export { IParserUtils };
+export * from "./IParser";

--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -392,6 +392,18 @@ export function testNoMoreTokens(state: IParserState): ParseError.UnusedTokensRe
     }
 }
 
+export function testNoOpenContext(state: IParserState): CommonError.InvariantError | undefined {
+    if (state.maybeCurrentContextNode !== undefined) {
+        const details: {} = { maybeContextNode: state.maybeCurrentContextNode };
+        return new CommonError.InvariantError(
+            "maybeContextNode should be falsey, there shouldn't be an open context",
+            details,
+        );
+    } else {
+        return undefined;
+    }
+}
+
 // -------------------------------------
 // ---------- Error factories ----------
 // -------------------------------------

--- a/src/parser/IParserState/index.ts
+++ b/src/parser/IParserState/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as IParserStateUtils from "./IParserStateUtils";
 
 export { IParserStateUtils };

--- a/src/parser/parsers/combinatorialParser.ts
+++ b/src/parser/parsers/combinatorialParser.ts
@@ -22,8 +22,9 @@ import { IParserState, IParserStateUtils } from "../IParserState";
 //
 // 2)
 // readUnaryExpression uses limited look ahead to eliminate several function calls on the call stack.
-export let CombinatorialParser: IParser<IParserState> = {
+export const CombinatorialParser: IParser<IParserState> = {
     ...Naive,
+    read: Naive.readDocument,
 
     // 12.2.3.2 Logical expressions
     readLogicalExpression: (state: IParserState, parser: IParser<IParserState>) =>

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -139,15 +139,16 @@ export function readKeyword<S extends IParserState = IParserState>(
 // ---------- 12.2.1 Documents ----------
 // --------------------------------------
 
-export function readDocument<S extends IParserState = IParserState>(state: S, parser: IParser<S>): TriedParse<S> {
-    let triedReadDocument: Result<Ast.TDocument, Error>;
+export function readDocument<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TDocument {
+    let document: Ast.TDocument;
 
     // Try parsing as an Expression document first.
     // If Expression document fails (including UnusedTokensRemainError) then try parsing a SectionDocument.
     // If both fail then return the error which parsed more tokens.
     try {
-        triedReadDocument = ResultUtils.okFactory(parser.readExpression(state, parser));
-        const maybeErr: ParseError.UnusedTokensRemainError | undefined = IParserStateUtils.testNoMoreTokens(state);
+        document = parser.readExpression(state, parser);
+        const maybeErr: Error | undefined =
+            IParserStateUtils.testNoMoreTokens(state) || IParserStateUtils.testNoOpenContext(state);
         if (maybeErr) {
             throw maybeErr;
         }
@@ -168,8 +169,9 @@ export function readDocument<S extends IParserState = IParserState>(state: S, pa
         }
 
         try {
-            triedReadDocument = ResultUtils.okFactory(readSectionDocument(state, parser));
-            const maybeErr: ParseError.UnusedTokensRemainError | undefined = IParserStateUtils.testNoMoreTokens(state);
+            document = readSectionDocument(state, parser);
+            const maybeErr: Error | undefined =
+                IParserStateUtils.testNoMoreTokens(state) || IParserStateUtils.testNoOpenContext(state);
             if (maybeErr) {
                 throw maybeErr;
             }
@@ -183,38 +185,11 @@ export function readDocument<S extends IParserState = IParserState>(state: S, pa
                 triedError = sectionError;
             }
 
-            triedReadDocument = ResultUtils.errFactory(triedError);
+            throw triedError;
         }
     }
 
-    if (ResultUtils.isErr(triedReadDocument)) {
-        const currentError: Error = triedReadDocument.error;
-        let convertedError: ParseError.TParseError<S>;
-        if (ParseError.isTInnerParseError(currentError)) {
-            convertedError = new ParseError.ParseError(currentError, state);
-        } else {
-            convertedError = CommonError.ensureCommonError(state.localizationTemplates, currentError);
-        }
-
-        return ResultUtils.errFactory(convertedError);
-    }
-    const document: Ast.TDocument = triedReadDocument.value;
-
-    if (state.maybeCurrentContextNode !== undefined) {
-        const details: {} = { maybeContextNode: state.maybeCurrentContextNode };
-        throw new CommonError.InvariantError(
-            "maybeContextNode should be falsey, there shouldn't be an open context",
-            details,
-        );
-    }
-
-    const contextState: ParseContext.State = state.contextState;
-    return ResultUtils.okFactory({
-        ast: document,
-        nodeIdMapCollection: contextState.nodeIdMapCollection,
-        leafNodeIds: contextState.leafNodeIds,
-        state,
-    });
+    return document;
 }
 
 // ----------------------------------------------

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -6,7 +6,7 @@ import { Language } from "../..";
 import { CommonError, isNever, Result, ResultUtils, TypeScriptUtils } from "../../common";
 import { Ast, AstUtils } from "../../language";
 import { LexerSnapshot } from "../../lexer";
-import { BracketDisambiguation, IParser, ParenthesisDisambiguation, TriedParse } from "../IParser";
+import { BracketDisambiguation, IParser, ParenthesisDisambiguation } from "../IParser";
 import { IParserState, IParserStateUtils } from "../IParserState";
 import { NodeIdMapIterator } from "../nodeIdMap";
 

--- a/src/parser/parsers/recursiveDescentParser.ts
+++ b/src/parser/parsers/recursiveDescentParser.ts
@@ -5,4 +5,7 @@ import { Naive } from ".";
 import { IParser } from "../IParser";
 import { IParserState } from "../IParserState";
 
-export let RecursiveDescentParser: IParser<IParserState> = { ...Naive };
+export let RecursiveDescentParser: IParser<IParserState> = {
+    ...Naive,
+    read: Naive.readDocument,
+};

--- a/src/task.ts
+++ b/src/task.ts
@@ -7,7 +7,17 @@ import { StartOfDoctumentKeywords } from "./inspection";
 import { ActiveNode, ActiveNodeUtils } from "./inspection/activeNode";
 import { Ast } from "./language";
 import { Lexer, LexError, LexerSnapshot, TriedLexerSnapshot } from "./lexer";
-import { IParser, IParserState, NodeIdMap, ParseContext, ParseError, ParseOk, TriedParse, TXorNode } from "./parser";
+import {
+    IParser,
+    IParserState,
+    IParserUtils,
+    NodeIdMap,
+    ParseContext,
+    ParseError,
+    ParseOk,
+    TriedParse,
+    TXorNode,
+} from "./parser";
 import { CommonSettings, LexSettings, ParseSettings } from "./settings";
 
 export type TriedInspection = Result<InspectionOk, CommonError.CommonError | LexError.LexError | ParseError.ParseError>;
@@ -56,8 +66,8 @@ export function tryParse<S extends IParserState = IParserState>(
     lexerSnapshot: LexerSnapshot,
 ): TriedParse<S> {
     const parser: IParser<S> = settings.parser;
-    const parserState: S = settings.newParserState(settings, lexerSnapshot);
-    return parser.readDocument(parserState, parser);
+    const state: S = settings.newParserState(settings, lexerSnapshot);
+    return IParserUtils.tryRead(state, parser);
 }
 
 export function tryInspection<S extends IParserState = IParserState>(
@@ -201,7 +211,7 @@ export function tryLexParseInspection<S extends IParserState = IParserState>(
 export function maybeTriedParseFromTriedLexParse<S extends IParserState>(
     triedLexParse: TriedLexParse<S>,
 ): TriedParse<S> | undefined {
-    let ast: Ast.TDocument;
+    let ast: Ast.TNode;
     let leafNodeIds: ReadonlyArray<number>;
     let nodeIdMapCollection: NodeIdMap.Collection;
     let state: S;

--- a/src/task.ts
+++ b/src/task.ts
@@ -95,8 +95,8 @@ export function tryInspection<S extends IParserState = IParserState>(
         leafNodeIds = context.leafNodeIds;
     } else {
         const parseOk: ParseOk<S> = triedParse.value;
-        nodeIdMapCollection = parseOk.nodeIdMapCollection;
-        leafNodeIds = parseOk.leafNodeIds;
+        nodeIdMapCollection = parseOk.state.contextState.nodeIdMapCollection;
+        leafNodeIds = parseOk.state.contextState.leafNodeIds;
     }
 
     // We should only get an undefined for activeNode iff the document is empty
@@ -230,8 +230,8 @@ export function maybeTriedParseFromTriedLexParse<S extends IParserState>(
     } else {
         const lexParseOk: LexParseOk<S> = triedLexParse.value;
         ast = lexParseOk.ast;
-        nodeIdMapCollection = lexParseOk.nodeIdMapCollection;
-        leafNodeIds = lexParseOk.leafNodeIds;
+        nodeIdMapCollection = lexParseOk.state.contextState.nodeIdMapCollection;
+        leafNodeIds = lexParseOk.state.contextState.leafNodeIds;
         state = lexParseOk.state;
     }
 

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -6,7 +6,7 @@ import "mocha";
 import { Inspection, Task } from "..";
 import { ResultUtils } from "../common";
 import { Lexer, LexerSnapshot, TriedLexerSnapshot } from "../lexer";
-import { IParserState, ParseError, ParseOk, TriedParse } from "../parser";
+import { IParserState, IParserUtils, ParseError, ParseOk, TriedParse } from "../parser";
 import { LexSettings, ParseSettings } from "../settings";
 
 export function expectDeepEqual<X, Y>(partial: X, expected: Y, actualFactoryFn: (partial: X) => Y): void {
@@ -86,5 +86,5 @@ function expectTriedParse<S extends IParserState = IParserState>(
     const lexerSnapshot: LexerSnapshot = triedSnapshot.value;
 
     const parserState: S = settings.newParserState(settings, lexerSnapshot);
-    return settings.parser.readDocument(parserState, settings.parser);
+    return IParserUtils.tryRead(parserState, settings.parser);
 }

--- a/src/test/libraryTest/inspection/autocomplete.ts
+++ b/src/test/libraryTest/inspection/autocomplete.ts
@@ -8,7 +8,7 @@ import { ResultUtils } from "../../../common";
 import { Position, StartOfDoctumentKeywords, TriedAutocomplete } from "../../../inspection";
 import { ActiveNode, ActiveNodeUtils } from "../../../inspection/activeNode";
 import { Ast } from "../../../language";
-import { IParserState, NodeIdMap, ParseError, ParseOk } from "../../../parser";
+import { IParserState, NodeIdMap, ParseContext, ParseError } from "../../../parser";
 import { CommonSettings, DefaultSettings, LexSettings, ParseSettings } from "../../../settings";
 import { expectParseErr, expectParseOk, expectTextWithPosition } from "../../common";
 
@@ -45,8 +45,14 @@ function expectParseOkAutocompleteOk<S extends IParserState = IParserState>(
     text: string,
     position: Position,
 ): ReadonlyArray<Language.KeywordKind> {
-    const parseOk: ParseOk<S> = expectParseOk(settings, text);
-    return expectAutocompleteOk(settings, parseOk.nodeIdMapCollection, parseOk.leafNodeIds, position, undefined);
+    const contextState: ParseContext.State = expectParseOk(settings, text).state.contextState;
+    return expectAutocompleteOk(
+        settings,
+        contextState.nodeIdMapCollection,
+        contextState.leafNodeIds,
+        position,
+        undefined,
+    );
 }
 
 function expectParseErrAutocompleteOk<S extends IParserState = IParserState>(
@@ -55,10 +61,11 @@ function expectParseErrAutocompleteOk<S extends IParserState = IParserState>(
     position: Position,
 ): ReadonlyArray<Language.KeywordKind> {
     const parseError: ParseError.ParseError<S> = expectParseErr(settings, text);
+    const contextState: ParseContext.State = expectParseErr(settings, text).state.contextState;
     return expectAutocompleteOk(
         settings,
-        parseError.state.contextState.nodeIdMapCollection,
-        parseError.state.contextState.leafNodeIds,
+        contextState.nodeIdMapCollection,
+        contextState.leafNodeIds,
         position,
         parseError,
     );

--- a/src/test/libraryTest/inspection/invokeExpression.ts
+++ b/src/test/libraryTest/inspection/invokeExpression.ts
@@ -7,7 +7,7 @@ import { Inspection } from "../../..";
 import { ResultUtils } from "../../../common";
 import { InvokeExpression, Position } from "../../../inspection";
 import { ActiveNode, ActiveNodeUtils } from "../../../inspection/activeNode";
-import { IParserState, NodeIdMap, ParseError, ParseOk } from "../../../parser";
+import { IParserState, NodeIdMap, ParseContext } from "../../../parser";
 import { CommonSettings, DefaultSettings, LexSettings, ParseSettings } from "../../../settings";
 import { expectParseErr, expectParseOk, expectTextWithPosition } from "../../common";
 
@@ -43,8 +43,8 @@ function expectParseOkInvokeExpressionOk<S extends IParserState = IParserState>(
     text: string,
     position: Position,
 ): InvokeExpression | undefined {
-    const parseOk: ParseOk<S> = expectParseOk(settings, text);
-    return expectInvokeExpressionOk(settings, parseOk.nodeIdMapCollection, parseOk.leafNodeIds, position);
+    const contextState: ParseContext.State = expectParseOk(settings, text).state.contextState;
+    return expectInvokeExpressionOk(settings, contextState.nodeIdMapCollection, contextState.leafNodeIds, position);
 }
 
 function expectParseErrInvokeExpressionOk<S extends IParserState = IParserState>(
@@ -52,13 +52,8 @@ function expectParseErrInvokeExpressionOk<S extends IParserState = IParserState>
     text: string,
     position: Position,
 ): InvokeExpression | undefined {
-    const parseError: ParseError.ParseError<S> = expectParseErr(settings, text);
-    return expectInvokeExpressionOk(
-        settings,
-        parseError.state.contextState.nodeIdMapCollection,
-        parseError.state.contextState.leafNodeIds,
-        position,
-    );
+    const contextState: ParseContext.State = expectParseErr(settings, text).state.contextState;
+    return expectInvokeExpressionOk(settings, contextState.nodeIdMapCollection, contextState.leafNodeIds, position);
 }
 
 describe(`subset Inspection - InvokeExpression`, () => {

--- a/src/test/libraryTest/inspection/scope.ts
+++ b/src/test/libraryTest/inspection/scope.ts
@@ -7,7 +7,7 @@ import { isNever, ResultUtils } from "../../../common";
 import { Position, ScopeItemByKey, ScopeItemKind } from "../../../inspection";
 import { ActiveNode, ActiveNodeUtils } from "../../../inspection/activeNode";
 import { Ast } from "../../../language";
-import { IParserState, NodeIdMap, ParseError, ParseOk } from "../../../parser";
+import { IParserState, NodeIdMap, ParseContext } from "../../../parser";
 import { CommonSettings, DefaultSettings, LexSettings, ParseSettings } from "../../../settings";
 import { expectDeepEqual, expectParseErr, expectParseOk, expectTextWithPosition } from "../../common";
 
@@ -163,8 +163,8 @@ export function expectParseOkScopeOk<S extends IParserState = IParserState>(
     text: string,
     position: Position,
 ): ScopeItemByKey {
-    const parseOk: ParseOk<S> = expectParseOk(settings, text);
-    return expectScopeForNodeOk(settings, parseOk.nodeIdMapCollection, parseOk.leafNodeIds, position);
+    const contextState: ParseContext.State = expectParseOk(settings, text).state.contextState;
+    return expectScopeForNodeOk(settings, contextState.nodeIdMapCollection, contextState.leafNodeIds, position);
 }
 
 export function expectParseErrScopeOk<S extends IParserState = IParserState>(
@@ -172,13 +172,8 @@ export function expectParseErrScopeOk<S extends IParserState = IParserState>(
     text: string,
     position: Position,
 ): ScopeItemByKey {
-    const parseError: ParseError.ParseError<S> = expectParseErr(settings, text);
-    return expectScopeForNodeOk(
-        settings,
-        parseError.state.contextState.nodeIdMapCollection,
-        parseError.state.contextState.leafNodeIds,
-        position,
-    );
+    const contextState: ParseContext.State = expectParseErr(settings, text).state.contextState;
+    return expectScopeForNodeOk(settings, contextState.nodeIdMapCollection, contextState.leafNodeIds, position);
 }
 
 describe(`subset Inspection - Scope - Identifier`, () => {

--- a/src/test/libraryTest/inspection/type.ts
+++ b/src/test/libraryTest/inspection/type.ts
@@ -149,7 +149,7 @@ describe(`Inspection - Scope - Type`, () => {
         });
     });
 
-    describe(`WIP ${Ast.NodeKind.IfExpression}`, () => {
+    describe(`${Ast.NodeKind.IfExpression}`, () => {
         it(`if true then 1 else false`, () => {
             const expression: string = `if true then 1 else false`;
             const expected: Type.TType = {

--- a/src/test/libraryTest/inspection/type.ts
+++ b/src/test/libraryTest/inspection/type.ts
@@ -7,7 +7,7 @@ import { CommonError, Result, ResultUtils } from "../../../common";
 import { Position, ScopeItemByKey, ScopeTypeMap, TriedScopeType } from "../../../inspection";
 import { ActiveNode, ActiveNodeUtils } from "../../../inspection/activeNode";
 import { Ast } from "../../../language";
-import { IParserState, NodeIdMap, ParseError, ParseOk } from "../../../parser";
+import { NodeIdMap, ParseContext } from "../../../parser";
 import { CommonSettings, DefaultSettings } from "../../../settings";
 import { Type } from "../../../type";
 import { expectDeepEqual, expectParseErr, expectParseOk, expectTextWithPosition } from "../../common";
@@ -64,11 +64,11 @@ function wrapExpression(expression: string): string {
 
 function expectParseOkTypeOk(expression: string, expected: AbridgedScopeType): void {
     const [text, position]: [string, Inspection.Position] = expectTextWithPosition(wrapExpression(expression));
-    const parseOk: ParseOk<IParserState> = expectParseOk(DefaultSettings, text);
+    const contextState: ParseContext.State = expectParseOk(DefaultSettings, text).state.contextState;
     const scopeTypeMap: ScopeTypeMap = expectTypeOk(
         DefaultSettings,
-        parseOk.nodeIdMapCollection,
-        parseOk.leafNodeIds,
+        contextState.nodeIdMapCollection,
+        contextState.leafNodeIds,
         position,
     );
     expectDeepEqual(scopeTypeMap, expected, actualFactoryFn);
@@ -76,11 +76,11 @@ function expectParseOkTypeOk(expression: string, expected: AbridgedScopeType): v
 
 function expectParseErrTypeOk(expression: string, expected: AbridgedScopeType): void {
     const [text, position]: [string, Inspection.Position] = expectTextWithPosition(wrapExpression(expression));
-    const parseErr: ParseError.ParseError<IParserState> = expectParseErr(DefaultSettings, text);
+    const contextState: ParseContext.State = expectParseErr(DefaultSettings, text).state.contextState;
     const scopeTypeMap: ScopeTypeMap = expectTypeOk(
         DefaultSettings,
-        parseErr.state.contextState.nodeIdMapCollection,
-        parseErr.state.contextState.leafNodeIds,
+        contextState.nodeIdMapCollection,
+        contextState.leafNodeIds,
         position,
     );
     expectDeepEqual(scopeTypeMap, expected, actualFactoryFn);

--- a/src/test/libraryTest/parser/children.ts
+++ b/src/test/libraryTest/parser/children.ts
@@ -16,9 +16,9 @@ interface ChildIdsByIdEntry {
 
 function acutalFactoryFn<S extends IParserState = IParserState>(lexParseOk: Task.LexParseOk<S>): ChildIdsByIdEntry[] {
     const actual: ChildIdsByIdEntry[] = [];
-    const astNodeById: NodeIdMap.AstNodeById = lexParseOk.nodeIdMapCollection.astNodeById;
+    const astNodeById: NodeIdMap.AstNodeById = lexParseOk.state.contextState.nodeIdMapCollection.astNodeById;
 
-    for (const [key, value] of lexParseOk.nodeIdMapCollection.childIdsById.entries()) {
+    for (const [key, value] of lexParseOk.state.contextState.nodeIdMapCollection.childIdsById.entries()) {
         actual.push({
             childNodeIds: value,
             id: key,

--- a/src/test/libraryTest/parser/simple.ts
+++ b/src/test/libraryTest/parser/simple.ts
@@ -108,17 +108,22 @@ function expectAbridgeNodes(text: string, expected: ReadonlyArray<AbridgedNode>)
 
 describe("Parser.AbridgedNode", () => {
     describe(`custom IParser.read`, () => {
-        it(`readErrorRaisingExpression`, () => {
+        it(`readParameterSpecificationList`, () => {
             const customParser: IParser<IParserState> = {
                 ...RecursiveDescentParser,
-                read: RecursiveDescentParser.readErrorRaisingExpression,
+                read: RecursiveDescentParser.readParameterSpecificationList,
             };
             const customSettings: Settings = {
                 ...DefaultSettings,
                 parser: customParser,
             };
-            const triedLexParse: Task.TriedLexParse = Task.tryLexParse(customSettings, "error 1");
-            expect(ResultUtils.isOk(triedLexParse)).to.equal(true, "triedLexParse should be an Ok");
+            const triedLexParse: Task.TriedLexParse = Task.tryLexParse(
+                customSettings,
+                "(a as number, optional b as text)",
+            );
+            if (!ResultUtils.isOk(triedLexParse)) {
+                throw new Error(`AssertFailed: ResultUtils.isOk(triedLexParse): ${triedLexParse.error.message}`);
+            }
         });
     });
 

--- a/src/test/libraryTest/parser/simple.ts
+++ b/src/test/libraryTest/parser/simple.ts
@@ -32,7 +32,7 @@ function collectAbridgeNodeFromAst(text: string): ReadonlyArray<AbridgedNode> {
         AbridgedNode[]
     >(
         state,
-        lexParseOk.nodeIdMapCollection,
+        lexParseOk.state.contextState.nodeIdMapCollection,
         lexParseOk.ast,
         Traverse.VisitNodeStrategy.BreadthFirst,
         collectAbridgeNodeVisit,
@@ -62,7 +62,7 @@ function expectNthNodeOfKind<N>(text: string, nodeKind: Ast.NodeKind, nthRequire
         Ast.TNode | undefined
     >(
         state,
-        lexParseOk.nodeIdMapCollection,
+        lexParseOk.state.contextState.nodeIdMapCollection,
         lexParseOk.ast,
         Traverse.VisitNodeStrategy.BreadthFirst,
         nthNodeVisit,
@@ -105,6 +105,10 @@ function expectAbridgeNodes(text: string, expected: ReadonlyArray<AbridgedNode>)
 }
 
 describe("Parser.AbridgedNode", () => {
+    describe(`IParser.read`, () => {
+        it(``);
+    });
+
     describe(`${Ast.NodeKind.ArithmeticExpression}`, () => {
         it(`1 & 2`, () => {
             const text: string = `1 & 2`;

--- a/src/test/libraryTest/parser/simple.ts
+++ b/src/test/libraryTest/parser/simple.ts
@@ -7,7 +7,9 @@ import { Task } from "../../..";
 import { ResultUtils, Traverse } from "../../../common";
 import { Ast } from "../../../language";
 import { DefaultTemplates } from "../../../localization";
-import { DefaultSettings } from "../../../settings";
+import { IParser, IParserState } from "../../../parser";
+import { RecursiveDescentParser } from "../../../parser/parsers";
+import { DefaultSettings, Settings } from "../../../settings";
 import { expectLexParseOk } from "../../common";
 
 type AbridgedNode = [Ast.NodeKind, number | undefined];
@@ -105,8 +107,19 @@ function expectAbridgeNodes(text: string, expected: ReadonlyArray<AbridgedNode>)
 }
 
 describe("Parser.AbridgedNode", () => {
-    describe(`IParser.read`, () => {
-        it(``);
+    describe(`custom IParser.read`, () => {
+        it(`readErrorRaisingExpression`, () => {
+            const customParser: IParser<IParserState> = {
+                ...RecursiveDescentParser,
+                read: RecursiveDescentParser.readErrorRaisingExpression,
+            };
+            const customSettings: Settings = {
+                ...DefaultSettings,
+                parser: customParser,
+            };
+            const triedLexParse: Task.TriedLexParse = Task.tryLexParse(customSettings, "error 1");
+            expect(ResultUtils.isOk(triedLexParse)).to.equal(true, "triedLexParse should be an Ok");
+        });
     });
 
     describe(`${Ast.NodeKind.ArithmeticExpression}`, () => {

--- a/src/test/resourceTest/benchmarkParser.ts
+++ b/src/test/resourceTest/benchmarkParser.ts
@@ -32,6 +32,12 @@ export interface FunctionTimestamp {
 }
 
 export const BenchmarkParser: IParser<BenchmarkState> = {
+    read: (state: BenchmarkState, parser: IParser<BenchmarkState>) => {
+        const readStartLambda: () => TriedParse<BenchmarkState> = () =>
+            state.baseParser.read(state, (parser as unknown) as IParser<IParserState>) as TriedParse<BenchmarkState>;
+        return traceFunction(state, parser, readStartLambda);
+    },
+
     // 12.1.6 Identifiers
     readIdentifier: (state: BenchmarkState, parser: IParser<BenchmarkState>) =>
         traceFunction(state, parser, state.baseParser.readIdentifier),

--- a/src/test/resourceTest/benchmarkParser.ts
+++ b/src/test/resourceTest/benchmarkParser.ts
@@ -7,7 +7,7 @@ import performanceNow = require("performance-now");
 import { Language } from "../..";
 import { Ast } from "../../language";
 import { LexerSnapshot } from "../../lexer";
-import { IParser, TriedParse } from "../../parser/IParser";
+import { IParser } from "../../parser/IParser";
 import { IParserState, IParserStateUtils } from "../../parser/IParserState";
 import { ParseSettings } from "../../settings";
 

--- a/src/test/resourceTest/benchmarkParser.ts
+++ b/src/test/resourceTest/benchmarkParser.ts
@@ -33,8 +33,8 @@ export interface FunctionTimestamp {
 
 export const BenchmarkParser: IParser<BenchmarkState> = {
     read: (state: BenchmarkState, parser: IParser<BenchmarkState>) => {
-        const readStartLambda: () => TriedParse<BenchmarkState> = () =>
-            state.baseParser.read(state, (parser as unknown) as IParser<IParserState>) as TriedParse<BenchmarkState>;
+        const readStartLambda: () => Ast.TNode = () =>
+            state.baseParser.read(state, (parser as unknown) as IParser<IParserState>) as Ast.TNode;
         return traceFunction(state, parser, readStartLambda);
     },
 
@@ -49,10 +49,8 @@ export const BenchmarkParser: IParser<BenchmarkState> = {
 
     // 12.2.1 Documents
     readDocument: (state: BenchmarkState, parser: IParser<BenchmarkState>) => {
-        const readDocumentLambda: () => TriedParse<BenchmarkState> = () =>
-            state.baseParser.readDocument(state, (parser as unknown) as IParser<IParserState>) as TriedParse<
-                BenchmarkState
-            >;
+        const readDocumentLambda: () => Ast.TDocument = () =>
+            state.baseParser.readDocument(state, (parser as unknown) as IParser<IParserState>) as Ast.TDocument;
         return traceFunction(state, parser, readDocumentLambda);
     },
 


### PR DESCRIPTION
* Adds a new fn to IParser, `read`, which acts as an entry point for parsing. It defaults to `readDocument`
* Added IParserUtils.
* Removed nodeIdMap and leafNodeIds from ParseOk as they're in the already returned state attribute.