### PR TITLE
Couple of bug fixes for autocomplete keywords

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,15 +10,13 @@
       "name": "Debug Library Tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [
-        "--debug",
+        "--inspect",
         "--colors",
         "--timeout",
         "999999",
-        "-r",
-        "ts-node/register",
-        "${workspaceFolder}/src/test/libraryTest/**/*.ts"
+        "${workspaceFolder}/lib/test/libraryTest/**/*.js"
       ],
-      "preLaunchTask": "build",
+      "preLaunchTask": "watch",
       "internalConsoleOptions": "openOnSessionStart"
     },
     {
@@ -27,7 +25,7 @@
       "name": "Debug Resource Tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [
-        "--debug",
+        "--inspect",
         "--colors",
         "--timeout",
         "999999",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,6 +14,15 @@
                 "kind": "build",
                 "isDefault": true
             }
+        },
+        {
+            "label": "watch",
+            "type": "typescript",
+            "tsconfig": "tsconfig.json",
+            "option": "watch",
+            "problemMatcher": "$tsc-watch",
+            "group": "build",
+            "isBackground": true
         }
     ]
 }

--- a/src/inspection/autocomplete.ts
+++ b/src/inspection/autocomplete.ts
@@ -143,13 +143,6 @@ function handleEdgeCases(
         activeNode.ancestry[1].node.kind === Ast.NodeKind.IdentifierExpression
     ) {
         inspected = StartOfDocumentKeywords;
-    } else if (
-        maybeParseErrorToken === undefined &&
-        activeNode.ancestry.length >= 2 &&
-        activeNode.ancestry[0].node.kind === Ast.NodeKind.LiteralExpression &&
-        activeNode.ancestry[1].node.kind === Ast.NodeKind.LogicalExpression
-    ) {
-        inspected = ExpressionKeywords;
     }
 
     if (
@@ -179,6 +172,7 @@ const ExpressionAutocomplete: ReadonlyArray<Language.KeywordKind> = ExpressionKe
 const AutocompleteExpressionKeys: ReadonlyArray<string> = [
     createMapKey(Ast.NodeKind.ErrorRaisingExpression, 1),
     createMapKey(Ast.NodeKind.GeneralizedIdentifierPairedExpression, 2),
+    createMapKey(Ast.NodeKind.FunctionExpression, 3),
     createMapKey(Ast.NodeKind.IdentifierPairedExpression, 2),
     createMapKey(Ast.NodeKind.IfExpression, 1),
     createMapKey(Ast.NodeKind.IfExpression, 3),
@@ -201,6 +195,9 @@ const AutocompleteConstantMap: Map<string, Language.KeywordKind> = new Map<strin
     [createMapKey(Ast.NodeKind.IfExpression, 0), Language.KeywordKind.If],
     [createMapKey(Ast.NodeKind.IfExpression, 2), Language.KeywordKind.Then],
     [createMapKey(Ast.NodeKind.IfExpression, 4), Language.KeywordKind.Else],
+
+    // Ast.NodeKind.LetExpression
+    [createMapKey(Ast.NodeKind.LetExpression, 2), Language.KeywordKind.In],
 
     // Ast.NodeKind.OtherwiseExpression
     [createMapKey(Ast.NodeKind.OtherwiseExpression, 0), Language.KeywordKind.Otherwise],

--- a/src/inspection/autocomplete.ts
+++ b/src/inspection/autocomplete.ts
@@ -15,7 +15,7 @@ export type Autocomplete = ReadonlyArray<Language.KeywordKind>;
 
 export type TriedAutocomplete = Result<Autocomplete, CommonError.CommonError>;
 
-export const StartOfDoctumentKeywords: ReadonlyArray<Language.KeywordKind> = [
+export const StartOfDocumentKeywords: ReadonlyArray<Language.KeywordKind> = [
     ...ExpressionKeywords,
     Language.KeywordKind.Section,
 ];
@@ -142,7 +142,7 @@ function handleEdgeCases(
         activeNode.ancestry[0].node.kind === Ast.NodeKind.Identifier &&
         activeNode.ancestry[1].node.kind === Ast.NodeKind.IdentifierExpression
     ) {
-        inspected = StartOfDoctumentKeywords;
+        inspected = StartOfDocumentKeywords;
     }
 
     if (

--- a/src/inspection/autocomplete.ts
+++ b/src/inspection/autocomplete.ts
@@ -143,6 +143,13 @@ function handleEdgeCases(
         activeNode.ancestry[1].node.kind === Ast.NodeKind.IdentifierExpression
     ) {
         inspected = StartOfDocumentKeywords;
+    } else if (
+        maybeParseErrorToken === undefined &&
+        activeNode.ancestry.length >= 2 &&
+        activeNode.ancestry[0].node.kind === Ast.NodeKind.LiteralExpression &&
+        activeNode.ancestry[1].node.kind === Ast.NodeKind.LogicalExpression
+    ) {
+        inspected = ExpressionKeywords;
     }
 
     if (

--- a/src/task.ts
+++ b/src/task.ts
@@ -3,7 +3,7 @@
 
 import { Inspection } from ".";
 import { Assert, CommonError, Result, ResultUtils } from "./common";
-import { StartOfDoctumentKeywords } from "./inspection";
+import { StartOfDocumentKeywords } from "./inspection";
 import { ActiveNode, ActiveNodeUtils } from "./inspection/activeNode";
 import { Ast } from "./language";
 import { Lexer, LexError, LexerSnapshot, TriedLexerSnapshot } from "./lexer";
@@ -112,7 +112,7 @@ export function tryInspection<S extends IParserState = IParserState>(
     if (maybeActiveNode === undefined) {
         return ResultUtils.okFactory({
             maybeActiveNode,
-            autocomplete: StartOfDoctumentKeywords,
+            autocomplete: StartOfDocumentKeywords,
             maybeInvokeExpression: undefined,
             scope: new Map(),
             scopeType: new Map(),

--- a/src/test/libraryTest/inspection/autocomplete.ts
+++ b/src/test/libraryTest/inspection/autocomplete.ts
@@ -617,4 +617,12 @@ describe(`Inspection - Autocomplete`, () => {
             expect(expectParseErrAutocompleteOk(DefaultSettings, text, position)).deep.equal(expected);
         });
     });
+
+    describe(`Other`, () => {
+        it(`let a = 1 |`, () => {
+            const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`let a = 1 |`);
+            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.In, Language.KeywordKind.Meta];
+            expect(expectParseErrAutocompleteOk(DefaultSettings, text, position)).deep.equal(expected);
+        });
+    });
 });

--- a/src/test/libraryTest/inspection/autocomplete.ts
+++ b/src/test/libraryTest/inspection/autocomplete.ts
@@ -610,7 +610,9 @@ describe(`Inspection - Autocomplete`, () => {
         });
 
         it(`section foo; a = () => true; b = "string"; c = 1; d = |;`, () => {
-            const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`section; x = |`);
+            const [text, position]: [string, Inspection.Position] = expectTextWithPosition(
+                `section foo; a = () => true; b = "string"; c = 1; d = |;`,
+            );
             const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
             expect(expectParseErrAutocompleteOk(DefaultSettings, text, position)).deep.equal(expected);
         });

--- a/src/test/libraryTest/inspection/autocomplete.ts
+++ b/src/test/libraryTest/inspection/autocomplete.ts
@@ -5,7 +5,7 @@ import { expect } from "chai";
 import "mocha";
 import { Inspection, Language } from "../../..";
 import { Assert } from "../../../common";
-import { Position, StartOfDoctumentKeywords, TriedAutocomplete } from "../../../inspection";
+import { Position, StartOfDocumentKeywords, TriedAutocomplete } from "../../../inspection";
 import { ActiveNode, ActiveNodeUtils } from "../../../inspection/activeNode";
 import { Ast } from "../../../language";
 import { IParserState, NodeIdMap, ParseContext, ParseError } from "../../../parser";
@@ -25,7 +25,7 @@ function expectAutocompleteOk<S extends IParserState>(
         position,
     );
     if (maybeActiveNode === undefined) {
-        return StartOfDoctumentKeywords;
+        return StartOfDocumentKeywords;
     }
 
     const triedInspect: TriedAutocomplete = Inspection.tryAutocomplete(
@@ -535,8 +535,8 @@ describe(`Inspection - Autocomplete`, () => {
             expect(expectParseErrAutocompleteOk(DefaultSettings, text, position)).deep.equal(expected);
         });
 
-        it(`let x = |`, () => {
-            const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`let x = |`);
+        it(`() => |`, () => {
+            const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`() => |`);
             const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
             expect(expectParseErrAutocompleteOk(DefaultSettings, text, position)).deep.equal(expected);
         });

--- a/src/test/libraryTest/inspection/autocomplete.ts
+++ b/src/test/libraryTest/inspection/autocomplete.ts
@@ -618,10 +618,24 @@ describe(`Inspection - Autocomplete`, () => {
         });
     });
 
-    describe(`Other`, () => {
+    describe(`${Ast.NodeKind.LetExpression}`, () => {
         it(`let a = 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`let a = 1 |`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.In, Language.KeywordKind.Meta];
+            // TODO: meta should be valid keyword here
+            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.In];
+            expect(expectParseErrAutocompleteOk(DefaultSettings, text, position)).deep.equal(expected);
+        });
+
+        it(`let a = 1 m|`, () => {
+            const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`let a = 1 m|`);
+            // TODO: meta should be valid keyword here
+            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.In];
+            expect(expectParseErrAutocompleteOk(DefaultSettings, text, position)).deep.equal(expected);
+        });
+
+        it(`let a = 1, |`, () => {
+            const [text, position]: [string, Inspection.Position] = expectTextWithPosition(`let a = 1, |`);
+            const expected: ReadonlyArray<Language.KeywordKind> = [];
             expect(expectParseErrAutocompleteOk(DefaultSettings, text, position)).deep.equal(expected);
         });
     });


### PR DESCRIPTION
Resolves #162 and solves the `in` portion of #163. 

Also modified the VS Code launch settings to make running unit tests faster.