### PR TITLE
Fix inspection regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.1.55",
+    "version": "0.1.56",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/inspection/type/inspectType.ts
+++ b/src/inspection/type/inspectType.ts
@@ -1454,13 +1454,16 @@ function maybeDereferencedIdentifier(state: TypeInspectionState, xorNode: TXorNo
 
     const scopeItemByKey: ScopeItemByKey = getOrCreateScope(state, identifier.id);
     const maybeScopeItem: undefined | TScopeItem = scopeItemByKey.get(identifierLiteral);
-    if (maybeScopeItem === undefined) {
-        throw new CommonError.InvariantError(`maybeScopeItem should be at least an instance of Undefined`);
-    }
-    const scopeItem: TScopeItem = maybeScopeItem;
-    if (scopeItem.isRecursive !== isIdentifierRecurisve) {
+
+    if (
+        // If the identifier couldn't be found in the generated scope,
+        // then either the scope generation is incorrect or it's an external identifier (eg. Odbc.Database).
+        maybeScopeItem === undefined ||
+        maybeScopeItem.isRecursive !== isIdentifierRecurisve
+    ) {
         return undefined;
     }
+    const scopeItem: TScopeItem = maybeScopeItem;
 
     let maybeNextXorNode: undefined | TXorNode;
     switch (scopeItem.kind) {


### PR DESCRIPTION
Since adding inspection on the type scope there was a regression where if it encounters an out-of-scope identifier then it errors out.

Whenever we start supporting the standard library an additional check should be made in maybeDereferencedIdentifierType, and when found neither in the local scope nor the standard library, error out.