### PR TITLE
getRoot helper functions

### DIFF
--- a/src/parser/IParser/IParser.ts
+++ b/src/parser/IParser/IParser.ts
@@ -19,7 +19,7 @@ export const enum BracketDisambiguation {
 }
 
 export interface ParseOk<S extends IParserState = IParserState> {
-    readonly ast: Ast.TNode;
+    readonly root: Ast.TNode;
     readonly state: S;
 }
 

--- a/src/parser/IParser/IParserUtils.ts
+++ b/src/parser/IParser/IParserUtils.ts
@@ -11,10 +11,10 @@ export function tryRead<State extends IParserState = IParserState>(
     state: State,
     parser: IParser<State>,
 ): TriedParse<State> {
-    let node: Ast.TNode;
+    let root: Ast.TNode;
 
     try {
-        node = parser.read(state, parser);
+        root = parser.read(state, parser);
     } catch (err) {
         let convertedError: ParseError.TParseError<State>;
         if (ParseError.isTInnerParseError(err)) {
@@ -36,7 +36,7 @@ export function tryRead<State extends IParserState = IParserState>(
     }
 
     return ResultUtils.okFactory({
-        ast: node,
+        root,
         nodeIdMapCollection: state.contextState.nodeIdMapCollection,
         leafNodeIds: state.contextState.leafNodeIds,
         state,

--- a/src/parser/context/context.ts
+++ b/src/parser/context/context.ts
@@ -27,14 +27,10 @@ import { Ast } from "../../language";
 //  With the third child being a yet-to-be evaluated Context of NodeKind.Csv
 
 export interface State {
-    readonly root: Root;
     readonly nodeIdMapCollection: NodeIdMap.Collection;
+    maybeRoot: Node | undefined;
     idCounter: number;
     leafNodeIds: number[];
-}
-
-export interface Root {
-    maybeNode: Node | undefined;
 }
 
 export interface Node {

--- a/src/parser/context/contextUtils.ts
+++ b/src/parser/context/contextUtils.ts
@@ -115,7 +115,7 @@ export function endContext(state: State, contextNode: Node, astNode: Ast.TNode):
 
     if (state.maybeRoot?.id === astNode.id) {
         if (state.nodeIdMapCollection.contextNodeById.size) {
-            throw new CommonError.InvariantError(`the root context shouldn't end untill all context nodes are closed`);
+            throw new CommonError.InvariantError(`the root context shouldn't end until all other context nodes have ended`);
         }
     }
 

--- a/src/parser/context/contextUtils.ts
+++ b/src/parser/context/contextUtils.ts
@@ -10,9 +10,6 @@ import { Node, State } from "./context";
 
 export function newState(): State {
     return {
-        root: {
-            maybeNode: undefined,
-        },
         nodeIdMapCollection: {
             astNodeById: new Map(),
             contextNodeById: new Map(),
@@ -20,6 +17,7 @@ export function newState(): State {
             childIdsById: new Map(),
             maybeRightMostLeaf: undefined,
         },
+        maybeRoot: undefined,
         idCounter: 0,
         leafNodeIds: [],
     };
@@ -76,8 +74,8 @@ export function startContext(
         maybeAttributeIndex,
     };
     nodeIdMapCollection.contextNodeById.set(nodeId, contextNode);
-    if (state.root.maybeNode === undefined) {
-        state.root.maybeNode = contextNode;
+    if (state.maybeRoot === undefined) {
+        state.maybeRoot = contextNode;
     }
 
     return contextNode;
@@ -112,6 +110,12 @@ export function endContext(state: State, contextNode: Node, astNode: Ast.TNode):
         ) {
             const unsafeNodeIdMapCollection: TypeScriptUtils.StripReadonly<NodeIdMap.Collection> = nodeIdMapCollection;
             unsafeNodeIdMapCollection.maybeRightMostLeaf = astNode;
+        }
+    }
+
+    if (state.maybeRoot?.id === astNode.id) {
+        if (state.nodeIdMapCollection.contextNodeById.size) {
+            throw new CommonError.InvariantError(`the root context shouldn't end untill all context nodes are closed`);
         }
     }
 
@@ -205,7 +209,7 @@ export function deleteContext(state: State, nodeId: number): Node | undefined {
             const maybeChildContext: Node | undefined = contextNodeById.get(childId);
             if (maybeChildContext) {
                 const childContext: Node = maybeChildContext;
-                state.root.maybeNode = childContext;
+                state.maybeRoot = childContext;
             }
         }
         // Not a leaf node, not the Root node.

--- a/src/test/libraryTest/inspection/type.ts
+++ b/src/test/libraryTest/inspection/type.ts
@@ -19,7 +19,7 @@ function expectParseOkNodeTypeEqual(text: string, expected: Type.TType): void {
         DefaultSettings,
         lexParseOk.state.contextState.nodeIdMapCollection,
         lexParseOk.state.contextState.leafNodeIds,
-        lexParseOk.ast.id,
+        lexParseOk.root.id,
     );
 
     expect(actual).deep.equal(expected);
@@ -27,7 +27,7 @@ function expectParseOkNodeTypeEqual(text: string, expected: Type.TType): void {
 
 function expectParseErrNodeTypeEqual(text: string, expected: Type.TType): void {
     const parseErr: ParseError.ParseError<IParserState> = expectParseErr(DefaultSettings, text);
-    const maybeRoot: ParseContext.Node | undefined = parseErr.state.contextState.root.maybeNode;
+    const maybeRoot: ParseContext.Node | undefined = parseErr.state.contextState.maybeRoot;
     if (maybeRoot === undefined) {
         throw new Error(`AssertFailed: maybeRoot !== undefined`);
     }

--- a/src/test/libraryTest/parser/simple.ts
+++ b/src/test/libraryTest/parser/simple.ts
@@ -35,7 +35,7 @@ function collectAbridgeNodeFromAst(text: string): ReadonlyArray<AbridgedNode> {
     >(
         state,
         lexParseOk.state.contextState.nodeIdMapCollection,
-        lexParseOk.ast,
+        lexParseOk.root,
         Traverse.VisitNodeStrategy.BreadthFirst,
         collectAbridgeNodeVisit,
         Traverse.expectExpandAllAstChildren,
@@ -65,7 +65,7 @@ function expectNthNodeOfKind<N>(text: string, nodeKind: Ast.NodeKind, nthRequire
     >(
         state,
         lexParseOk.state.contextState.nodeIdMapCollection,
-        lexParseOk.ast,
+        lexParseOk.root,
         Traverse.VisitNodeStrategy.BreadthFirst,
         nthNodeVisit,
         Traverse.expectExpandAllAstChildren,


### PR DESCRIPTION
Adding root to the return of task functions makes things even uglier. Instead I added some helper functions to get the root. Let me know if there are more painful spots with the TXorNode APIs.