### PR TITLE
Custom parse start should return Err, not throw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.1.52",
+    "version": "0.1.53",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/parser/IParser/IParserUtils.ts
+++ b/src/parser/IParser/IParserUtils.ts
@@ -27,12 +27,12 @@ export function tryRead<State extends IParserState = IParserState>(
 
     const maybeCommonErr: CommonError.InvariantError | undefined = IParserStateUtils.testNoOpenContext(state);
     if (maybeCommonErr) {
-        throw maybeCommonErr;
+        return ResultUtils.errFactory(new CommonError.CommonError(maybeCommonErr));
     }
 
     const maybeLeftoverErr: ParseError.UnusedTokensRemainError | undefined = IParserStateUtils.testNoMoreTokens(state);
     if (maybeLeftoverErr) {
-        throw maybeLeftoverErr;
+        return ResultUtils.errFactory(new ParseError.ParseError(maybeLeftoverErr, state));
     }
 
     return ResultUtils.okFactory({

--- a/src/test/libraryTest/parser/error.ts
+++ b/src/test/libraryTest/parser/error.ts
@@ -4,8 +4,9 @@
 import { expect } from "chai";
 import "mocha";
 import { DefaultTemplates, Localization } from "../../../localization";
-import { ParseError } from "../../../parser";
-import { DefaultSettings } from "../../../settings";
+import { IParser, IParserState, ParseError } from "../../../parser";
+import { RecursiveDescentParser } from "../../../parser/parsers";
+import { DefaultSettings, Settings } from "../../../settings";
 import { expectParseErr } from "../../common";
 
 function expectCsvContinuationError(text: string): ParseError.ExpectedCsvContinuationError {
@@ -41,10 +42,26 @@ describe("Parser.Error", () => {
         expect(innerError instanceof ParseError.UnterminatedParenthesesError).to.equal(true, innerError.message);
     });
 
-    it("UnusedTokensRemainError: 1 1", () => {
-        const text: string = "1 1";
-        const innerError: ParseError.TInnerParseError = expectParseErr(DefaultSettings, text).innerError;
-        expect(innerError instanceof ParseError.UnusedTokensRemainError).to.equal(true, innerError.message);
+    describe(`UnusedTokensRemainError`, () => {
+        it("default parser", () => {
+            const text: string = "1 1";
+            const innerError: ParseError.TInnerParseError = expectParseErr(DefaultSettings, text).innerError;
+            expect(innerError instanceof ParseError.UnusedTokensRemainError).to.equal(true, innerError.message);
+        });
+
+        it("custom start", () => {
+            const customParser: IParser<IParserState> = {
+                ...RecursiveDescentParser,
+                read: RecursiveDescentParser.readIdentifier,
+            };
+            const customSettings: Settings = {
+                ...DefaultSettings,
+                parser: customParser,
+            };
+            const text: string = "a b";
+            const innerError: ParseError.TInnerParseError = expectParseErr(customSettings, text).innerError;
+            expect(innerError instanceof ParseError.UnusedTokensRemainError).to.equal(true, innerError.message);
+        });
     });
 
     it(`Dangling Comma for LetExpression`, () => {


### PR DESCRIPTION
The sanity checks in tryRead should return Err on errors, not throw.