### PR TITLE
Refactor Language to exports

### DIFF
--- a/src/common/stringUtils.ts
+++ b/src/common/stringUtils.ts
@@ -4,7 +4,7 @@
 // tslint:disable-next-line: no-require-imports
 import GraphemeSplitter = require("grapheme-splitter");
 import { Assert, CommonError, Pattern } from ".";
-import { KeywordKind, Keywords } from "../language";
+import { Keyword } from "../language";
 
 export const graphemeSplitter: GraphemeSplitter = new GraphemeSplitter();
 
@@ -64,7 +64,7 @@ export function isGeneralizedIdentifier(text: string): boolean {
 }
 
 export function isKeyword(text: string): boolean {
-    return Keywords.indexOf(text as KeywordKind) !== -1;
+    return Keyword.KeywordKinds.indexOf(text as Keyword.KeywordKind) !== -1;
 }
 
 export function isQuotedIdentifier(text: string): boolean {

--- a/src/inspection/activeNode/activeNodeUtils.ts
+++ b/src/inspection/activeNode/activeNodeUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, AstUtils } from "../../language";
+import { Ast, Constant, ConstantUtils } from "../../language";
 import {
     AncestryUtils,
     NodeIdMap,
@@ -89,19 +89,19 @@ interface AstNodeSearch {
 }
 
 const DrilldownConstantKind: ReadonlyArray<string> = [
-    Ast.WrapperConstantKind.LeftBrace,
-    Ast.WrapperConstantKind.LeftBracket,
-    Ast.WrapperConstantKind.LeftParenthesis,
+    Constant.WrapperConstantKind.LeftBrace,
+    Constant.WrapperConstantKind.LeftBracket,
+    Constant.WrapperConstantKind.LeftParenthesis,
 ];
 
 const ShiftRightConstantKinds: ReadonlyArray<string> = [
-    Ast.MiscConstantKind.Comma,
-    Ast.MiscConstantKind.Equal,
-    Ast.MiscConstantKind.FatArrow,
-    Ast.WrapperConstantKind.RightBrace,
-    Ast.WrapperConstantKind.RightBracket,
-    Ast.WrapperConstantKind.RightParenthesis,
-    Ast.MiscConstantKind.Semicolon,
+    Constant.MiscConstantKind.Comma,
+    Constant.MiscConstantKind.Equal,
+    Constant.MiscConstantKind.FatArrow,
+    Constant.WrapperConstantKind.RightBrace,
+    Constant.WrapperConstantKind.RightBracket,
+    Constant.WrapperConstantKind.RightParenthesis,
+    Constant.MiscConstantKind.Semicolon,
     ...DrilldownConstantKind,
 ];
 
@@ -112,27 +112,30 @@ function isAnchorNode(position: Position, astNode: Ast.TNode): boolean {
 
     if (astNode.kind === Ast.NodeKind.Identifier || astNode.kind === Ast.NodeKind.GeneralizedIdentifier) {
         return true;
-    } else if (astNode.kind === Ast.NodeKind.LiteralExpression && astNode.literalKind === Ast.LiteralKind.Numeric) {
+    } else if (
+        astNode.kind === Ast.NodeKind.LiteralExpression &&
+        astNode.literalKind === Constant.LiteralKind.Numeric
+    ) {
         return true;
     } else if (astNode.kind === Ast.NodeKind.Constant) {
         switch (astNode.constantKind) {
-            case Ast.KeywordConstantKind.As:
-            case Ast.KeywordConstantKind.Each:
-            case Ast.KeywordConstantKind.Else:
-            case Ast.KeywordConstantKind.Error:
-            case Ast.KeywordConstantKind.If:
-            case Ast.KeywordConstantKind.In:
-            case Ast.KeywordConstantKind.Is:
-            case Ast.KeywordConstantKind.Section:
-            case Ast.KeywordConstantKind.Shared:
-            case Ast.KeywordConstantKind.Let:
-            case Ast.KeywordConstantKind.Meta:
-            case Ast.KeywordConstantKind.Otherwise:
-            case Ast.KeywordConstantKind.Then:
-            case Ast.KeywordConstantKind.Try:
-            case Ast.KeywordConstantKind.Type:
+            case Constant.KeywordConstantKind.As:
+            case Constant.KeywordConstantKind.Each:
+            case Constant.KeywordConstantKind.Else:
+            case Constant.KeywordConstantKind.Error:
+            case Constant.KeywordConstantKind.If:
+            case Constant.KeywordConstantKind.In:
+            case Constant.KeywordConstantKind.Is:
+            case Constant.KeywordConstantKind.Section:
+            case Constant.KeywordConstantKind.Shared:
+            case Constant.KeywordConstantKind.Let:
+            case Constant.KeywordConstantKind.Meta:
+            case Constant.KeywordConstantKind.Otherwise:
+            case Constant.KeywordConstantKind.Then:
+            case Constant.KeywordConstantKind.Try:
+            case Constant.KeywordConstantKind.Type:
 
-            case Ast.PrimitiveTypeConstantKind.Null:
+            case Constant.PrimitiveTypeConstantKind.Null:
                 return true;
 
             default:
@@ -198,7 +201,10 @@ function maybeFindAstNodes(
         if (
             DrilldownConstantKind.indexOf(maybeBestOnOrBeforeNode.constantKind) !== -1 &&
             maybeBestAfter?.kind === Ast.NodeKind.Constant &&
-            AstUtils.isPairedWrapperConstantKinds(maybeBestOnOrBeforeNode.constantKind, maybeBestAfter.constantKind)
+            ConstantUtils.isPairedWrapperConstantKinds(
+                maybeBestOnOrBeforeNode.constantKind,
+                maybeBestAfter.constantKind,
+            )
         ) {
             const parent: Ast.TNode = NodeIdMapUtils.assertParentAst(nodeIdMapCollection, currentOnOrBefore.id, [
                 Ast.NodeKind.RecordExpression,
@@ -270,7 +276,7 @@ function maybeIdentifierUnderPosition(
     let identifier: Ast.Identifier | Ast.GeneralizedIdentifier;
 
     // If closestLeaf is '@', then check if it's part of an IdentifierExpression.
-    if (leaf.node.kind === Ast.NodeKind.Constant && leaf.node.constantKind === Ast.MiscConstantKind.AtSign) {
+    if (leaf.node.kind === Ast.NodeKind.Constant && leaf.node.constantKind === Constant.MiscConstantKind.AtSign) {
         const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(leaf.node.id);
         if (maybeParentId === undefined) {
             return undefined;

--- a/src/inspection/autocomplete.ts
+++ b/src/inspection/autocomplete.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Language } from "..";
 import { ArrayUtils, Assert, CommonError, Result } from "../common";
 import { ResultUtils } from "../common/result";
-import { Ast, Constant, Keyword } from "../language";
+import { Ast, Constant, Keyword, Token } from "../language";
 import { getLocalizationTemplates } from "../localization";
 import {
     AncestryUtils,
@@ -57,7 +56,7 @@ interface InspectAutocompleteState {
     readonly nodeIdMapCollection: NodeIdMap.Collection;
     readonly leafNodeIds: ReadonlyArray<number>;
     readonly activeNode: ActiveNode;
-    readonly maybeParseErrorToken: Language.Token | undefined;
+    readonly maybeParseErrorToken: Token.Token | undefined;
     readonly maybeTrailingText: TrailingText | undefined;
     parent: TXorNode;
     child: TXorNode;
@@ -132,7 +131,7 @@ function inspectAutocomplete(
     nodeIdMapCollection: NodeIdMap.Collection,
     leafNodeIds: ReadonlyArray<number>,
     activeNode: ActiveNode,
-    maybeParseErrorToken: Language.Token | undefined,
+    maybeParseErrorToken: Token.Token | undefined,
 ): ReadonlyArray<AutocompleteOption> {
     const maybeTrailingText: TrailingText | undefined =
         maybeParseErrorToken !== undefined ? trailingTextFactory(activeNode, maybeParseErrorToken) : undefined;
@@ -180,7 +179,7 @@ function inspectAutocomplete(
     );
 }
 
-function trailingTextFactory(activeNode: ActiveNode, parseErrorToken: Language.Token): TrailingText {
+function trailingTextFactory(activeNode: ActiveNode, parseErrorToken: Token.Token): TrailingText {
     return {
         text: parseErrorToken.data,
         isInOrOnPosition: PositionUtils.isInToken(activeNode.position, parseErrorToken, false, true),
@@ -244,7 +243,7 @@ function createMapKey(nodeKind: Ast.NodeKind, maybeAttributeIndex: number | unde
 function maybeEdgeCase(state: InspectAutocompleteState): ReadonlyArray<AutocompleteOption> | undefined {
     const activeNode: ActiveNode = state.activeNode;
     const ancestry: ReadonlyArray<TXorNode> = activeNode.ancestry;
-    const maybeParseErrorToken: Language.Token | undefined = state.maybeParseErrorToken;
+    const maybeParseErrorToken: Token.Token | undefined = state.maybeParseErrorToken;
     let maybeInspected: ReadonlyArray<AutocompleteOption> | undefined;
 
     // The user is typing in a new file, which the parser defaults to searching for an identifier.
@@ -379,7 +378,7 @@ function autocompleteErrorHandlingExpression(
 ): ReadonlyArray<Keyword.KeywordKind> | undefined {
     const position: Position = state.activeNode.position;
     const child: TXorNode = state.child;
-    const maybeParseErrorToken: Language.Token | undefined = state.maybeParseErrorToken;
+    const maybeParseErrorToken: Token.Token | undefined = state.maybeParseErrorToken;
 
     const maybeChildAttributeIndex: number | undefined = child.node.maybeAttributeIndex;
     if (maybeChildAttributeIndex === 0) {
@@ -388,11 +387,11 @@ function autocompleteErrorHandlingExpression(
         // 'try true o|' creates a ParseError.
         // It's ambiguous if the next token should be either 'otherwise' or 'or'.
         if (maybeParseErrorToken !== undefined) {
-            const errorToken: Language.Token = maybeParseErrorToken;
+            const errorToken: Token.Token = maybeParseErrorToken;
 
             // First we test if we can autocomplete using the error token.
             if (
-                errorToken.kind === Language.TokenKind.Identifier &&
+                errorToken.kind === Token.TokenKind.Identifier &&
                 PositionUtils.isInToken(position, maybeParseErrorToken, false, true)
             ) {
                 const tokenData: string = maybeParseErrorToken.data;

--- a/src/inspection/autocomplete.ts
+++ b/src/inspection/autocomplete.ts
@@ -22,7 +22,7 @@ import { Position, PositionUtils } from "./position";
 
 export type Autocomplete = ReadonlyArray<AutocompleteOption>;
 
-export type AutocompleteOption = Keyword.KeywordKind | Constant.PrimitiveTypeConstantKind;
+export type AutocompleteOption = Keyword.KeywordKind;
 
 export type TriedAutocomplete = Result<Autocomplete, CommonError.CommonError>;
 
@@ -280,12 +280,6 @@ function maybeEdgeCase(state: InspectAutocompleteState): ReadonlyArray<Autocompl
         ancestry[2].node.kind === Ast.NodeKind.FunctionExpression
     ) {
         maybeInspected = [Keyword.KeywordKind.As];
-    }
-
-    // The combinatorial parser directly parses a PrimitiveType from a BinOpExpression
-    // when the binary operator is either `as` or `is`.
-    else if (ancestry[0].kind === XorNodeKind.Context && ancestry[0].node.kind === Ast.NodeKind.PrimitiveType) {
-        maybeInspected = Constant.PrimitiveTypeConstantKinds;
     }
 
     return maybeInspected;

--- a/src/inspection/position/positionUtils.ts
+++ b/src/inspection/position/positionUtils.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Language } from "../..";
 import { Assert } from "../../common";
-import { Ast } from "../../language";
+import { Ast, Token } from "../../language";
 import { NodeIdMap, NodeIdMapUtils, ParseContext, TXorNode, XorNodeKind } from "../../parser";
 import { Position } from "./position";
 
@@ -84,11 +83,11 @@ export function isAfterXor(
 }
 
 export function isBeforeContext(position: Position, contextNode: ParseContext.Node, isBoundIncluded: boolean): boolean {
-    const maybeTokenStart: Language.Token | undefined = contextNode.maybeTokenStart;
+    const maybeTokenStart: Token.Token | undefined = contextNode.maybeTokenStart;
     if (maybeTokenStart === undefined) {
         return false;
     }
-    const tokenStart: Language.Token = maybeTokenStart;
+    const tokenStart: Token.Token = maybeTokenStart;
 
     return isBeforeTokenPosition(position, tokenStart.positionStart, isBoundIncluded);
 }
@@ -175,7 +174,7 @@ export function isAfterAst(position: Position, astNode: Ast.TNode, isBoundInclud
 
 export function isInToken(
     position: Position,
-    token: Language.Token,
+    token: Token.Token,
     isLowerBoundIncluded: boolean,
     isHigherBoundIncluded: boolean,
 ): boolean {
@@ -187,7 +186,7 @@ export function isInToken(
 
 export function isBeforeTokenPosition(
     position: Position,
-    tokenPosition: Language.TokenPosition,
+    tokenPosition: Token.TokenPosition,
     isBoundIncluded: boolean,
 ): boolean {
     const positionLineNumber: number = position.lineNumber;
@@ -202,13 +201,13 @@ export function isBeforeTokenPosition(
     }
 }
 
-export function isOnTokenPosition(position: Position, tokenPosition: Language.TokenPosition): boolean {
+export function isOnTokenPosition(position: Position, tokenPosition: Token.TokenPosition): boolean {
     return position.lineNumber === tokenPosition.lineNumber && position.lineCodeUnit === tokenPosition.lineCodeUnit;
 }
 
 export function isAfterTokenPosition(
     position: Position,
-    tokenPosition: Language.TokenPosition,
+    tokenPosition: Token.TokenPosition,
     isBoundIncluded: boolean,
 ): boolean {
     const positionLineNumber: number = position.lineNumber;

--- a/src/inspection/scope/scopeItem.ts
+++ b/src/inspection/scope/scopeItem.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast } from "../../language";
+import { Ast, Constant } from "../../language";
 import { TXorNode } from "../../parser";
 
 export type TScopeItem =
@@ -41,7 +41,7 @@ export interface ParameterScopeItem extends IScopeItem {
     readonly name: Ast.Identifier;
     readonly isOptional: boolean;
     readonly isNullable: boolean;
-    readonly maybeType: Ast.PrimitiveTypeConstantKind | undefined;
+    readonly maybeType: Constant.PrimitiveTypeConstantKind | undefined;
 }
 
 export interface SectionMemberScopeItem extends IScopeItem {

--- a/src/inspection/type/inspectType/inspectTypeConstant.ts
+++ b/src/inspection/type/inspectType/inspectTypeConstant.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, Type, TypeUtils } from "../../../language";
+import { Ast, Constant, Type, TypeUtils } from "../../../language";
 import { TXorNode, XorNodeKind, XorNodeUtils } from "../../../parser";
 
 export function inspectTypeConstant(xorNode: TXorNode): Type.TType {
@@ -13,61 +13,61 @@ export function inspectTypeConstant(xorNode: TXorNode): Type.TType {
 
     const constant: Ast.TConstant = xorNode.node as Ast.TConstant;
     switch (constant.constantKind) {
-        case Ast.PrimitiveTypeConstantKind.Action:
+        case Constant.PrimitiveTypeConstantKind.Action:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Action);
 
-        case Ast.PrimitiveTypeConstantKind.Any:
+        case Constant.PrimitiveTypeConstantKind.Any:
             return Type.AnyInstance;
 
-        case Ast.PrimitiveTypeConstantKind.AnyNonNull:
+        case Constant.PrimitiveTypeConstantKind.AnyNonNull:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.AnyNonNull);
 
-        case Ast.PrimitiveTypeConstantKind.Binary:
+        case Constant.PrimitiveTypeConstantKind.Binary:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Binary);
 
-        case Ast.PrimitiveTypeConstantKind.Date:
+        case Constant.PrimitiveTypeConstantKind.Date:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Date);
 
-        case Ast.PrimitiveTypeConstantKind.DateTime:
+        case Constant.PrimitiveTypeConstantKind.DateTime:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.DateTime);
 
-        case Ast.PrimitiveTypeConstantKind.DateTimeZone:
+        case Constant.PrimitiveTypeConstantKind.DateTimeZone:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.DateTimeZone);
 
-        case Ast.PrimitiveTypeConstantKind.Duration:
+        case Constant.PrimitiveTypeConstantKind.Duration:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Duration);
 
-        case Ast.PrimitiveTypeConstantKind.Function:
+        case Constant.PrimitiveTypeConstantKind.Function:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Function);
 
-        case Ast.PrimitiveTypeConstantKind.List:
+        case Constant.PrimitiveTypeConstantKind.List:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.List);
 
-        case Ast.PrimitiveTypeConstantKind.Logical:
+        case Constant.PrimitiveTypeConstantKind.Logical:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Logical);
 
-        case Ast.PrimitiveTypeConstantKind.None:
+        case Constant.PrimitiveTypeConstantKind.None:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.None);
 
-        case Ast.PrimitiveTypeConstantKind.Null:
+        case Constant.PrimitiveTypeConstantKind.Null:
             return Type.NoneInstance;
 
-        case Ast.PrimitiveTypeConstantKind.Number:
+        case Constant.PrimitiveTypeConstantKind.Number:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Number);
 
-        case Ast.PrimitiveTypeConstantKind.Record:
+        case Constant.PrimitiveTypeConstantKind.Record:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Record);
 
-        case Ast.PrimitiveTypeConstantKind.Table:
+        case Constant.PrimitiveTypeConstantKind.Table:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Table);
 
-        case Ast.PrimitiveTypeConstantKind.Text:
+        case Constant.PrimitiveTypeConstantKind.Text:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Text);
 
-        case Ast.PrimitiveTypeConstantKind.Time:
+        case Constant.PrimitiveTypeConstantKind.Time:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Time);
 
-        case Ast.PrimitiveTypeConstantKind.Type:
+        case Constant.PrimitiveTypeConstantKind.Type:
             return TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Type);
 
         default:

--- a/src/inspection/type/inspectType/inspectTypeLiteralExpression.ts
+++ b/src/inspection/type/inspectType/inspectTypeLiteralExpression.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Assert } from "../../../common";
-import { Ast, Type, TypeUtils } from "../../../language";
+import { Ast, Constant, Type, TypeUtils } from "../../../language";
 import { TXorNode, XorNodeKind, XorNodeUtils } from "../../../parser";
 
 export function inspectTypeLiteralExpression(xorNode: TXorNode): Type.TType {
@@ -11,9 +11,9 @@ export function inspectTypeLiteralExpression(xorNode: TXorNode): Type.TType {
     switch (xorNode.kind) {
         case XorNodeKind.Ast:
             // We already checked it's a Ast Literal Expression.
-            const literalKind: Ast.LiteralKind = (xorNode.node as Ast.LiteralExpression).literalKind;
+            const literalKind: Constant.LiteralKind = (xorNode.node as Ast.LiteralExpression).literalKind;
             const typeKind: Type.TypeKind = TypeUtils.typeKindFromLiteralKind(literalKind);
-            return TypeUtils.primitiveTypeFactory(literalKind === Ast.LiteralKind.Null, typeKind);
+            return TypeUtils.primitiveTypeFactory(literalKind === Constant.LiteralKind.Null, typeKind);
 
         case XorNodeKind.Context:
             return Type.UnknownInstance;

--- a/src/inspection/type/inspectType/inspectTypeTBinOpExpression.ts
+++ b/src/inspection/type/inspectType/inspectTypeTBinOpExpression.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Assert, CommonError } from "../../../common";
-import { Ast, AstUtils, Type, TypeUtils } from "../../../language";
+import { Ast, AstUtils, Constant, Type, TypeUtils } from "../../../language";
 import { NodeIdMapIterator, TXorNode, XorNodeKind } from "../../../parser";
 import { InspectTypeState, inspectXor } from "./common";
 
@@ -22,10 +22,10 @@ export function inspectTypeTBinOpExpression(state: InspectTypeState, xorNode: TX
     );
 
     const maybeLeft: TXorNode | undefined = children[0];
-    const maybeOperatorKind: Ast.TBinOpExpressionOperator | undefined =
+    const maybeOperatorKind: Constant.TBinOpExpressionOperator | undefined =
         children[1] === undefined || children[1].kind === XorNodeKind.Context
             ? undefined
-            : (children[1].node as Ast.IConstant<Ast.TBinOpExpressionOperator>).constantKind;
+            : (children[1].node as Ast.IConstant<Constant.TBinOpExpressionOperator>).constantKind;
     const maybeRight: TXorNode | undefined = children[2];
 
     // ''
@@ -39,7 +39,7 @@ export function inspectTypeTBinOpExpression(state: InspectTypeState, xorNode: TX
     // '1 +'
     else if (maybeRight === undefined || maybeRight.kind === XorNodeKind.Context) {
         const leftType: Type.TType = inspectXor(state, maybeLeft);
-        const operatorKind: Ast.TBinOpExpressionOperator = maybeOperatorKind;
+        const operatorKind: Constant.TBinOpExpressionOperator = maybeOperatorKind;
 
         const key: string = partialLookupKey(leftType.kind, operatorKind);
         const maybeAllowedTypeKinds: ReadonlySet<Type.TypeKind> | undefined = PartialLookup.get(key);
@@ -62,7 +62,7 @@ export function inspectTypeTBinOpExpression(state: InspectTypeState, xorNode: TX
     // '1 + 1'
     else {
         const leftType: Type.TType = inspectXor(state, maybeLeft);
-        const operatorKind: Ast.TBinOpExpressionOperator = maybeOperatorKind;
+        const operatorKind: Constant.TBinOpExpressionOperator = maybeOperatorKind;
         const rightType: Type.TType = inspectXor(state, maybeRight);
 
         const key: string = lookupKey(leftType.kind, operatorKind, rightType.kind);
@@ -74,7 +74,7 @@ export function inspectTypeTBinOpExpression(state: InspectTypeState, xorNode: TX
 
         // '[foo = 1] & [bar = 2]'
         if (
-            operatorKind === Ast.ArithmeticOperatorKind.And &&
+            operatorKind === Constant.ArithmeticOperatorKind.And &&
             (resultTypeKind === Type.TypeKind.Record || resultTypeKind === Type.TypeKind.Table)
         ) {
             return inspectRecordOrTableUnion(leftType as TRecordOrTable, rightType as TRecordOrTable);
@@ -156,12 +156,12 @@ export const Lookup: ReadonlyMap<string, Type.TypeKind> = new Map([
     ...createLookupsForRelational(Type.TypeKind.Time),
     ...createLookupsForEquality(Type.TypeKind.Time),
     ...createLookupsForClockKind(Type.TypeKind.Time),
-    [lookupKey(Type.TypeKind.Date, Ast.ArithmeticOperatorKind.And, Type.TypeKind.Time), Type.TypeKind.DateTime],
+    [lookupKey(Type.TypeKind.Date, Constant.ArithmeticOperatorKind.And, Type.TypeKind.Time), Type.TypeKind.DateTime],
 
     ...createLookupsForRelational(Type.TypeKind.Date),
     ...createLookupsForEquality(Type.TypeKind.Date),
     ...createLookupsForClockKind(Type.TypeKind.Date),
-    [lookupKey(Type.TypeKind.Date, Ast.ArithmeticOperatorKind.And, Type.TypeKind.Time), Type.TypeKind.DateTime],
+    [lookupKey(Type.TypeKind.Date, Constant.ArithmeticOperatorKind.And, Type.TypeKind.Time), Type.TypeKind.DateTime],
 
     ...createLookupsForRelational(Type.TypeKind.DateTime),
     ...createLookupsForEquality(Type.TypeKind.DateTime),
@@ -174,41 +174,41 @@ export const Lookup: ReadonlyMap<string, Type.TypeKind> = new Map([
     ...createLookupsForRelational(Type.TypeKind.Duration),
     ...createLookupsForEquality(Type.TypeKind.Duration),
     [
-        lookupKey(Type.TypeKind.Duration, Ast.ArithmeticOperatorKind.Addition, Type.TypeKind.Duration),
+        lookupKey(Type.TypeKind.Duration, Constant.ArithmeticOperatorKind.Addition, Type.TypeKind.Duration),
         Type.TypeKind.Duration,
     ],
     [
-        lookupKey(Type.TypeKind.Duration, Ast.ArithmeticOperatorKind.Subtraction, Type.TypeKind.Duration),
+        lookupKey(Type.TypeKind.Duration, Constant.ArithmeticOperatorKind.Subtraction, Type.TypeKind.Duration),
         Type.TypeKind.Duration,
     ],
     [
-        lookupKey(Type.TypeKind.Duration, Ast.ArithmeticOperatorKind.Multiplication, Type.TypeKind.Number),
+        lookupKey(Type.TypeKind.Duration, Constant.ArithmeticOperatorKind.Multiplication, Type.TypeKind.Number),
         Type.TypeKind.Duration,
     ],
     [
-        lookupKey(Type.TypeKind.Number, Ast.ArithmeticOperatorKind.Multiplication, Type.TypeKind.Duration),
+        lookupKey(Type.TypeKind.Number, Constant.ArithmeticOperatorKind.Multiplication, Type.TypeKind.Duration),
         Type.TypeKind.Duration,
     ],
     [
-        lookupKey(Type.TypeKind.Duration, Ast.ArithmeticOperatorKind.Division, Type.TypeKind.Number),
+        lookupKey(Type.TypeKind.Duration, Constant.ArithmeticOperatorKind.Division, Type.TypeKind.Number),
         Type.TypeKind.Duration,
     ],
 
     ...createLookupsForRelational(Type.TypeKind.Text),
     ...createLookupsForEquality(Type.TypeKind.Text),
-    [lookupKey(Type.TypeKind.Text, Ast.ArithmeticOperatorKind.And, Type.TypeKind.Text), Type.TypeKind.Text],
+    [lookupKey(Type.TypeKind.Text, Constant.ArithmeticOperatorKind.And, Type.TypeKind.Text), Type.TypeKind.Text],
 
     ...createLookupsForRelational(Type.TypeKind.Binary),
     ...createLookupsForEquality(Type.TypeKind.Binary),
 
     ...createLookupsForEquality(Type.TypeKind.List),
-    [lookupKey(Type.TypeKind.List, Ast.ArithmeticOperatorKind.And, Type.TypeKind.List), Type.TypeKind.List],
+    [lookupKey(Type.TypeKind.List, Constant.ArithmeticOperatorKind.And, Type.TypeKind.List), Type.TypeKind.List],
 
     ...createLookupsForEquality(Type.TypeKind.Record),
-    [lookupKey(Type.TypeKind.Record, Ast.ArithmeticOperatorKind.And, Type.TypeKind.Record), Type.TypeKind.Record],
+    [lookupKey(Type.TypeKind.Record, Constant.ArithmeticOperatorKind.And, Type.TypeKind.Record), Type.TypeKind.Record],
 
     ...createLookupsForEquality(Type.TypeKind.Table),
-    [lookupKey(Type.TypeKind.Table, Ast.ArithmeticOperatorKind.And, Type.TypeKind.Table), Type.TypeKind.Table],
+    [lookupKey(Type.TypeKind.Table, Constant.ArithmeticOperatorKind.And, Type.TypeKind.Table), Type.TypeKind.Table],
 ]);
 
 // Keys: <first operand> <operator>
@@ -248,46 +248,46 @@ export const PartialLookup: ReadonlyMap<string, ReadonlySet<Type.TypeKind>> = ne
 
 export function lookupKey(
     leftTypeKind: Type.TypeKind,
-    operatorKind: Ast.TBinOpExpressionOperator,
+    operatorKind: Constant.TBinOpExpressionOperator,
     rightTypeKind: Type.TypeKind,
 ): string {
     return `${leftTypeKind},${operatorKind},${rightTypeKind}`;
 }
 
-export function partialLookupKey(leftTypeKind: Type.TypeKind, operatorKind: Ast.TBinOpExpressionOperator): string {
+export function partialLookupKey(leftTypeKind: Type.TypeKind, operatorKind: Constant.TBinOpExpressionOperator): string {
     return `${leftTypeKind},${operatorKind}`;
 }
 
 function createLookupsForRelational(typeKind: Type.TypeKind): ReadonlyArray<[string, Type.TypeKind]> {
     return [
-        [lookupKey(typeKind, Ast.RelationalOperatorKind.GreaterThan, typeKind), Type.TypeKind.Logical],
-        [lookupKey(typeKind, Ast.RelationalOperatorKind.GreaterThanEqualTo, typeKind), Type.TypeKind.Logical],
-        [lookupKey(typeKind, Ast.RelationalOperatorKind.LessThan, typeKind), Type.TypeKind.Logical],
-        [lookupKey(typeKind, Ast.RelationalOperatorKind.LessThanEqualTo, typeKind), Type.TypeKind.Logical],
+        [lookupKey(typeKind, Constant.RelationalOperatorKind.GreaterThan, typeKind), Type.TypeKind.Logical],
+        [lookupKey(typeKind, Constant.RelationalOperatorKind.GreaterThanEqualTo, typeKind), Type.TypeKind.Logical],
+        [lookupKey(typeKind, Constant.RelationalOperatorKind.LessThan, typeKind), Type.TypeKind.Logical],
+        [lookupKey(typeKind, Constant.RelationalOperatorKind.LessThanEqualTo, typeKind), Type.TypeKind.Logical],
     ];
 }
 
 function createLookupsForEquality(typeKind: Type.TypeKind): ReadonlyArray<[string, Type.TypeKind]> {
     return [
-        [lookupKey(typeKind, Ast.EqualityOperatorKind.EqualTo, typeKind), Type.TypeKind.Logical],
-        [lookupKey(typeKind, Ast.EqualityOperatorKind.NotEqualTo, typeKind), Type.TypeKind.Logical],
+        [lookupKey(typeKind, Constant.EqualityOperatorKind.EqualTo, typeKind), Type.TypeKind.Logical],
+        [lookupKey(typeKind, Constant.EqualityOperatorKind.NotEqualTo, typeKind), Type.TypeKind.Logical],
     ];
 }
 
-// Note: does not include the and <'&'> operator.
+// Note: does not include the and <'&'> Constant.
 function createLookupsForArithmetic(typeKind: Type.TypeKind): ReadonlyArray<[string, Type.TypeKind]> {
     return [
-        [lookupKey(typeKind, Ast.ArithmeticOperatorKind.Addition, typeKind), typeKind],
-        [lookupKey(typeKind, Ast.ArithmeticOperatorKind.Division, typeKind), typeKind],
-        [lookupKey(typeKind, Ast.ArithmeticOperatorKind.Multiplication, typeKind), typeKind],
-        [lookupKey(typeKind, Ast.ArithmeticOperatorKind.Subtraction, typeKind), typeKind],
+        [lookupKey(typeKind, Constant.ArithmeticOperatorKind.Addition, typeKind), typeKind],
+        [lookupKey(typeKind, Constant.ArithmeticOperatorKind.Division, typeKind), typeKind],
+        [lookupKey(typeKind, Constant.ArithmeticOperatorKind.Multiplication, typeKind), typeKind],
+        [lookupKey(typeKind, Constant.ArithmeticOperatorKind.Subtraction, typeKind), typeKind],
     ];
 }
 
 function createLookupsForLogical(typeKind: Type.TypeKind): ReadonlyArray<[string, Type.TypeKind]> {
     return [
-        [lookupKey(typeKind, Ast.LogicalOperatorKind.And, typeKind), typeKind],
-        [lookupKey(typeKind, Ast.LogicalOperatorKind.Or, typeKind), typeKind],
+        [lookupKey(typeKind, Constant.LogicalOperatorKind.And, typeKind), typeKind],
+        [lookupKey(typeKind, Constant.LogicalOperatorKind.Or, typeKind), typeKind],
     ];
 }
 
@@ -295,9 +295,9 @@ function createLookupsForClockKind(
     typeKind: Type.TypeKind.Date | Type.TypeKind.DateTime | Type.TypeKind.DateTimeZone | Type.TypeKind.Time,
 ): ReadonlyArray<[string, Type.TypeKind]> {
     return [
-        [lookupKey(typeKind, Ast.ArithmeticOperatorKind.Addition, Type.TypeKind.Duration), typeKind],
-        [lookupKey(Type.TypeKind.Duration, Ast.ArithmeticOperatorKind.Addition, typeKind), typeKind],
-        [lookupKey(typeKind, Ast.ArithmeticOperatorKind.Subtraction, Type.TypeKind.Duration), typeKind],
-        [lookupKey(typeKind, Ast.ArithmeticOperatorKind.Subtraction, typeKind), Type.TypeKind.Duration],
+        [lookupKey(typeKind, Constant.ArithmeticOperatorKind.Addition, Type.TypeKind.Duration), typeKind],
+        [lookupKey(Type.TypeKind.Duration, Constant.ArithmeticOperatorKind.Addition, typeKind), typeKind],
+        [lookupKey(typeKind, Constant.ArithmeticOperatorKind.Subtraction, Type.TypeKind.Duration), typeKind],
+        [lookupKey(typeKind, Constant.ArithmeticOperatorKind.Subtraction, typeKind), Type.TypeKind.Duration],
     ];
 }

--- a/src/inspection/type/inspectType/inspectTypeUnaryExpression.ts
+++ b/src/inspection/type/inspectType/inspectTypeUnaryExpression.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast, Type } from "../../../language";
+import { Ast, Constant, Type } from "../../../language";
 import { NodeIdMap, NodeIdMapIterator, NodeIdMapUtils, TXorNode, XorNodeUtils } from "../../../parser";
 import { InspectTypeState, inspectXor } from "./common";
 
@@ -31,20 +31,20 @@ export function inspectTypeUnaryExpression(state: InspectTypeState, xorNode: TXo
 
     // Only certain operators are allowed depending on the type.
     // Unlike BinOpExpression, it's easier to implement the check without a lookup table.
-    let expectedUnaryOperatorKinds: ReadonlyArray<Ast.UnaryOperatorKind>;
+    let expectedUnaryOperatorKinds: ReadonlyArray<Constant.UnaryOperatorKind>;
     const expressionType: Type.TType = inspectXor(state, maybeExpression);
     if (expressionType.kind === Type.TypeKind.Number) {
-        expectedUnaryOperatorKinds = [Ast.UnaryOperatorKind.Positive, Ast.UnaryOperatorKind.Negative];
+        expectedUnaryOperatorKinds = [Constant.UnaryOperatorKind.Positive, Constant.UnaryOperatorKind.Negative];
     } else if (expressionType.kind === Type.TypeKind.Logical) {
-        expectedUnaryOperatorKinds = [Ast.UnaryOperatorKind.Not];
+        expectedUnaryOperatorKinds = [Constant.UnaryOperatorKind.Not];
     } else {
         return Type.NoneInstance;
     }
 
-    const operators: ReadonlyArray<Ast.IConstant<Ast.UnaryOperatorKind>> = NodeIdMapIterator.maybeIterChildrenAst(
+    const operators: ReadonlyArray<Ast.IConstant<Constant.UnaryOperatorKind>> = NodeIdMapIterator.maybeIterChildrenAst(
         nodeIdMapCollection,
         maybeOperatorsWrapper.node.id,
-    ) as ReadonlyArray<Ast.IConstant<Ast.UnaryOperatorKind>>;
+    ) as ReadonlyArray<Ast.IConstant<Constant.UnaryOperatorKind>>;
     for (const operator of operators) {
         if (expectedUnaryOperatorKinds.indexOf(operator.constantKind) === -1) {
             return Type.NoneInstance;

--- a/src/language/ast/ast.ts
+++ b/src/language/ast/ast.ts
@@ -930,3 +930,60 @@ export const enum LiteralKind {
     Record = "Record",
     Text = "Text",
 }
+
+// ------------------------------------------
+// ---------- const enum iterables ----------
+// ------------------------------------------
+
+export const PrimitiveTypeConstantKinds: ReadonlyArray<PrimitiveTypeConstantKind> = [
+    PrimitiveTypeConstantKind.Action,
+    PrimitiveTypeConstantKind.Any,
+    PrimitiveTypeConstantKind.AnyNonNull,
+    PrimitiveTypeConstantKind.Binary,
+    PrimitiveTypeConstantKind.Date,
+    PrimitiveTypeConstantKind.DateTime,
+    PrimitiveTypeConstantKind.DateTimeZone,
+    PrimitiveTypeConstantKind.Duration,
+    PrimitiveTypeConstantKind.Function,
+    PrimitiveTypeConstantKind.List,
+    PrimitiveTypeConstantKind.Logical,
+    PrimitiveTypeConstantKind.None,
+    PrimitiveTypeConstantKind.Null,
+    PrimitiveTypeConstantKind.Number,
+    PrimitiveTypeConstantKind.Record,
+    PrimitiveTypeConstantKind.Table,
+    PrimitiveTypeConstantKind.Text,
+    PrimitiveTypeConstantKind.Time,
+    PrimitiveTypeConstantKind.Type,
+];
+
+export const ArithmeticOperatorKinds: ReadonlyArray<ArithmeticOperatorKind> = [
+    ArithmeticOperatorKind.Multiplication,
+    ArithmeticOperatorKind.Division,
+    ArithmeticOperatorKind.Addition,
+    ArithmeticOperatorKind.Subtraction,
+    ArithmeticOperatorKind.And,
+];
+
+export const EqualityOperatorKinds: ReadonlyArray<EqualityOperatorKind> = [
+    EqualityOperatorKind.EqualTo,
+    EqualityOperatorKind.NotEqualTo,
+];
+
+export const LogicalOperatorKinds: ReadonlyArray<LogicalOperatorKind> = [
+    LogicalOperatorKind.And,
+    LogicalOperatorKind.Or,
+];
+
+export const RelationalOperatorKinds: ReadonlyArray<RelationalOperatorKind> = [
+    RelationalOperatorKind.LessThan,
+    RelationalOperatorKind.LessThanEqualTo,
+    RelationalOperatorKind.GreaterThan,
+    RelationalOperatorKind.GreaterThanEqualTo,
+];
+
+export const UnaryOperatorKinds: ReadonlyArray<UnaryOperatorKind> = [
+    UnaryOperatorKind.Positive,
+    UnaryOperatorKind.Negative,
+    UnaryOperatorKind.Not,
+];

--- a/src/language/ast/ast.ts
+++ b/src/language/ast/ast.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { Constant } from "..";
 import { TokenRange } from "../token";
 
 export const enum NodeKind {
@@ -106,7 +107,7 @@ export type TAuxiliaryNodes =
 
 export type TArrayWrapper =
     | IArrayWrapper<AsNullablePrimitiveType>
-    | IArrayWrapper<IConstant<UnaryOperatorKind>>
+    | IArrayWrapper<IConstant<Constant.UnaryOperatorKind>>
     | IArrayWrapper<IsNullablePrimitiveType>
     | IArrayWrapper<SectionMember>
     | IArrayWrapper<TRecursivePrimaryExpression>
@@ -220,9 +221,9 @@ export interface Section extends INode {
     readonly kind: NodeKind.Section;
     readonly isLeaf: false;
     readonly maybeLiteralAttributes: RecordLiteral | undefined;
-    readonly sectionConstant: IConstant<KeywordConstantKind.Section>;
+    readonly sectionConstant: IConstant<Constant.KeywordConstantKind.Section>;
     readonly maybeName: Identifier | undefined;
-    readonly semicolonConstant: IConstant<MiscConstantKind.Semicolon>;
+    readonly semicolonConstant: IConstant<Constant.MiscConstantKind.Semicolon>;
     readonly sectionMembers: IArrayWrapper<SectionMember>;
 }
 
@@ -230,9 +231,9 @@ export interface SectionMember extends INode {
     readonly kind: NodeKind.SectionMember;
     readonly isLeaf: false;
     readonly maybeLiteralAttributes: RecordLiteral | undefined;
-    readonly maybeSharedConstant: IConstant<KeywordConstantKind.Shared> | undefined;
+    readonly maybeSharedConstant: IConstant<Constant.KeywordConstantKind.Shared> | undefined;
     readonly namePairedExpression: IdentifierPairedExpression;
-    readonly semicolonConstant: IConstant<MiscConstantKind.Semicolon>;
+    readonly semicolonConstant: IConstant<Constant.MiscConstantKind.Semicolon>;
 }
 
 // ------------------------------------------
@@ -263,15 +264,19 @@ export type TIsExpression = IsExpression | TAsExpression;
 export type TNullablePrimitiveType = NullablePrimitiveType | PrimitiveType;
 
 export interface NullablePrimitiveType
-    extends IPairedConstant<NodeKind.NullablePrimitiveType, IdentifierConstantKind.Nullable, PrimitiveType> {}
+    extends IPairedConstant<NodeKind.NullablePrimitiveType, Constant.IdentifierConstantKind.Nullable, PrimitiveType> {}
 
 export interface IsNullablePrimitiveType
-    extends IPairedConstant<NodeKind.IsNullablePrimitiveType, KeywordConstantKind.Is, TNullablePrimitiveType> {}
+    extends IPairedConstant<
+        NodeKind.IsNullablePrimitiveType,
+        Constant.KeywordConstantKind.Is,
+        TNullablePrimitiveType
+    > {}
 
 export interface PrimitiveType extends INode {
     readonly kind: NodeKind.PrimitiveType;
     readonly isLeaf: false;
-    readonly primitiveType: IConstant<PrimitiveTypeConstantKind>;
+    readonly primitiveType: IConstant<Constant.PrimitiveTypeConstantKind>;
 }
 
 // --------------------------------------------
@@ -308,7 +313,7 @@ export interface MetadataExpression
     extends IBinOpExpression<
         NodeKind.MetadataExpression,
         TUnaryExpression,
-        KeywordConstantKind.Meta,
+        Constant.KeywordConstantKind.Meta,
         TUnaryExpression
     > {}
 
@@ -321,7 +326,7 @@ export type TUnaryExpression = UnaryExpression | TTypeExpression;
 export interface UnaryExpression extends INode {
     readonly kind: NodeKind.UnaryExpression;
     readonly isLeaf: false;
-    readonly operators: IArrayWrapper<IConstant<UnaryOperatorKind>>;
+    readonly operators: IArrayWrapper<IConstant<Constant.UnaryOperatorKind>>;
     readonly typeExpression: TTypeExpression;
 }
 
@@ -348,7 +353,7 @@ export interface LiteralExpression extends INode {
     readonly kind: NodeKind.LiteralExpression;
     readonly isLeaf: true;
     readonly literal: string;
-    readonly literalKind: Exclude<LiteralKind, LiteralKind.Record>;
+    readonly literalKind: Exclude<Constant.LiteralKind, Constant.LiteralKind.Record>;
 }
 
 // -----------------------------------------------------
@@ -358,7 +363,7 @@ export interface LiteralExpression extends INode {
 export interface IdentifierExpression extends INode {
     readonly kind: NodeKind.IdentifierExpression;
     readonly isLeaf: false;
-    readonly maybeInclusiveConstant: IConstant<MiscConstantKind.AtSign> | undefined;
+    readonly maybeInclusiveConstant: IConstant<Constant.MiscConstantKind.AtSign> | undefined;
     readonly identifier: Identifier;
 }
 
@@ -375,7 +380,7 @@ export interface ParenthesizedExpression extends IParenthesisWrapped<NodeKind.Pa
 export interface NotImplementedExpression extends INode {
     readonly kind: NodeKind.NotImplementedExpression;
     readonly isLeaf: false;
-    readonly ellipsisConstant: IConstant<MiscConstantKind.Ellipsis>;
+    readonly ellipsisConstant: IConstant<Constant.MiscConstantKind.Ellipsis>;
 }
 
 // -------------------------------------------------
@@ -396,7 +401,7 @@ export interface RangeExpression extends INode {
     readonly kind: NodeKind.RangeExpression;
     readonly isLeaf: false;
     readonly left: TExpression;
-    readonly rangeConstant: IConstant<MiscConstantKind.DotDot>;
+    readonly rangeConstant: IConstant<Constant.MiscConstantKind.DotDot>;
     readonly right: TExpression;
 }
 
@@ -413,7 +418,7 @@ export interface RecordExpression
 
 export interface ItemAccessExpression extends IBraceWrapped<NodeKind.ItemAccessExpression, TExpression> {
     // located after closeWrapperConstant
-    readonly maybeOptionalConstant: IConstant<MiscConstantKind.QuestionMark> | undefined;
+    readonly maybeOptionalConstant: IConstant<Constant.MiscConstantKind.QuestionMark> | undefined;
 }
 
 // --------------------------------------------------------
@@ -424,12 +429,12 @@ export type TFieldAccessExpression = FieldSelector | FieldProjection;
 
 export interface FieldSelector extends IBracketWrapped<NodeKind.FieldSelector, GeneralizedIdentifier> {
     // located after closeWrapperConstant
-    readonly maybeOptionalConstant: IConstant<MiscConstantKind.QuestionMark> | undefined;
+    readonly maybeOptionalConstant: IConstant<Constant.MiscConstantKind.QuestionMark> | undefined;
 }
 
 export interface FieldProjection extends IBracketWrapped<NodeKind.FieldProjection, ICsvArray<FieldSelector>> {
     // located after closeWrapperConstant
-    readonly maybeOptionalConstant: IConstant<MiscConstantKind.QuestionMark> | undefined;
+    readonly maybeOptionalConstant: IConstant<Constant.MiscConstantKind.QuestionMark> | undefined;
 }
 
 // ---------------------------------------------------
@@ -441,7 +446,7 @@ export interface FunctionExpression extends INode {
     readonly isLeaf: false;
     readonly parameters: IParameterList<AsNullablePrimitiveType | undefined>;
     readonly maybeFunctionReturnType: AsNullablePrimitiveType | undefined;
-    readonly fatArrowConstant: IConstant<MiscConstantKind.FatArrow>;
+    readonly fatArrowConstant: IConstant<Constant.MiscConstantKind.FatArrow>;
     readonly expression: TExpression;
 }
 
@@ -450,7 +455,7 @@ export interface FunctionExpression extends INode {
 // -----------------------------------------------
 
 export interface EachExpression
-    extends IPairedConstant<NodeKind.EachExpression, KeywordConstantKind.Each, TExpression> {}
+    extends IPairedConstant<NodeKind.EachExpression, Constant.KeywordConstantKind.Each, TExpression> {}
 
 // ----------------------------------------------
 // ---------- 12.2.3.23 Let expression ----------
@@ -458,9 +463,9 @@ export interface EachExpression
 
 export interface LetExpression extends INode {
     readonly kind: NodeKind.LetExpression;
-    readonly letConstant: IConstant<KeywordConstantKind.Let>;
+    readonly letConstant: IConstant<Constant.KeywordConstantKind.Let>;
     readonly variableList: ICsvArray<IdentifierPairedExpression>;
-    readonly inConstant: IConstant<KeywordConstantKind.In>;
+    readonly inConstant: IConstant<Constant.KeywordConstantKind.In>;
     readonly expression: TExpression;
 }
 
@@ -471,11 +476,11 @@ export interface LetExpression extends INode {
 export interface IfExpression extends INode {
     readonly kind: NodeKind.IfExpression;
     readonly isLeaf: false;
-    readonly ifConstant: IConstant<KeywordConstantKind.If>;
+    readonly ifConstant: IConstant<Constant.KeywordConstantKind.If>;
     readonly condition: TExpression;
-    readonly thenConstant: IConstant<KeywordConstantKind.Then>;
+    readonly thenConstant: IConstant<Constant.KeywordConstantKind.Then>;
     readonly trueExpression: TExpression;
-    readonly elseConstant: IConstant<KeywordConstantKind.Else>;
+    readonly elseConstant: IConstant<Constant.KeywordConstantKind.Else>;
     readonly falseExpression: TExpression;
 }
 
@@ -493,14 +498,15 @@ export type TPrimaryType = PrimitiveType | FunctionType | ListType | NullableTyp
 export interface FunctionType extends INode {
     readonly kind: NodeKind.FunctionType;
     readonly isLeaf: false;
-    readonly functionConstant: IConstant<PrimitiveTypeConstantKind.Function>;
+    readonly functionConstant: IConstant<Constant.PrimitiveTypeConstantKind.Function>;
     readonly parameters: IParameterList<AsType>;
     readonly functionReturnType: AsType;
 }
 
 export interface ListType extends IBraceWrapped<NodeKind.ListType, TType> {}
 
-export interface NullableType extends IPairedConstant<NodeKind.NullableType, IdentifierConstantKind.Nullable, TType> {}
+export interface NullableType
+    extends IPairedConstant<NodeKind.NullableType, Constant.IdentifierConstantKind.Nullable, TType> {}
 
 export interface RecordType extends INode {
     readonly kind: NodeKind.RecordType;
@@ -511,7 +517,7 @@ export interface RecordType extends INode {
 export interface TableType extends INode {
     readonly kind: NodeKind.TableType;
     readonly isLeaf: false;
-    readonly tableConstant: IConstant<PrimitiveTypeConstantKind.Table>;
+    readonly tableConstant: IConstant<Constant.PrimitiveTypeConstantKind.Table>;
     readonly rowType: FieldSpecificationList | TPrimaryExpression;
 }
 
@@ -520,7 +526,7 @@ export interface TableType extends INode {
 // --------------------------------------------------------
 
 export interface ErrorRaisingExpression
-    extends IPairedConstant<NodeKind.ErrorRaisingExpression, KeywordConstantKind.Error, TExpression> {}
+    extends IPairedConstant<NodeKind.ErrorRaisingExpression, Constant.KeywordConstantKind.Error, TExpression> {}
 
 // ---------------------------------------------------------
 // ---------- 12.2.3.27 Error handling expression ----------
@@ -529,13 +535,13 @@ export interface ErrorRaisingExpression
 export interface ErrorHandlingExpression extends INode {
     readonly kind: NodeKind.ErrorHandlingExpression;
     readonly isLeaf: false;
-    readonly tryConstant: IConstant<KeywordConstantKind.Try>;
+    readonly tryConstant: IConstant<Constant.KeywordConstantKind.Try>;
     readonly protectedExpression: TExpression;
     readonly maybeOtherwiseExpression: OtherwiseExpression | undefined;
 }
 
 export interface OtherwiseExpression
-    extends IPairedConstant<NodeKind.OtherwiseExpression, KeywordConstantKind.Otherwise, TExpression> {}
+    extends IPairedConstant<NodeKind.OtherwiseExpression, Constant.KeywordConstantKind.Otherwise, TExpression> {}
 
 export interface RecursivePrimaryExpression extends INode {
     readonly kind: NodeKind.RecursivePrimaryExpression;
@@ -545,7 +551,7 @@ export interface RecursivePrimaryExpression extends INode {
 }
 
 export interface TypePrimaryType
-    extends IPairedConstant<NodeKind.TypePrimaryType, KeywordConstantKind.Type, TPrimaryType> {}
+    extends IPairedConstant<NodeKind.TypePrimaryType, Constant.KeywordConstantKind.Type, TPrimaryType> {}
 
 // -----------------------------------------------
 // ---------- 12.2.4 Literal Attributes ----------
@@ -554,12 +560,12 @@ export interface TypePrimaryType
 export type TAnyLiteral = ListLiteral | LiteralExpression | RecordLiteral;
 
 export interface ListLiteral extends IBraceWrapped<NodeKind.ListLiteral, ICsvArray<TAnyLiteral>> {
-    readonly literalKind: LiteralKind.List;
+    readonly literalKind: Constant.LiteralKind.List;
 }
 
 export interface RecordLiteral
     extends IBracketWrapped<NodeKind.RecordLiteral, ICsvArray<GeneralizedIdentifierPairedAnyLiteral>> {
-    readonly literalKind: LiteralKind.Record;
+    readonly literalKind: Constant.LiteralKind.Record;
 }
 
 // -----------------------------------------
@@ -578,20 +584,23 @@ export interface ICsvArray<T extends TCsvType> extends IArrayWrapper<ICsv<T>> {}
 export interface ICsv<T> extends INode {
     readonly kind: NodeKind.Csv;
     readonly node: T;
-    readonly maybeCommaConstant: IConstant<MiscConstantKind.Comma> | undefined;
+    readonly maybeCommaConstant: IConstant<Constant.MiscConstantKind.Comma> | undefined;
 }
 
 export interface IKeyValuePair<Kind extends TKeyValuePairNodeKind, Key, Value> extends INode {
     readonly kind: Kind;
     readonly key: Key;
-    readonly equalConstant: IConstant<MiscConstantKind.Equal>;
+    readonly equalConstant: IConstant<Constant.MiscConstantKind.Equal>;
     readonly value: Value;
 }
 
 // A [Constant, T] tuple
 // eg. EachExpression is a `each` Constant paired with a TExpression
-export interface IPairedConstant<Kind extends TPairedConstantNodeKind, ConstantKind extends TConstantKind, Paired>
-    extends INode {
+export interface IPairedConstant<
+    Kind extends TPairedConstantNodeKind,
+    ConstantKind extends Constant.TConstantKind,
+    Paired
+> extends INode {
     readonly kind: Kind;
     readonly constant: IConstant<ConstantKind>;
     readonly paired: Paired;
@@ -599,9 +608,9 @@ export interface IPairedConstant<Kind extends TPairedConstantNodeKind, ConstantK
 
 export interface IWrapped<
     Kind extends TWrappedNodeKind,
-    Open extends WrapperConstantKind,
+    Open extends Constant.WrapperConstantKind,
     Content,
-    Close extends WrapperConstantKind
+    Close extends Constant.WrapperConstantKind
 > extends INode {
     readonly kind: Kind;
     readonly openWrapperConstant: IConstant<Open>;
@@ -610,13 +619,23 @@ export interface IWrapped<
 }
 
 export interface IBraceWrapped<Kind extends TWrappedNodeKind, Content>
-    extends IWrapped<Kind, WrapperConstantKind.LeftBrace, Content, WrapperConstantKind.RightBrace> {}
+    extends IWrapped<Kind, Constant.WrapperConstantKind.LeftBrace, Content, Constant.WrapperConstantKind.RightBrace> {}
 
 export interface IBracketWrapped<Kind extends TWrappedNodeKind, Content>
-    extends IWrapped<Kind, WrapperConstantKind.LeftBracket, Content, WrapperConstantKind.RightBracket> {}
+    extends IWrapped<
+        Kind,
+        Constant.WrapperConstantKind.LeftBracket,
+        Content,
+        Constant.WrapperConstantKind.RightBracket
+    > {}
 
 export interface IParenthesisWrapped<Kind extends TWrappedNodeKind, Content>
-    extends IWrapped<Kind, WrapperConstantKind.LeftParenthesis, Content, WrapperConstantKind.RightParenthesis> {}
+    extends IWrapped<
+        Kind,
+        Constant.WrapperConstantKind.LeftParenthesis,
+        Content,
+        Constant.WrapperConstantKind.RightParenthesis
+    > {}
 
 // --------------------------------------
 // ---------- IBinOpExpression ----------
@@ -633,26 +652,26 @@ export type TBinOpExpression =
     | RelationalExpression
     | TBinOpExpressionSubtype;
 
-export type TBinOpExpressionOperator =
-    | ArithmeticOperatorKind
-    | EqualityOperatorKind
-    | LogicalOperatorKind
-    | RelationalOperatorKind
-    | MiscConstantKind.NullCoalescingOperator
-    | KeywordConstantKind.As
-    | KeywordConstantKind.Is
-    | KeywordConstantKind.Meta;
-
 // The following types are needed for recursiveReadBinOpExpressionHelper,
 // and are created by converting IBinOpExpression<A, B, C, D> to IBinOpExpression<A, D, C, D>.
 export type TBinOpExpressionSubtype =
-    | IBinOpExpression<NodeKind.AsExpression, TNullablePrimitiveType, KeywordConstantKind.As, TNullablePrimitiveType>
-    | IBinOpExpression<NodeKind.IsExpression, TNullablePrimitiveType, KeywordConstantKind.Is, TNullablePrimitiveType>;
+    | IBinOpExpression<
+          NodeKind.AsExpression,
+          TNullablePrimitiveType,
+          Constant.KeywordConstantKind.As,
+          TNullablePrimitiveType
+      >
+    | IBinOpExpression<
+          NodeKind.IsExpression,
+          TNullablePrimitiveType,
+          Constant.KeywordConstantKind.Is,
+          TNullablePrimitiveType
+      >;
 
 export interface IBinOpExpression<
     Kind extends TBinOpExpressionNodeKind,
     Left,
-    OperatorKind extends TBinOpExpressionOperator,
+    OperatorKind extends Constant.TBinOpExpressionOperator,
     Right
 > extends INode {
     readonly kind: Kind;
@@ -669,7 +688,7 @@ export interface ArithmeticExpression
     extends IBinOpExpression<
         NodeKind.ArithmeticExpression,
         TArithmeticExpression,
-        ArithmeticOperatorKind,
+        Constant.ArithmeticOperatorKind,
         TArithmeticExpression
     > {}
 
@@ -677,7 +696,7 @@ export interface AsExpression
     extends IBinOpExpression<
         NodeKind.AsExpression,
         TEqualityExpression,
-        KeywordConstantKind.As,
+        Constant.KeywordConstantKind.As,
         TNullablePrimitiveType
     > {}
 
@@ -685,21 +704,31 @@ export interface EqualityExpression
     extends IBinOpExpression<
         NodeKind.EqualityExpression,
         TEqualityExpression,
-        EqualityOperatorKind,
+        Constant.EqualityOperatorKind,
         TEqualityExpression
     > {}
 
 export interface IsExpression
-    extends IBinOpExpression<NodeKind.IsExpression, TAsExpression, KeywordConstantKind.Is, TNullablePrimitiveType> {}
+    extends IBinOpExpression<
+        NodeKind.IsExpression,
+        TAsExpression,
+        Constant.KeywordConstantKind.Is,
+        TNullablePrimitiveType
+    > {}
 
 export interface LogicalExpression
-    extends IBinOpExpression<NodeKind.LogicalExpression, TLogicalExpression, LogicalOperatorKind, TLogicalExpression> {}
+    extends IBinOpExpression<
+        NodeKind.LogicalExpression,
+        TLogicalExpression,
+        Constant.LogicalOperatorKind,
+        TLogicalExpression
+    > {}
 
 export interface RelationalExpression
     extends IBinOpExpression<
         NodeKind.RelationalExpression,
         TRelationalExpression,
-        RelationalOperatorKind,
+        Constant.RelationalOperatorKind,
         TRelationalExpression
     > {}
 
@@ -728,39 +757,31 @@ export interface IParameterList<T extends TParameterType>
 export interface IParameter<T extends TParameterType> extends INode {
     readonly kind: NodeKind.Parameter;
     readonly isLeaf: false;
-    readonly maybeOptionalConstant: IConstant<IdentifierConstantKind.Optional> | undefined;
+    readonly maybeOptionalConstant: IConstant<Constant.IdentifierConstantKind.Optional> | undefined;
     readonly name: Identifier;
     readonly maybeParameterType: T;
 }
 
 export interface AsNullablePrimitiveType
-    extends IPairedConstant<NodeKind.AsNullablePrimitiveType, KeywordConstantKind.As, TNullablePrimitiveType> {}
+    extends IPairedConstant<
+        NodeKind.AsNullablePrimitiveType,
+        Constant.KeywordConstantKind.As,
+        TNullablePrimitiveType
+    > {}
 
-export interface AsType extends IPairedConstant<NodeKind.AsType, KeywordConstantKind.As, TType> {}
+export interface AsType extends IPairedConstant<NodeKind.AsType, Constant.KeywordConstantKind.As, TType> {}
 
 // ------------------------------
 // ---------- Constant ----------
 // ------------------------------
 
-export type TConstantKind =
-    | ArithmeticOperatorKind
-    | EqualityOperatorKind
-    | IdentifierConstantKind
-    | KeywordConstantKind
-    | LogicalOperatorKind
-    | MiscConstantKind
-    | PrimitiveTypeConstantKind
-    | RelationalOperatorKind
-    | UnaryOperatorKind
-    | WrapperConstantKind;
-
-export interface IConstant<ConstantKind extends TConstantKind> extends INode {
+export interface IConstant<ConstantKind extends Constant.TConstantKind> extends INode {
     readonly kind: NodeKind.Constant;
     readonly isLeaf: true;
     readonly constantKind: ConstantKind;
 }
 
-export type TConstant = IConstant<TConstantKind>;
+export type TConstant = IConstant<Constant.TConstantKind>;
 
 // ----------------------------------------------
 // ---------- NullCoalescingExpression ----------
@@ -776,7 +797,7 @@ export interface NullCoalescingExpression
     extends IBinOpExpression<
         NodeKind.NullCoalescingExpression,
         TLogicalExpression,
-        MiscConstantKind.NullCoalescingOperator,
+        Constant.MiscConstantKind.NullCoalescingOperator,
         TLogicalExpression
     > {}
 
@@ -787,19 +808,19 @@ export interface NullCoalescingExpression
 export interface FieldSpecification extends INode {
     readonly kind: NodeKind.FieldSpecification;
     readonly isLeaf: false;
-    readonly maybeOptionalConstant: IConstant<IdentifierConstantKind.Optional> | undefined;
+    readonly maybeOptionalConstant: IConstant<Constant.IdentifierConstantKind.Optional> | undefined;
     readonly name: GeneralizedIdentifier;
     readonly maybeFieldTypeSpecification: FieldTypeSpecification | undefined;
 }
 export interface FieldSpecificationList
     extends IBracketWrapped<NodeKind.FieldSpecificationList, ICsvArray<FieldSpecification>> {
     // located between content and closeWrapperConstant
-    readonly maybeOpenRecordMarkerConstant: IConstant<MiscConstantKind.Ellipsis> | undefined;
+    readonly maybeOpenRecordMarkerConstant: IConstant<Constant.MiscConstantKind.Ellipsis> | undefined;
 }
 
 export interface FieldTypeSpecification extends INode {
     readonly kind: NodeKind.FieldTypeSpecification;
-    readonly equalConstant: IConstant<MiscConstantKind.Equal>;
+    readonly equalConstant: IConstant<Constant.MiscConstantKind.Equal>;
     readonly fieldType: TType;
 }
 
@@ -814,176 +835,3 @@ export interface Identifier extends INode {
     readonly isLeaf: true;
     readonly literal: string;
 }
-
-// ---------------------------------
-// ---------- const enums ----------
-// ---------------------------------
-
-export const enum MiscConstantKind {
-    // TokenKind
-    Ampersand = "&",
-    AtSign = "@",
-    Comma = ",",
-    DotDot = "..",
-    Ellipsis = "...",
-    Equal = "=",
-    FatArrow = "=>",
-    NullCoalescingOperator = "??",
-    Semicolon = ";",
-    QuestionMark = "?",
-}
-
-export const enum WrapperConstantKind {
-    LeftBrace = "{",
-    LeftBracket = "[",
-    LeftParenthesis = "(",
-    RightBrace = "}",
-    RightBracket = "]",
-    RightParenthesis = ")",
-}
-
-export const enum KeywordConstantKind {
-    And = "and",
-    As = "as",
-    Each = "each",
-    Else = "else",
-    Error = "error",
-    False = "false",
-    If = "if",
-    In = "in",
-    Is = "is",
-    Let = "let",
-    Meta = "meta",
-    Otherwise = "otherwise",
-    Or = "or",
-    Section = "section",
-    Shared = "shared",
-    Then = "then",
-    True = "true",
-    Try = "try",
-    Type = "type",
-}
-
-export const enum PrimitiveTypeConstantKind {
-    Action = "action",
-    Any = "any",
-    AnyNonNull = "anynonnull",
-    Binary = "binary",
-    Date = "date",
-    DateTime = "datetime",
-    DateTimeZone = "datetimezone",
-    Duration = "duration",
-    Function = "function",
-    List = "list",
-    Logical = "logical",
-    None = "none",
-    Null = "null",
-    Number = "number",
-    Record = "record",
-    Table = "table",
-    Text = "text",
-    Time = "time",
-    Type = "type",
-}
-
-export const enum IdentifierConstantKind {
-    Nullable = "nullable",
-    Optional = "optional",
-}
-
-export const enum ArithmeticOperatorKind {
-    Multiplication = "*",
-    Division = "/",
-    Addition = "+",
-    Subtraction = "-",
-    And = "&",
-}
-
-export const enum EqualityOperatorKind {
-    EqualTo = "=",
-    NotEqualTo = "<>",
-}
-
-export const enum LogicalOperatorKind {
-    And = "and",
-    Or = "or",
-}
-
-export const enum RelationalOperatorKind {
-    LessThan = "<",
-    LessThanEqualTo = "<=",
-    GreaterThan = ">",
-    GreaterThanEqualTo = ">=",
-}
-
-export const enum UnaryOperatorKind {
-    Positive = "+",
-    Negative = "-",
-    Not = "not",
-}
-
-export const enum LiteralKind {
-    List = "List",
-    Logical = "Logical",
-    Null = "Null",
-    Numeric = "Numeric",
-    Record = "Record",
-    Text = "Text",
-}
-
-// ------------------------------------------
-// ---------- const enum iterables ----------
-// ------------------------------------------
-
-export const PrimitiveTypeConstantKinds: ReadonlyArray<PrimitiveTypeConstantKind> = [
-    PrimitiveTypeConstantKind.Action,
-    PrimitiveTypeConstantKind.Any,
-    PrimitiveTypeConstantKind.AnyNonNull,
-    PrimitiveTypeConstantKind.Binary,
-    PrimitiveTypeConstantKind.Date,
-    PrimitiveTypeConstantKind.DateTime,
-    PrimitiveTypeConstantKind.DateTimeZone,
-    PrimitiveTypeConstantKind.Duration,
-    PrimitiveTypeConstantKind.Function,
-    PrimitiveTypeConstantKind.List,
-    PrimitiveTypeConstantKind.Logical,
-    PrimitiveTypeConstantKind.None,
-    PrimitiveTypeConstantKind.Null,
-    PrimitiveTypeConstantKind.Number,
-    PrimitiveTypeConstantKind.Record,
-    PrimitiveTypeConstantKind.Table,
-    PrimitiveTypeConstantKind.Text,
-    PrimitiveTypeConstantKind.Time,
-    PrimitiveTypeConstantKind.Type,
-];
-
-export const ArithmeticOperatorKinds: ReadonlyArray<ArithmeticOperatorKind> = [
-    ArithmeticOperatorKind.Multiplication,
-    ArithmeticOperatorKind.Division,
-    ArithmeticOperatorKind.Addition,
-    ArithmeticOperatorKind.Subtraction,
-    ArithmeticOperatorKind.And,
-];
-
-export const EqualityOperatorKinds: ReadonlyArray<EqualityOperatorKind> = [
-    EqualityOperatorKind.EqualTo,
-    EqualityOperatorKind.NotEqualTo,
-];
-
-export const LogicalOperatorKinds: ReadonlyArray<LogicalOperatorKind> = [
-    LogicalOperatorKind.And,
-    LogicalOperatorKind.Or,
-];
-
-export const RelationalOperatorKinds: ReadonlyArray<RelationalOperatorKind> = [
-    RelationalOperatorKind.LessThan,
-    RelationalOperatorKind.LessThanEqualTo,
-    RelationalOperatorKind.GreaterThan,
-    RelationalOperatorKind.GreaterThanEqualTo,
-];
-
-export const UnaryOperatorKinds: ReadonlyArray<UnaryOperatorKind> = [
-    UnaryOperatorKind.Positive,
-    UnaryOperatorKind.Negative,
-    UnaryOperatorKind.Not,
-];

--- a/src/language/ast/astUtils.ts
+++ b/src/language/ast/astUtils.ts
@@ -3,16 +3,16 @@
 
 import { ArrayUtils, Assert, CommonError } from "../../common";
 import { Ast } from "../ast";
-import { TokenKind } from "../token";
+import { Constant } from "../constant";
 
 export interface SimplifiedType {
     readonly isNullable: boolean;
-    readonly primitiveTypeConstantKind: Ast.PrimitiveTypeConstantKind;
+    readonly primitiveTypeConstantKind: Constant.PrimitiveTypeConstantKind;
 }
 
 export function simplifyType(type: Ast.TType): SimplifiedType {
     let isNullable: boolean;
-    let primitiveTypeConstantKind: Ast.PrimitiveTypeConstantKind;
+    let primitiveTypeConstantKind: Constant.PrimitiveTypeConstantKind;
 
     switch (type.kind) {
         case Ast.NodeKind.PrimitiveType:
@@ -27,22 +27,22 @@ export function simplifyType(type: Ast.TType): SimplifiedType {
 
         case Ast.NodeKind.FunctionType:
             isNullable = false;
-            primitiveTypeConstantKind = Ast.PrimitiveTypeConstantKind.Function;
+            primitiveTypeConstantKind = Constant.PrimitiveTypeConstantKind.Function;
             break;
 
         case Ast.NodeKind.ListType:
             isNullable = false;
-            primitiveTypeConstantKind = Ast.PrimitiveTypeConstantKind.List;
+            primitiveTypeConstantKind = Constant.PrimitiveTypeConstantKind.List;
             break;
 
         case Ast.NodeKind.RecordType:
             isNullable = false;
-            primitiveTypeConstantKind = Ast.PrimitiveTypeConstantKind.Record;
+            primitiveTypeConstantKind = Constant.PrimitiveTypeConstantKind.Record;
             break;
 
         case Ast.NodeKind.TableType:
             isNullable = false;
-            primitiveTypeConstantKind = Ast.PrimitiveTypeConstantKind.Table;
+            primitiveTypeConstantKind = Constant.PrimitiveTypeConstantKind.Table;
             break;
 
         default:
@@ -61,7 +61,7 @@ export function simplifyType(type: Ast.TType): SimplifiedType {
 
 export function simplifyAsNullablePrimitiveType(node: Ast.AsNullablePrimitiveType): SimplifiedType {
     let isNullable: boolean;
-    let primitiveTypeConstantKind: Ast.PrimitiveTypeConstantKind;
+    let primitiveTypeConstantKind: Constant.PrimitiveTypeConstantKind;
 
     const nullablePrimitiveType: Ast.TNullablePrimitiveType = node.paired;
     switch (nullablePrimitiveType.kind) {
@@ -85,207 +85,9 @@ export function simplifyAsNullablePrimitiveType(node: Ast.AsNullablePrimitiveTyp
     };
 }
 
-export function maybeUnaryOperatorKindFrom(maybeTokenKind: TokenKind | undefined): Ast.UnaryOperatorKind | undefined {
-    switch (maybeTokenKind) {
-        case TokenKind.Plus:
-            return Ast.UnaryOperatorKind.Positive;
-        case TokenKind.Minus:
-            return Ast.UnaryOperatorKind.Negative;
-        case TokenKind.KeywordNot:
-            return Ast.UnaryOperatorKind.Not;
-        default:
-            return undefined;
-    }
-}
-
-export function maybeArithmeticOperatorKindFrom(
-    maybeTokenKind: TokenKind | undefined,
-): Ast.ArithmeticOperatorKind | undefined {
-    switch (maybeTokenKind) {
-        case TokenKind.Asterisk:
-            return Ast.ArithmeticOperatorKind.Multiplication;
-        case TokenKind.Division:
-            return Ast.ArithmeticOperatorKind.Division;
-        case TokenKind.Plus:
-            return Ast.ArithmeticOperatorKind.Addition;
-        case TokenKind.Minus:
-            return Ast.ArithmeticOperatorKind.Subtraction;
-        case TokenKind.Ampersand:
-            return Ast.ArithmeticOperatorKind.And;
-        default:
-            return undefined;
-    }
-}
-
-export function maybeEqualityOperatorKindFrom(
-    maybeTokenKind: TokenKind | undefined,
-): Ast.EqualityOperatorKind | undefined {
-    switch (maybeTokenKind) {
-        case TokenKind.Equal:
-            return Ast.EqualityOperatorKind.EqualTo;
-        case TokenKind.NotEqual:
-            return Ast.EqualityOperatorKind.NotEqualTo;
-        default:
-            return undefined;
-    }
-}
-
-export function maybeLogicalOperatorKindFrom(
-    maybeTokenKind: TokenKind | undefined,
-): Ast.LogicalOperatorKind | undefined {
-    switch (maybeTokenKind) {
-        case TokenKind.KeywordAnd:
-            return Ast.LogicalOperatorKind.And;
-        case TokenKind.KeywordOr:
-            return Ast.LogicalOperatorKind.Or;
-        default:
-            return undefined;
-    }
-}
-
-export function maybeRelationalOperatorKindFrom(
-    maybeTokenKind: TokenKind | undefined,
-): Ast.RelationalOperatorKind | undefined {
-    switch (maybeTokenKind) {
-        case TokenKind.LessThan:
-            return Ast.RelationalOperatorKind.LessThan;
-        case TokenKind.LessThanEqualTo:
-            return Ast.RelationalOperatorKind.LessThanEqualTo;
-        case TokenKind.GreaterThan:
-            return Ast.RelationalOperatorKind.GreaterThan;
-        case TokenKind.GreaterThanEqualTo:
-            return Ast.RelationalOperatorKind.GreaterThanEqualTo;
-        default:
-            return undefined;
-    }
-}
-
-export function maybeBinOpExpressionOperatorKindFrom(
-    maybeTokenKind: TokenKind | undefined,
-): Ast.TBinOpExpressionOperator | undefined {
-    switch (maybeTokenKind) {
-        // ArithmeticOperator
-        case TokenKind.Asterisk:
-            return Ast.ArithmeticOperatorKind.Multiplication;
-        case TokenKind.Division:
-            return Ast.ArithmeticOperatorKind.Division;
-        case TokenKind.Plus:
-            return Ast.ArithmeticOperatorKind.Addition;
-        case TokenKind.Minus:
-            return Ast.ArithmeticOperatorKind.Subtraction;
-        case TokenKind.Ampersand:
-            return Ast.ArithmeticOperatorKind.And;
-
-        // EqualityOperator
-        case TokenKind.Equal:
-            return Ast.EqualityOperatorKind.EqualTo;
-        case TokenKind.NotEqual:
-            return Ast.EqualityOperatorKind.NotEqualTo;
-
-        // LogicalOperator
-        case TokenKind.KeywordAnd:
-            return Ast.LogicalOperatorKind.And;
-        case TokenKind.KeywordOr:
-            return Ast.LogicalOperatorKind.Or;
-
-        // RelationalOperator
-        case TokenKind.LessThan:
-            return Ast.RelationalOperatorKind.LessThan;
-        case TokenKind.LessThanEqualTo:
-            return Ast.RelationalOperatorKind.LessThanEqualTo;
-        case TokenKind.GreaterThan:
-            return Ast.RelationalOperatorKind.GreaterThan;
-        case TokenKind.GreaterThanEqualTo:
-            return Ast.RelationalOperatorKind.GreaterThanEqualTo;
-
-        // Keyword operator
-        case TokenKind.KeywordAs:
-            return Ast.KeywordConstantKind.As;
-        case TokenKind.KeywordIs:
-            return Ast.KeywordConstantKind.Is;
-        case TokenKind.KeywordMeta:
-            return Ast.KeywordConstantKind.Meta;
-
-        case TokenKind.NullCoalescingOperator:
-            return Ast.MiscConstantKind.NullCoalescingOperator;
-
-        default:
-            return undefined;
-    }
-}
-
-export function binOpExpressionOperatorPrecedence(operator: Ast.TBinOpExpressionOperator): number {
-    switch (operator) {
-        case Ast.KeywordConstantKind.Meta:
-            return 110;
-
-        case Ast.ArithmeticOperatorKind.Multiplication:
-        case Ast.ArithmeticOperatorKind.Division:
-            return 100;
-
-        case Ast.ArithmeticOperatorKind.Addition:
-        case Ast.ArithmeticOperatorKind.Subtraction:
-        case Ast.ArithmeticOperatorKind.And:
-            return 90;
-
-        case Ast.RelationalOperatorKind.GreaterThan:
-        case Ast.RelationalOperatorKind.GreaterThanEqualTo:
-        case Ast.RelationalOperatorKind.LessThan:
-        case Ast.RelationalOperatorKind.LessThanEqualTo:
-            return 80;
-
-        case Ast.EqualityOperatorKind.EqualTo:
-        case Ast.EqualityOperatorKind.NotEqualTo:
-            return 70;
-
-        case Ast.KeywordConstantKind.As:
-            return 60;
-
-        case Ast.KeywordConstantKind.Is:
-            return 50;
-
-        case Ast.LogicalOperatorKind.And:
-            return 40;
-
-        case Ast.LogicalOperatorKind.Or:
-            return 30;
-
-        case Ast.MiscConstantKind.NullCoalescingOperator:
-            return 20;
-
-        default:
-            throw Assert.isNever(operator);
-    }
-}
-
-export function maybeLiteralKindFrom(
-    maybeTokenKind: TokenKind | undefined,
-): Ast.LiteralKind.Numeric | Ast.LiteralKind.Logical | Ast.LiteralKind.Null | Ast.LiteralKind.Text | undefined {
-    switch (maybeTokenKind) {
-        case TokenKind.HexLiteral:
-        case TokenKind.KeywordHashNan:
-        case TokenKind.KeywordHashInfinity:
-        case TokenKind.NumericLiteral:
-            return Ast.LiteralKind.Numeric;
-
-        case TokenKind.KeywordFalse:
-        case TokenKind.KeywordTrue:
-            return Ast.LiteralKind.Logical;
-
-        case TokenKind.NullLiteral:
-            return Ast.LiteralKind.Null;
-
-        case TokenKind.TextLiteral:
-            return Ast.LiteralKind.Text;
-
-        default:
-            return undefined;
-    }
-}
-
 export function primitiveTypeConstantKindFrom(
     node: Ast.AsNullablePrimitiveType | Ast.NullablePrimitiveType | Ast.PrimitiveType,
-): Ast.PrimitiveTypeConstantKind {
+): Constant.PrimitiveTypeConstantKind {
     switch (node.kind) {
         case Ast.NodeKind.AsNullablePrimitiveType:
             return primitiveTypeConstantKindFrom(node.paired);
@@ -298,34 +100,6 @@ export function primitiveTypeConstantKindFrom(
 
         default:
             throw Assert.isNever(node);
-    }
-}
-
-export function isPrimitiveTypeConstantKind(
-    maybePrimitiveTypeConstantKind: string,
-): maybePrimitiveTypeConstantKind is Ast.PrimitiveTypeConstantKind {
-    switch (maybePrimitiveTypeConstantKind) {
-        case Ast.IdentifierConstantKind.Nullable:
-        case Ast.IdentifierConstantKind.Optional:
-        case Ast.PrimitiveTypeConstantKind.Any:
-        case Ast.PrimitiveTypeConstantKind.AnyNonNull:
-        case Ast.PrimitiveTypeConstantKind.Binary:
-        case Ast.PrimitiveTypeConstantKind.Date:
-        case Ast.PrimitiveTypeConstantKind.DateTime:
-        case Ast.PrimitiveTypeConstantKind.DateTimeZone:
-        case Ast.PrimitiveTypeConstantKind.Duration:
-        case Ast.PrimitiveTypeConstantKind.Function:
-        case Ast.PrimitiveTypeConstantKind.List:
-        case Ast.PrimitiveTypeConstantKind.Logical:
-        case Ast.PrimitiveTypeConstantKind.None:
-        case Ast.PrimitiveTypeConstantKind.Number:
-        case Ast.PrimitiveTypeConstantKind.Record:
-        case Ast.PrimitiveTypeConstantKind.Table:
-        case Ast.PrimitiveTypeConstantKind.Text:
-        case Ast.PrimitiveTypeConstantKind.Time:
-            return true;
-        default:
-            return false;
     }
 }
 
@@ -360,16 +134,6 @@ export function isTBinOpExpressionKind(nodeKind: Ast.NodeKind): nodeKind is Ast.
         default:
             return false;
     }
-}
-
-export function isPairedWrapperConstantKinds(left: Ast.TConstantKind, right: Ast.TConstantKind): boolean {
-    Assert.isTrue(left < right, `the first argument should be 'less than' the second, eg. '[' < ']`);
-
-    return (
-        (left === Ast.WrapperConstantKind.LeftBrace && right === Ast.WrapperConstantKind.RightBrace) ||
-        (left === Ast.WrapperConstantKind.LeftBracket && right === Ast.WrapperConstantKind.RightBracket) ||
-        (left === Ast.WrapperConstantKind.LeftParenthesis && right === Ast.WrapperConstantKind.RightParenthesis)
-    );
 }
 
 export function assertNodeKind(node: Ast.TNode, expectedNodeKind: Ast.NodeKind): void {

--- a/src/language/constant/constant.ts
+++ b/src/language/constant/constant.ts
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export type TConstantKind =
+    | ArithmeticOperatorKind
+    | EqualityOperatorKind
+    | IdentifierConstantKind
+    | KeywordConstantKind
+    | LogicalOperatorKind
+    | MiscConstantKind
+    | PrimitiveTypeConstantKind
+    | RelationalOperatorKind
+    | UnaryOperatorKind
+    | WrapperConstantKind;
+
+export type TBinOpExpressionOperator =
+    | ArithmeticOperatorKind
+    | EqualityOperatorKind
+    | LogicalOperatorKind
+    | RelationalOperatorKind
+    | MiscConstantKind.NullCoalescingOperator
+    | KeywordConstantKind.As
+    | KeywordConstantKind.Is
+    | KeywordConstantKind.Meta;
+
+// ---------------------------------
+// ---------- const enums ----------
+// ---------------------------------
+
+export const enum MiscConstantKind {
+    // TokenKind
+    Ampersand = "&",
+    AtSign = "@",
+    Comma = ",",
+    DotDot = "..",
+    Ellipsis = "...",
+    Equal = "=",
+    FatArrow = "=>",
+    NullCoalescingOperator = "??",
+    Semicolon = ";",
+    QuestionMark = "?",
+}
+
+export const enum WrapperConstantKind {
+    LeftBrace = "{",
+    LeftBracket = "[",
+    LeftParenthesis = "(",
+    RightBrace = "}",
+    RightBracket = "]",
+    RightParenthesis = ")",
+}
+
+export const enum KeywordConstantKind {
+    And = "and",
+    As = "as",
+    Each = "each",
+    Else = "else",
+    Error = "error",
+    False = "false",
+    If = "if",
+    In = "in",
+    Is = "is",
+    Let = "let",
+    Meta = "meta",
+    Otherwise = "otherwise",
+    Or = "or",
+    Section = "section",
+    Shared = "shared",
+    Then = "then",
+    True = "true",
+    Try = "try",
+    Type = "type",
+}
+
+export const enum PrimitiveTypeConstantKind {
+    Action = "action",
+    Any = "any",
+    AnyNonNull = "anynonnull",
+    Binary = "binary",
+    Date = "date",
+    DateTime = "datetime",
+    DateTimeZone = "datetimezone",
+    Duration = "duration",
+    Function = "function",
+    List = "list",
+    Logical = "logical",
+    None = "none",
+    Null = "null",
+    Number = "number",
+    Record = "record",
+    Table = "table",
+    Text = "text",
+    Time = "time",
+    Type = "type",
+}
+
+export const enum IdentifierConstantKind {
+    Nullable = "nullable",
+    Optional = "optional",
+}
+
+export const enum LiteralKind {
+    List = "List",
+    Logical = "Logical",
+    Null = "Null",
+    Numeric = "Numeric",
+    Record = "Record",
+    Text = "Text",
+}
+
+// ------------------------------------------
+// ---------- const enum iterables ----------
+// ------------------------------------------
+
+export const PrimitiveTypeConstantKinds: ReadonlyArray<PrimitiveTypeConstantKind> = [
+    PrimitiveTypeConstantKind.Action,
+    PrimitiveTypeConstantKind.Any,
+    PrimitiveTypeConstantKind.AnyNonNull,
+    PrimitiveTypeConstantKind.Binary,
+    PrimitiveTypeConstantKind.Date,
+    PrimitiveTypeConstantKind.DateTime,
+    PrimitiveTypeConstantKind.DateTimeZone,
+    PrimitiveTypeConstantKind.Duration,
+    PrimitiveTypeConstantKind.Function,
+    PrimitiveTypeConstantKind.List,
+    PrimitiveTypeConstantKind.Logical,
+    PrimitiveTypeConstantKind.None,
+    PrimitiveTypeConstantKind.Null,
+    PrimitiveTypeConstantKind.Number,
+    PrimitiveTypeConstantKind.Record,
+    PrimitiveTypeConstantKind.Table,
+    PrimitiveTypeConstantKind.Text,
+    PrimitiveTypeConstantKind.Time,
+    PrimitiveTypeConstantKind.Type,
+];
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// ------------------------------------------
+// ---------- operator const enums ----------
+// ------------------------------------------
+
+export const enum ArithmeticOperatorKind {
+    Multiplication = "*",
+    Division = "/",
+    Addition = "+",
+    Subtraction = "-",
+    And = "&",
+}
+
+export const enum EqualityOperatorKind {
+    EqualTo = "=",
+    NotEqualTo = "<>",
+}
+
+export const enum LogicalOperatorKind {
+    And = "and",
+    Or = "or",
+}
+
+export const enum RelationalOperatorKind {
+    LessThan = "<",
+    LessThanEqualTo = "<=",
+    GreaterThan = ">",
+    GreaterThanEqualTo = ">=",
+}
+
+export const enum UnaryOperatorKind {
+    Positive = "+",
+    Negative = "-",
+    Not = "not",
+}
+
+// ---------------------------------------------------
+// ---------- operator const enum iterables ----------
+// ---------------------------------------------------
+
+export const ArithmeticOperatorKinds: ReadonlyArray<ArithmeticOperatorKind> = [
+    ArithmeticOperatorKind.Multiplication,
+    ArithmeticOperatorKind.Division,
+    ArithmeticOperatorKind.Addition,
+    ArithmeticOperatorKind.Subtraction,
+    ArithmeticOperatorKind.And,
+];
+
+export const EqualityOperatorKinds: ReadonlyArray<EqualityOperatorKind> = [
+    EqualityOperatorKind.EqualTo,
+    EqualityOperatorKind.NotEqualTo,
+];
+
+export const LogicalOperatorKinds: ReadonlyArray<LogicalOperatorKind> = [
+    LogicalOperatorKind.And,
+    LogicalOperatorKind.Or,
+];
+
+export const RelationalOperatorKinds: ReadonlyArray<RelationalOperatorKind> = [
+    RelationalOperatorKind.LessThan,
+    RelationalOperatorKind.LessThanEqualTo,
+    RelationalOperatorKind.GreaterThan,
+    RelationalOperatorKind.GreaterThanEqualTo,
+];
+
+export const UnaryOperatorKinds: ReadonlyArray<UnaryOperatorKind> = [
+    UnaryOperatorKind.Positive,
+    UnaryOperatorKind.Negative,
+    UnaryOperatorKind.Not,
+];

--- a/src/language/constant/constantUtils.ts
+++ b/src/language/constant/constantUtils.ts
@@ -1,0 +1,249 @@
+import { Assert } from "../../common";
+import { TokenKind } from "../token";
+import {
+    ArithmeticOperatorKind,
+    EqualityOperatorKind,
+    IdentifierConstantKind,
+    KeywordConstantKind,
+    LiteralKind,
+    LogicalOperatorKind,
+    MiscConstantKind,
+    PrimitiveTypeConstantKind,
+    RelationalOperatorKind,
+    TBinOpExpressionOperator,
+    TConstantKind,
+    UnaryOperatorKind,
+    WrapperConstantKind,
+} from "./constant";
+
+export function maybeUnaryOperatorKindFrom(maybeTokenKind: TokenKind | undefined): UnaryOperatorKind | undefined {
+    switch (maybeTokenKind) {
+        case TokenKind.Plus:
+            return UnaryOperatorKind.Positive;
+        case TokenKind.Minus:
+            return UnaryOperatorKind.Negative;
+        case TokenKind.KeywordNot:
+            return UnaryOperatorKind.Not;
+        default:
+            return undefined;
+    }
+}
+
+export function maybeArithmeticOperatorKindFrom(
+    maybeTokenKind: TokenKind | undefined,
+): ArithmeticOperatorKind | undefined {
+    switch (maybeTokenKind) {
+        case TokenKind.Asterisk:
+            return ArithmeticOperatorKind.Multiplication;
+        case TokenKind.Division:
+            return ArithmeticOperatorKind.Division;
+        case TokenKind.Plus:
+            return ArithmeticOperatorKind.Addition;
+        case TokenKind.Minus:
+            return ArithmeticOperatorKind.Subtraction;
+        case TokenKind.Ampersand:
+            return ArithmeticOperatorKind.And;
+        default:
+            return undefined;
+    }
+}
+
+export function maybeEqualityOperatorKindFrom(maybeTokenKind: TokenKind | undefined): EqualityOperatorKind | undefined {
+    switch (maybeTokenKind) {
+        case TokenKind.Equal:
+            return EqualityOperatorKind.EqualTo;
+        case TokenKind.NotEqual:
+            return EqualityOperatorKind.NotEqualTo;
+        default:
+            return undefined;
+    }
+}
+
+export function maybeLogicalOperatorKindFrom(maybeTokenKind: TokenKind | undefined): LogicalOperatorKind | undefined {
+    switch (maybeTokenKind) {
+        case TokenKind.KeywordAnd:
+            return LogicalOperatorKind.And;
+        case TokenKind.KeywordOr:
+            return LogicalOperatorKind.Or;
+        default:
+            return undefined;
+    }
+}
+
+export function maybeRelationalOperatorKindFrom(
+    maybeTokenKind: TokenKind | undefined,
+): RelationalOperatorKind | undefined {
+    switch (maybeTokenKind) {
+        case TokenKind.LessThan:
+            return RelationalOperatorKind.LessThan;
+        case TokenKind.LessThanEqualTo:
+            return RelationalOperatorKind.LessThanEqualTo;
+        case TokenKind.GreaterThan:
+            return RelationalOperatorKind.GreaterThan;
+        case TokenKind.GreaterThanEqualTo:
+            return RelationalOperatorKind.GreaterThanEqualTo;
+        default:
+            return undefined;
+    }
+}
+
+export function maybeBinOpExpressionOperatorKindFrom(
+    maybeTokenKind: TokenKind | undefined,
+): TBinOpExpressionOperator | undefined {
+    switch (maybeTokenKind) {
+        // ArithmeticOperator
+        case TokenKind.Asterisk:
+            return ArithmeticOperatorKind.Multiplication;
+        case TokenKind.Division:
+            return ArithmeticOperatorKind.Division;
+        case TokenKind.Plus:
+            return ArithmeticOperatorKind.Addition;
+        case TokenKind.Minus:
+            return ArithmeticOperatorKind.Subtraction;
+        case TokenKind.Ampersand:
+            return ArithmeticOperatorKind.And;
+
+        // EqualityOperator
+        case TokenKind.Equal:
+            return EqualityOperatorKind.EqualTo;
+        case TokenKind.NotEqual:
+            return EqualityOperatorKind.NotEqualTo;
+
+        // LogicalOperator
+        case TokenKind.KeywordAnd:
+            return LogicalOperatorKind.And;
+        case TokenKind.KeywordOr:
+            return LogicalOperatorKind.Or;
+
+        // RelationalOperator
+        case TokenKind.LessThan:
+            return RelationalOperatorKind.LessThan;
+        case TokenKind.LessThanEqualTo:
+            return RelationalOperatorKind.LessThanEqualTo;
+        case TokenKind.GreaterThan:
+            return RelationalOperatorKind.GreaterThan;
+        case TokenKind.GreaterThanEqualTo:
+            return RelationalOperatorKind.GreaterThanEqualTo;
+
+        // Keyword operator
+        case TokenKind.KeywordAs:
+            return KeywordConstantKind.As;
+        case TokenKind.KeywordIs:
+            return KeywordConstantKind.Is;
+        case TokenKind.KeywordMeta:
+            return KeywordConstantKind.Meta;
+
+        case TokenKind.NullCoalescingOperator:
+            return MiscConstantKind.NullCoalescingOperator;
+
+        default:
+            return undefined;
+    }
+}
+
+export function binOpExpressionOperatorPrecedence(operator: TBinOpExpressionOperator): number {
+    switch (operator) {
+        case KeywordConstantKind.Meta:
+            return 110;
+
+        case ArithmeticOperatorKind.Multiplication:
+        case ArithmeticOperatorKind.Division:
+            return 100;
+
+        case ArithmeticOperatorKind.Addition:
+        case ArithmeticOperatorKind.Subtraction:
+        case ArithmeticOperatorKind.And:
+            return 90;
+
+        case RelationalOperatorKind.GreaterThan:
+        case RelationalOperatorKind.GreaterThanEqualTo:
+        case RelationalOperatorKind.LessThan:
+        case RelationalOperatorKind.LessThanEqualTo:
+            return 80;
+
+        case EqualityOperatorKind.EqualTo:
+        case EqualityOperatorKind.NotEqualTo:
+            return 70;
+
+        case KeywordConstantKind.As:
+            return 60;
+
+        case KeywordConstantKind.Is:
+            return 50;
+
+        case LogicalOperatorKind.And:
+            return 40;
+
+        case LogicalOperatorKind.Or:
+            return 30;
+
+        case MiscConstantKind.NullCoalescingOperator:
+            return 20;
+
+        default:
+            throw Assert.isNever(operator);
+    }
+}
+
+export function maybeLiteralKindFrom(
+    maybeTokenKind: TokenKind | undefined,
+): LiteralKind.Numeric | LiteralKind.Logical | LiteralKind.Null | LiteralKind.Text | undefined {
+    switch (maybeTokenKind) {
+        case TokenKind.HexLiteral:
+        case TokenKind.KeywordHashNan:
+        case TokenKind.KeywordHashInfinity:
+        case TokenKind.NumericLiteral:
+            return LiteralKind.Numeric;
+
+        case TokenKind.KeywordFalse:
+        case TokenKind.KeywordTrue:
+            return LiteralKind.Logical;
+
+        case TokenKind.NullLiteral:
+            return LiteralKind.Null;
+
+        case TokenKind.TextLiteral:
+            return LiteralKind.Text;
+
+        default:
+            return undefined;
+    }
+}
+
+export function isPrimitiveTypeConstantKind(
+    maybePrimitiveTypeConstantKind: string,
+): maybePrimitiveTypeConstantKind is PrimitiveTypeConstantKind {
+    switch (maybePrimitiveTypeConstantKind) {
+        case IdentifierConstantKind.Nullable:
+        case IdentifierConstantKind.Optional:
+        case PrimitiveTypeConstantKind.Any:
+        case PrimitiveTypeConstantKind.AnyNonNull:
+        case PrimitiveTypeConstantKind.Binary:
+        case PrimitiveTypeConstantKind.Date:
+        case PrimitiveTypeConstantKind.DateTime:
+        case PrimitiveTypeConstantKind.DateTimeZone:
+        case PrimitiveTypeConstantKind.Duration:
+        case PrimitiveTypeConstantKind.Function:
+        case PrimitiveTypeConstantKind.List:
+        case PrimitiveTypeConstantKind.Logical:
+        case PrimitiveTypeConstantKind.None:
+        case PrimitiveTypeConstantKind.Number:
+        case PrimitiveTypeConstantKind.Record:
+        case PrimitiveTypeConstantKind.Table:
+        case PrimitiveTypeConstantKind.Text:
+        case PrimitiveTypeConstantKind.Time:
+            return true;
+        default:
+            return false;
+    }
+}
+
+export function isPairedWrapperConstantKinds(left: TConstantKind, right: TConstantKind): boolean {
+    Assert.isTrue(left < right, `the first argument should be 'less than' the second, eg. '[' < ']`);
+
+    return (
+        (left === WrapperConstantKind.LeftBrace && right === WrapperConstantKind.RightBrace) ||
+        (left === WrapperConstantKind.LeftBracket && right === WrapperConstantKind.RightBracket) ||
+        (left === WrapperConstantKind.LeftParenthesis && right === WrapperConstantKind.RightParenthesis)
+    );
+}

--- a/src/language/constant/index.ts
+++ b/src/language/constant/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as Constant from "./constant";
+import * as ConstantUtils from "./constantUtils";
+export { Constant, ConstantUtils };

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as Keyword from "./keyword";
+
+export { Keyword };
 export * from "./ast";
+export * from "./constant";
 export * from "./comment";
-export * from "./keyword";
 export * from "./token";
 export * from "./type";

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as Comment from "./comment";
 import * as Keyword from "./keyword";
+import * as Token from "./token";
 
-export { Keyword };
+export { Comment, Keyword, Token };
 export * from "./ast";
 export * from "./constant";
-export * from "./comment";
-export * from "./token";
 export * from "./type";

--- a/src/language/keyword.ts
+++ b/src/language/keyword.ts
@@ -35,7 +35,7 @@ export const enum KeywordKind {
     HashTime = "#time",
 }
 
-export const Keywords: ReadonlyArray<KeywordKind> = [
+export const KeywordKinds: ReadonlyArray<KeywordKind> = [
     KeywordKind.And,
     KeywordKind.As,
     KeywordKind.Each,
@@ -69,7 +69,7 @@ export const Keywords: ReadonlyArray<KeywordKind> = [
     KeywordKind.HashTime,
 ];
 
-export const ExpressionKeywords: ReadonlyArray<KeywordKind> = [
+export const ExpressionKeywordKinds: ReadonlyArray<KeywordKind> = [
     KeywordKind.Each,
     KeywordKind.Error,
     KeywordKind.False,

--- a/src/language/type/typeUtils/primitive.ts
+++ b/src/language/type/typeUtils/primitive.ts
@@ -3,68 +3,68 @@
 
 import { Type } from "..";
 import { Assert } from "../../../common";
-import { Ast } from "../../ast";
+import { Constant } from "../../constant";
 
 export function maybePrimitiveTypeConstantKindFromTypeKind(
     typeKind: Type.TypeKind,
-): Ast.PrimitiveTypeConstantKind | undefined {
+): Constant.PrimitiveTypeConstantKind | undefined {
     switch (typeKind) {
         case Type.TypeKind.Action:
-            return Ast.PrimitiveTypeConstantKind.Action;
+            return Constant.PrimitiveTypeConstantKind.Action;
 
         case Type.TypeKind.Any:
-            return Ast.PrimitiveTypeConstantKind.Any;
+            return Constant.PrimitiveTypeConstantKind.Any;
 
         case Type.TypeKind.AnyNonNull:
-            return Ast.PrimitiveTypeConstantKind.AnyNonNull;
+            return Constant.PrimitiveTypeConstantKind.AnyNonNull;
 
         case Type.TypeKind.Binary:
-            return Ast.PrimitiveTypeConstantKind.Binary;
+            return Constant.PrimitiveTypeConstantKind.Binary;
 
         case Type.TypeKind.Date:
-            return Ast.PrimitiveTypeConstantKind.Date;
+            return Constant.PrimitiveTypeConstantKind.Date;
 
         case Type.TypeKind.DateTime:
-            return Ast.PrimitiveTypeConstantKind.DateTime;
+            return Constant.PrimitiveTypeConstantKind.DateTime;
 
         case Type.TypeKind.DateTimeZone:
-            return Ast.PrimitiveTypeConstantKind.DateTimeZone;
+            return Constant.PrimitiveTypeConstantKind.DateTimeZone;
 
         case Type.TypeKind.Duration:
-            return Ast.PrimitiveTypeConstantKind.Duration;
+            return Constant.PrimitiveTypeConstantKind.Duration;
 
         case Type.TypeKind.Function:
-            return Ast.PrimitiveTypeConstantKind.Function;
+            return Constant.PrimitiveTypeConstantKind.Function;
 
         case Type.TypeKind.List:
-            return Ast.PrimitiveTypeConstantKind.List;
+            return Constant.PrimitiveTypeConstantKind.List;
 
         case Type.TypeKind.Logical:
-            return Ast.PrimitiveTypeConstantKind.Logical;
+            return Constant.PrimitiveTypeConstantKind.Logical;
 
         case Type.TypeKind.None:
-            return Ast.PrimitiveTypeConstantKind.None;
+            return Constant.PrimitiveTypeConstantKind.None;
 
         case Type.TypeKind.Null:
-            return Ast.PrimitiveTypeConstantKind.Null;
+            return Constant.PrimitiveTypeConstantKind.Null;
 
         case Type.TypeKind.Number:
-            return Ast.PrimitiveTypeConstantKind.Number;
+            return Constant.PrimitiveTypeConstantKind.Number;
 
         case Type.TypeKind.Record:
-            return Ast.PrimitiveTypeConstantKind.Record;
+            return Constant.PrimitiveTypeConstantKind.Record;
 
         case Type.TypeKind.Table:
-            return Ast.PrimitiveTypeConstantKind.Table;
+            return Constant.PrimitiveTypeConstantKind.Table;
 
         case Type.TypeKind.Text:
-            return Ast.PrimitiveTypeConstantKind.Text;
+            return Constant.PrimitiveTypeConstantKind.Text;
 
         case Type.TypeKind.Time:
-            return Ast.PrimitiveTypeConstantKind.Time;
+            return Constant.PrimitiveTypeConstantKind.Time;
 
         case Type.TypeKind.Type:
-            return Ast.PrimitiveTypeConstantKind.Type;
+            return Constant.PrimitiveTypeConstantKind.Type;
 
         case Type.TypeKind.NotApplicable:
         case Type.TypeKind.Unknown:
@@ -76,64 +76,64 @@ export function maybePrimitiveTypeConstantKindFromTypeKind(
 }
 
 export function typeKindFromPrimitiveTypeConstantKind(
-    primitiveTypeConstantKind: Ast.PrimitiveTypeConstantKind,
+    primitiveTypeConstantKind: Constant.PrimitiveTypeConstantKind,
 ): Type.TypeKind {
     switch (primitiveTypeConstantKind) {
-        case Ast.PrimitiveTypeConstantKind.Action:
+        case Constant.PrimitiveTypeConstantKind.Action:
             return Type.TypeKind.Action;
 
-        case Ast.PrimitiveTypeConstantKind.Any:
+        case Constant.PrimitiveTypeConstantKind.Any:
             return Type.TypeKind.Any;
 
-        case Ast.PrimitiveTypeConstantKind.AnyNonNull:
+        case Constant.PrimitiveTypeConstantKind.AnyNonNull:
             return Type.TypeKind.AnyNonNull;
 
-        case Ast.PrimitiveTypeConstantKind.Binary:
+        case Constant.PrimitiveTypeConstantKind.Binary:
             return Type.TypeKind.Binary;
 
-        case Ast.PrimitiveTypeConstantKind.Date:
+        case Constant.PrimitiveTypeConstantKind.Date:
             return Type.TypeKind.Date;
 
-        case Ast.PrimitiveTypeConstantKind.DateTime:
+        case Constant.PrimitiveTypeConstantKind.DateTime:
             return Type.TypeKind.DateTime;
 
-        case Ast.PrimitiveTypeConstantKind.DateTimeZone:
+        case Constant.PrimitiveTypeConstantKind.DateTimeZone:
             return Type.TypeKind.DateTimeZone;
 
-        case Ast.PrimitiveTypeConstantKind.Duration:
+        case Constant.PrimitiveTypeConstantKind.Duration:
             return Type.TypeKind.Duration;
 
-        case Ast.PrimitiveTypeConstantKind.Function:
+        case Constant.PrimitiveTypeConstantKind.Function:
             return Type.TypeKind.Function;
 
-        case Ast.PrimitiveTypeConstantKind.List:
+        case Constant.PrimitiveTypeConstantKind.List:
             return Type.TypeKind.List;
 
-        case Ast.PrimitiveTypeConstantKind.Logical:
+        case Constant.PrimitiveTypeConstantKind.Logical:
             return Type.TypeKind.Logical;
 
-        case Ast.PrimitiveTypeConstantKind.None:
+        case Constant.PrimitiveTypeConstantKind.None:
             return Type.TypeKind.None;
 
-        case Ast.PrimitiveTypeConstantKind.Null:
+        case Constant.PrimitiveTypeConstantKind.Null:
             return Type.TypeKind.Null;
 
-        case Ast.PrimitiveTypeConstantKind.Number:
+        case Constant.PrimitiveTypeConstantKind.Number:
             return Type.TypeKind.Number;
 
-        case Ast.PrimitiveTypeConstantKind.Record:
+        case Constant.PrimitiveTypeConstantKind.Record:
             return Type.TypeKind.Record;
 
-        case Ast.PrimitiveTypeConstantKind.Table:
+        case Constant.PrimitiveTypeConstantKind.Table:
             return Type.TypeKind.Table;
 
-        case Ast.PrimitiveTypeConstantKind.Text:
+        case Constant.PrimitiveTypeConstantKind.Text:
             return Type.TypeKind.Text;
 
-        case Ast.PrimitiveTypeConstantKind.Time:
+        case Constant.PrimitiveTypeConstantKind.Time:
             return Type.TypeKind.Time;
 
-        case Ast.PrimitiveTypeConstantKind.Type:
+        case Constant.PrimitiveTypeConstantKind.Type:
             return Type.TypeKind.Type;
 
         default:

--- a/src/language/type/typeUtils/typeUtils.ts
+++ b/src/language/type/typeUtils/typeUtils.ts
@@ -5,6 +5,7 @@ import { Type } from "..";
 import { Assert } from "../../../common";
 import { NodeIdMap, NodeIdMapUtils, ParseContext, TXorNode, XorNodeKind } from "../../../parser";
 import { Ast, AstUtils } from "../../ast";
+import { Constant } from "../../constant";
 import { isEqualType } from "./isEqualType";
 import { typeKindFromPrimitiveTypeConstantKind } from "./primitive";
 
@@ -138,24 +139,24 @@ export function flattenAnyUnion(anyUnion: Type.AnyUnion): ReadonlyArray<Type.TTy
     return newUnionedTypePairs;
 }
 
-export function typeKindFromLiteralKind(literalKind: Ast.LiteralKind): Type.TypeKind {
+export function typeKindFromLiteralKind(literalKind: Constant.LiteralKind): Type.TypeKind {
     switch (literalKind) {
-        case Ast.LiteralKind.List:
+        case Constant.LiteralKind.List:
             return Type.TypeKind.List;
 
-        case Ast.LiteralKind.Logical:
+        case Constant.LiteralKind.Logical:
             return Type.TypeKind.Logical;
 
-        case Ast.LiteralKind.Null:
+        case Constant.LiteralKind.Null:
             return Type.TypeKind.Null;
 
-        case Ast.LiteralKind.Numeric:
+        case Constant.LiteralKind.Numeric:
             return Type.TypeKind.Number;
 
-        case Ast.LiteralKind.Record:
+        case Constant.LiteralKind.Record:
             return Type.TypeKind.Record;
 
-        case Ast.LiteralKind.Text:
+        case Constant.LiteralKind.Text:
             return Type.TypeKind.Text;
 
         default:

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { LexError } from ".";
-import { Language } from "..";
 import {
     ArrayUtils,
     Assert,
@@ -16,6 +15,7 @@ import {
     ResultUtils,
     StringUtils,
 } from "../common";
+import { Keyword, Token } from "../language";
 import { getLocalizationTemplates, ILocalizationTemplates } from "../localization";
 import { LexSettings } from "../settings";
 
@@ -73,7 +73,7 @@ export interface ILexerLine {
     readonly lineTerminator: string; // must be a valid Power Query newline character
     readonly lineModeStart: LineMode; // (the previous TLine's lineModeEnd) || LineMode.Default
     readonly lineModeEnd: LineMode;
-    readonly tokens: ReadonlyArray<Language.LineToken>;
+    readonly tokens: ReadonlyArray<Token.LineToken>;
 }
 
 // An error was thrown before anything could be tokenized.
@@ -159,8 +159,8 @@ export function equalLines(leftLines: ReadonlyArray<TLine>, rightLines: Readonly
     for (let lineIndex: number = 0; lineIndex < numLines; lineIndex += 1) {
         const left: TLine = leftLines[lineIndex];
         const right: TLine = rightLines[lineIndex];
-        const leftTokens: ReadonlyArray<Language.LineToken> = left.tokens;
-        const rightTokens: ReadonlyArray<Language.LineToken> = right.tokens;
+        const leftTokens: ReadonlyArray<Token.LineToken> = left.tokens;
+        const rightTokens: ReadonlyArray<Token.LineToken> = right.tokens;
 
         const isEqualQuickCheck: boolean =
             left.kind === right.kind &&
@@ -185,7 +185,7 @@ export function equalLines(leftLines: ReadonlyArray<TLine>, rightLines: Readonly
 }
 
 // deep token comparison
-export function equalTokens(leftToken: Language.LineToken, rightToken: Language.LineToken): boolean {
+export function equalTokens(leftToken: Token.LineToken, rightToken: Token.LineToken): boolean {
     return (
         leftToken.kind === rightToken.kind &&
         leftToken.data === rightToken.data &&
@@ -226,12 +226,12 @@ export function maybeErrorLineMap(state: State): ErrorLineMap | undefined {
 }
 
 interface TokenizeChanges {
-    readonly tokens: ReadonlyArray<Language.LineToken>;
+    readonly tokens: ReadonlyArray<Token.LineToken>;
     readonly lineModeEnd: LineMode;
 }
 
 interface LineModeAlteringRead {
-    readonly token: Language.LineToken;
+    readonly token: Token.LineToken;
     readonly lineMode: LineMode;
 }
 
@@ -580,7 +580,7 @@ function tokenize(
         currentPosition = drainWhitespace(text, currentPosition);
     }
 
-    const newTokens: Language.LineToken[] = [];
+    const newTokens: Token.LineToken[] = [];
     let continueLexing: boolean = currentPosition !== text.length;
     let maybeError: LexError.TLexError | undefined;
 
@@ -615,7 +615,7 @@ function tokenize(
             }
 
             lineMode = readOutcome.lineMode;
-            const token: Language.LineToken = readOutcome.token;
+            const token: Token.LineToken = readOutcome.token;
             newTokens.push(token);
 
             if (lineMode === LineMode.Default) {
@@ -670,7 +670,7 @@ function updateLineState(
     switch (tokenizePartialResult.kind) {
         case PartialResultKind.Ok: {
             const tokenizeChanges: TokenizeChanges = tokenizePartialResult.value;
-            const newTokens: ReadonlyArray<Language.LineToken> = line.tokens.concat(tokenizeChanges.tokens);
+            const newTokens: ReadonlyArray<Token.LineToken> = line.tokens.concat(tokenizeChanges.tokens);
 
             return {
                 kind: LineKind.Touched,
@@ -684,7 +684,7 @@ function updateLineState(
 
         case PartialResultKind.Mixed: {
             const tokenizeChanges: TokenizeChanges = tokenizePartialResult.value;
-            const newTokens: ReadonlyArray<Language.LineToken> = line.tokens.concat(tokenizeChanges.tokens);
+            const newTokens: ReadonlyArray<Token.LineToken> = line.tokens.concat(tokenizeChanges.tokens);
 
             return {
                 kind: LineKind.TouchedWithError,
@@ -720,13 +720,13 @@ function tokenizeMultilineCommentContentOrEnd(line: TLine, positionStart: number
 
     if (indexOfCloseComment === -1) {
         return {
-            token: readRestOfLine(Language.LineTokenKind.MultilineCommentContent, text, positionStart),
+            token: readRestOfLine(Token.LineTokenKind.MultilineCommentContent, text, positionStart),
             lineMode: LineMode.Comment,
         };
     } else {
         const positionEnd: number = indexOfCloseComment + 2;
         return {
-            token: readTokenFrom(Language.LineTokenKind.MultilineCommentEnd, text, positionStart, positionEnd),
+            token: readTokenFrom(Token.LineTokenKind.MultilineCommentEnd, text, positionStart, positionEnd),
             lineMode: LineMode.Default,
         };
     }
@@ -736,28 +736,28 @@ function tokenizeMultilineCommentContentOrEnd(line: TLine, positionStart: number
 function tokenizeQuotedIdentifierContentOrEnd(line: TLine, currentPosition: number): LineModeAlteringRead {
     const read: LineModeAlteringRead = tokenizeTextLiteralContentOrEnd(line, currentPosition);
     switch (read.token.kind) {
-        case Language.LineTokenKind.TextLiteralContent:
+        case Token.LineTokenKind.TextLiteralContent:
             return {
                 lineMode: LineMode.QuotedIdentifier,
                 token: {
                     ...read.token,
-                    kind: Language.LineTokenKind.QuotedIdentifierContent,
+                    kind: Token.LineTokenKind.QuotedIdentifierContent,
                 },
             };
 
-        case Language.LineTokenKind.TextLiteralEnd:
+        case Token.LineTokenKind.TextLiteralEnd:
             return {
                 lineMode: LineMode.Default,
                 token: {
                     ...read.token,
-                    kind: Language.LineTokenKind.QuotedIdentifierEnd,
+                    kind: Token.LineTokenKind.QuotedIdentifierEnd,
                 },
             };
 
         default:
             const details: {} = { read };
             throw new CommonError.InvariantError(
-                `expected the return to be either ${Language.LineTokenKind.TextLiteralContent} or ${Language.LineTokenKind.TextLiteralEnd}`,
+                `expected the return to be either ${Token.LineTokenKind.TextLiteralContent} or ${Token.LineTokenKind.TextLiteralEnd}`,
                 details,
             );
     }
@@ -770,13 +770,13 @@ function tokenizeTextLiteralContentOrEnd(line: TLine, currentPosition: number): 
 
     if (maybePositionEnd === undefined) {
         return {
-            token: readRestOfLine(Language.LineTokenKind.TextLiteralContent, text, currentPosition),
+            token: readRestOfLine(Token.LineTokenKind.TextLiteralContent, text, currentPosition),
             lineMode: LineMode.Text,
         };
     } else {
         const positionEnd: number = maybePositionEnd + 1;
         return {
-            token: readTokenFrom(Language.LineTokenKind.TextLiteralEnd, text, currentPosition, positionEnd),
+            token: readTokenFrom(Token.LineTokenKind.TextLiteralEnd, text, currentPosition, positionEnd),
             lineMode: LineMode.Default,
         };
     }
@@ -791,44 +791,44 @@ function tokenizeDefault(
     const text: string = line.text;
 
     const chr1: string = text[positionStart];
-    let token: Language.LineToken;
+    let token: Token.LineToken;
     let lineMode: LineMode = LineMode.Default;
 
     if (chr1 === "!") {
-        token = readConstant(Language.LineTokenKind.Bang, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.Bang, text, positionStart, 1);
     } else if (chr1 === "&") {
-        token = readConstant(Language.LineTokenKind.Ampersand, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.Ampersand, text, positionStart, 1);
     } else if (chr1 === "(") {
-        token = readConstant(Language.LineTokenKind.LeftParenthesis, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.LeftParenthesis, text, positionStart, 1);
     } else if (chr1 === ")") {
-        token = readConstant(Language.LineTokenKind.RightParenthesis, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.RightParenthesis, text, positionStart, 1);
     } else if (chr1 === "*") {
-        token = readConstant(Language.LineTokenKind.Asterisk, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.Asterisk, text, positionStart, 1);
     } else if (chr1 === "+") {
-        token = readConstant(Language.LineTokenKind.Plus, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.Plus, text, positionStart, 1);
     } else if (chr1 === ",") {
-        token = readConstant(Language.LineTokenKind.Comma, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.Comma, text, positionStart, 1);
     } else if (chr1 === "-") {
-        token = readConstant(Language.LineTokenKind.Minus, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.Minus, text, positionStart, 1);
     } else if (chr1 === ";") {
-        token = readConstant(Language.LineTokenKind.Semicolon, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.Semicolon, text, positionStart, 1);
     } else if (chr1 === "?") {
         const chr2: string | undefined = text[positionStart + 1];
         if (chr2 === "?") {
-            token = readConstant(Language.LineTokenKind.NullCoalescingOperator, text, positionStart, 2);
+            token = readConstant(Token.LineTokenKind.NullCoalescingOperator, text, positionStart, 2);
         } else {
-            token = readConstant(Language.LineTokenKind.QuestionMark, text, positionStart, 1);
+            token = readConstant(Token.LineTokenKind.QuestionMark, text, positionStart, 1);
         }
     } else if (chr1 === "@") {
-        token = readConstant(Language.LineTokenKind.AtSign, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.AtSign, text, positionStart, 1);
     } else if (chr1 === "[") {
-        token = readConstant(Language.LineTokenKind.LeftBracket, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.LeftBracket, text, positionStart, 1);
     } else if (chr1 === "]") {
-        token = readConstant(Language.LineTokenKind.RightBracket, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.RightBracket, text, positionStart, 1);
     } else if (chr1 === "{") {
-        token = readConstant(Language.LineTokenKind.LeftBrace, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.LeftBrace, text, positionStart, 1);
     } else if (chr1 === "}") {
-        token = readConstant(Language.LineTokenKind.RightBrace, text, positionStart, 1);
+        token = readConstant(Token.LineTokenKind.RightBrace, text, positionStart, 1);
     } else if (chr1 === '"') {
         const read: LineModeAlteringRead = readOrStartTextLiteral(text, positionStart);
         token = read.token;
@@ -857,9 +857,9 @@ function tokenizeDefault(
             const chr3: string = text[positionStart + 2];
 
             if (chr3 === ".") {
-                token = readConstant(Language.LineTokenKind.Ellipsis, text, positionStart, 3);
+                token = readConstant(Token.LineTokenKind.Ellipsis, text, positionStart, 3);
             } else {
-                token = readConstant(Language.LineTokenKind.DotDot, text, positionStart, 2);
+                token = readConstant(Token.LineTokenKind.DotDot, text, positionStart, 2);
             }
         } else {
             throw unexpectedReadError(localizationTemplates, text, lineNumber, positionStart);
@@ -868,27 +868,27 @@ function tokenizeDefault(
         const chr2: string | undefined = text[positionStart + 1];
 
         if (chr2 === "=") {
-            token = readConstant(Language.LineTokenKind.GreaterThanEqualTo, text, positionStart, 2);
+            token = readConstant(Token.LineTokenKind.GreaterThanEqualTo, text, positionStart, 2);
         } else {
-            token = readConstant(Language.LineTokenKind.GreaterThan, text, positionStart, 1);
+            token = readConstant(Token.LineTokenKind.GreaterThan, text, positionStart, 1);
         }
     } else if (chr1 === "<") {
         const chr2: string | undefined = text[positionStart + 1];
 
         if (chr2 === "=") {
-            token = readConstant(Language.LineTokenKind.LessThanEqualTo, text, positionStart, 2);
+            token = readConstant(Token.LineTokenKind.LessThanEqualTo, text, positionStart, 2);
         } else if (chr2 === ">") {
-            token = readConstant(Language.LineTokenKind.NotEqual, text, positionStart, 2);
+            token = readConstant(Token.LineTokenKind.NotEqual, text, positionStart, 2);
         } else {
-            token = readConstant(Language.LineTokenKind.LessThan, text, positionStart, 1);
+            token = readConstant(Token.LineTokenKind.LessThan, text, positionStart, 1);
         }
     } else if (chr1 === "=") {
         const chr2: string | undefined = text[positionStart + 1];
 
         if (chr2 === ">") {
-            token = readConstant(Language.LineTokenKind.FatArrow, text, positionStart, 2);
+            token = readConstant(Token.LineTokenKind.FatArrow, text, positionStart, 2);
         } else {
-            token = readConstant(Language.LineTokenKind.Equal, text, positionStart, 1);
+            token = readConstant(Token.LineTokenKind.Equal, text, positionStart, 1);
         }
     } else if (chr1 === "/") {
         const chr2: string | undefined = text[positionStart + 1];
@@ -900,7 +900,7 @@ function tokenizeDefault(
             token = read.token;
             lineMode = read.lineMode;
         } else {
-            token = readConstant(Language.LineTokenKind.Division, text, positionStart, 1);
+            token = readConstant(Token.LineTokenKind.Division, text, positionStart, 1);
         }
     } else if (chr1 === "#") {
         const chr2: string | undefined = text[positionStart + 1];
@@ -943,12 +943,12 @@ function readOrStartTextLiteral(text: string, currentPosition: number): LineMode
     if (maybePositionEnd !== undefined) {
         const positionEnd: number = maybePositionEnd + 1;
         return {
-            token: readTokenFrom(Language.LineTokenKind.TextLiteral, text, currentPosition, positionEnd),
+            token: readTokenFrom(Token.LineTokenKind.TextLiteral, text, currentPosition, positionEnd),
             lineMode: LineMode.Default,
         };
     } else {
         return {
-            token: readRestOfLine(Language.LineTokenKind.TextLiteralStart, text, currentPosition),
+            token: readRestOfLine(Token.LineTokenKind.TextLiteralStart, text, currentPosition),
             lineMode: LineMode.Text,
         };
     }
@@ -959,7 +959,7 @@ function readHexLiteral(
     text: string,
     lineNumber: number,
     positionStart: number,
-): Language.LineToken {
+): Token.LineToken {
     const maybePositionEnd: number | undefined = maybeIndexOfRegexEnd(Pattern.Hex, text, positionStart);
     if (maybePositionEnd === undefined) {
         throw new LexError.ExpectedError(
@@ -970,7 +970,7 @@ function readHexLiteral(
     }
     const positionEnd: number = maybePositionEnd;
 
-    return readTokenFrom(Language.LineTokenKind.HexLiteral, text, positionStart, positionEnd);
+    return readTokenFrom(Token.LineTokenKind.HexLiteral, text, positionStart, positionEnd);
 }
 
 function readNumericLiteral(
@@ -978,7 +978,7 @@ function readNumericLiteral(
     text: string,
     lineNumber: number,
     positionStart: number,
-): Language.LineToken {
+): Token.LineToken {
     const maybePositionEnd: number | undefined = maybeIndexOfRegexEnd(Pattern.Numeric, text, positionStart);
     if (maybePositionEnd === undefined) {
         throw new LexError.ExpectedError(
@@ -989,24 +989,24 @@ function readNumericLiteral(
     }
     const positionEnd: number = maybePositionEnd;
 
-    return readTokenFrom(Language.LineTokenKind.NumericLiteral, text, positionStart, positionEnd);
+    return readTokenFrom(Token.LineTokenKind.NumericLiteral, text, positionStart, positionEnd);
 }
 
-function readLineComment(text: string, positionStart: number): Language.LineToken {
-    return readRestOfLine(Language.LineTokenKind.LineComment, text, positionStart);
+function readLineComment(text: string, positionStart: number): Token.LineToken {
+    return readRestOfLine(Token.LineTokenKind.LineComment, text, positionStart);
 }
 
 function readOrStartMultilineComment(text: string, positionStart: number): LineModeAlteringRead {
     const indexOfCloseComment: number = text.indexOf("*/", positionStart + 2);
     if (indexOfCloseComment === -1) {
         return {
-            token: readRestOfLine(Language.LineTokenKind.MultilineCommentStart, text, positionStart),
+            token: readRestOfLine(Token.LineTokenKind.MultilineCommentStart, text, positionStart),
             lineMode: LineMode.Comment,
         };
     } else {
         const positionEnd: number = indexOfCloseComment + 2;
         return {
-            token: readTokenFrom(Language.LineTokenKind.MultilineComment, text, positionStart, positionEnd),
+            token: readTokenFrom(Token.LineTokenKind.MultilineComment, text, positionStart, positionEnd),
             lineMode: LineMode.Default,
         };
     }
@@ -1017,8 +1017,8 @@ function readKeyword(
     text: string,
     lineNumber: number,
     positionStart: number,
-): Language.LineToken {
-    const maybeLineToken: Language.LineToken | undefined = maybeReadKeyword(text, positionStart);
+): Token.LineToken {
+    const maybeLineToken: Token.LineToken | undefined = maybeReadKeyword(text, positionStart);
     if (maybeLineToken) {
         return maybeLineToken;
     } else {
@@ -1026,7 +1026,7 @@ function readKeyword(
     }
 }
 
-function maybeReadKeyword(text: string, currentPosition: number): Language.LineToken | undefined {
+function maybeReadKeyword(text: string, currentPosition: number): Token.LineToken | undefined {
     const identifierPositionStart: number = text[currentPosition] === "#" ? currentPosition + 1 : currentPosition;
 
     const maybeIdentifierPositionEnd: number | undefined = maybeIndexOfIdentifierEnd(text, identifierPositionStart);
@@ -1036,7 +1036,7 @@ function maybeReadKeyword(text: string, currentPosition: number): Language.LineT
     const identifierPositionEnd: number = maybeIdentifierPositionEnd;
 
     const data: string = text.substring(currentPosition, identifierPositionEnd);
-    const maybeKeywordTokenKind: Language.LineTokenKind | undefined = maybeKeywordLineTokenKindFrom(data);
+    const maybeKeywordTokenKind: Token.LineTokenKind | undefined = maybeKeywordLineTokenKindFrom(data);
     if (maybeKeywordTokenKind === undefined) {
         return undefined;
     } else {
@@ -1055,12 +1055,12 @@ function readOrStartQuotedIdentifier(text: string, currentPosition: number): Lin
         const positionEnd: number = maybePositionEnd + 1;
 
         return {
-            token: readTokenFrom(Language.LineTokenKind.Identifier, text, currentPosition, positionEnd),
+            token: readTokenFrom(Token.LineTokenKind.Identifier, text, currentPosition, positionEnd),
             lineMode: LineMode.Default,
         };
     } else {
         return {
-            token: readRestOfLine(Language.LineTokenKind.QuotedIdentifierStart, text, currentPosition),
+            token: readRestOfLine(Token.LineTokenKind.QuotedIdentifierStart, text, currentPosition),
             lineMode: LineMode.QuotedIdentifier,
         };
     }
@@ -1073,7 +1073,7 @@ function readKeywordOrIdentifier(
     text: string,
     lineNumber: number,
     positionStart: number,
-): Language.LineToken {
+): Token.LineToken {
     // keyword
     if (text[positionStart] === "#") {
         return readKeyword(localizationTemplates, text, lineNumber, positionStart);
@@ -1090,15 +1090,15 @@ function readKeywordOrIdentifier(
         }
         const positionEnd: number = maybePositionEnd;
         const data: string = text.substring(positionStart, positionEnd);
-        const maybeKeywordTokenKind: Language.LineTokenKind | undefined = maybeKeywordLineTokenKindFrom(data);
+        const maybeKeywordTokenKind: Token.LineTokenKind | undefined = maybeKeywordLineTokenKindFrom(data);
 
-        let tokenKind: Language.LineTokenKind;
+        let tokenKind: Token.LineTokenKind;
         if (maybeKeywordTokenKind !== undefined) {
             tokenKind = maybeKeywordTokenKind;
         } else if (data === "null") {
-            tokenKind = Language.LineTokenKind.NullLiteral;
+            tokenKind = Token.LineTokenKind.NullLiteral;
         } else {
-            tokenKind = Language.LineTokenKind.Identifier;
+            tokenKind = Token.LineTokenKind.Identifier;
         }
 
         return {
@@ -1111,21 +1111,21 @@ function readKeywordOrIdentifier(
 }
 
 function readConstant(
-    lineTokenKind: Language.LineTokenKind,
+    lineTokenKind: Token.LineTokenKind,
     text: string,
     positionStart: number,
     length: number,
-): Language.LineToken {
+): Token.LineToken {
     const positionEnd: number = positionStart + length;
     return readTokenFrom(lineTokenKind, text, positionStart, positionEnd);
 }
 
 function readTokenFrom(
-    lineTokenKind: Language.LineTokenKind,
+    lineTokenKind: Token.LineTokenKind,
     text: string,
     positionStart: number,
     positionEnd: number,
-): Language.LineToken {
+): Token.LineToken {
     return {
         kind: lineTokenKind,
         positionStart,
@@ -1134,11 +1134,7 @@ function readTokenFrom(
     };
 }
 
-function readRestOfLine(
-    lineTokenKind: Language.LineTokenKind,
-    text: string,
-    positionStart: number,
-): Language.LineToken {
+function readRestOfLine(lineTokenKind: Token.LineTokenKind, text: string, positionStart: number): Token.LineToken {
     const positionEnd: number = text.length;
     return readTokenFrom(lineTokenKind, text, positionStart, positionEnd);
 }
@@ -1153,70 +1149,70 @@ function maybeIndexOfIdentifierEnd(text: string, positionStart: number): number 
     return maybeLength !== undefined ? positionStart + maybeLength : undefined;
 }
 
-function maybeKeywordLineTokenKindFrom(data: string): Language.LineTokenKind | undefined {
+function maybeKeywordLineTokenKindFrom(data: string): Token.LineTokenKind | undefined {
     switch (data) {
-        case Language.Keyword.KeywordKind.And:
-            return Language.LineTokenKind.KeywordAnd;
-        case Language.Keyword.KeywordKind.As:
-            return Language.LineTokenKind.KeywordAs;
-        case Language.Keyword.KeywordKind.Each:
-            return Language.LineTokenKind.KeywordEach;
-        case Language.Keyword.KeywordKind.Else:
-            return Language.LineTokenKind.KeywordElse;
-        case Language.Keyword.KeywordKind.Error:
-            return Language.LineTokenKind.KeywordError;
-        case Language.Keyword.KeywordKind.False:
-            return Language.LineTokenKind.KeywordFalse;
-        case Language.Keyword.KeywordKind.If:
-            return Language.LineTokenKind.KeywordIf;
-        case Language.Keyword.KeywordKind.In:
-            return Language.LineTokenKind.KeywordIn;
-        case Language.Keyword.KeywordKind.Is:
-            return Language.LineTokenKind.KeywordIs;
-        case Language.Keyword.KeywordKind.Let:
-            return Language.LineTokenKind.KeywordLet;
-        case Language.Keyword.KeywordKind.Meta:
-            return Language.LineTokenKind.KeywordMeta;
-        case Language.Keyword.KeywordKind.Not:
-            return Language.LineTokenKind.KeywordNot;
-        case Language.Keyword.KeywordKind.Or:
-            return Language.LineTokenKind.KeywordOr;
-        case Language.Keyword.KeywordKind.Otherwise:
-            return Language.LineTokenKind.KeywordOtherwise;
-        case Language.Keyword.KeywordKind.Section:
-            return Language.LineTokenKind.KeywordSection;
-        case Language.Keyword.KeywordKind.Shared:
-            return Language.LineTokenKind.KeywordShared;
-        case Language.Keyword.KeywordKind.Then:
-            return Language.LineTokenKind.KeywordThen;
-        case Language.Keyword.KeywordKind.True:
-            return Language.LineTokenKind.KeywordTrue;
-        case Language.Keyword.KeywordKind.Try:
-            return Language.LineTokenKind.KeywordTry;
-        case Language.Keyword.KeywordKind.Type:
-            return Language.LineTokenKind.KeywordType;
-        case Language.Keyword.KeywordKind.HashBinary:
-            return Language.LineTokenKind.KeywordHashBinary;
-        case Language.Keyword.KeywordKind.HashDate:
-            return Language.LineTokenKind.KeywordHashDate;
-        case Language.Keyword.KeywordKind.HashDateTime:
-            return Language.LineTokenKind.KeywordHashDateTime;
-        case Language.Keyword.KeywordKind.HashDateTimeZone:
-            return Language.LineTokenKind.KeywordHashDateTimeZone;
-        case Language.Keyword.KeywordKind.HashDuration:
-            return Language.LineTokenKind.KeywordHashDuration;
-        case Language.Keyword.KeywordKind.HashInfinity:
-            return Language.LineTokenKind.KeywordHashInfinity;
-        case Language.Keyword.KeywordKind.HashNan:
-            return Language.LineTokenKind.KeywordHashNan;
-        case Language.Keyword.KeywordKind.HashSections:
-            return Language.LineTokenKind.KeywordHashSections;
-        case Language.Keyword.KeywordKind.HashShared:
-            return Language.LineTokenKind.KeywordHashShared;
-        case Language.Keyword.KeywordKind.HashTable:
-            return Language.LineTokenKind.KeywordHashTable;
-        case Language.Keyword.KeywordKind.HashTime:
-            return Language.LineTokenKind.KeywordHashTime;
+        case Keyword.KeywordKind.And:
+            return Token.LineTokenKind.KeywordAnd;
+        case Keyword.KeywordKind.As:
+            return Token.LineTokenKind.KeywordAs;
+        case Keyword.KeywordKind.Each:
+            return Token.LineTokenKind.KeywordEach;
+        case Keyword.KeywordKind.Else:
+            return Token.LineTokenKind.KeywordElse;
+        case Keyword.KeywordKind.Error:
+            return Token.LineTokenKind.KeywordError;
+        case Keyword.KeywordKind.False:
+            return Token.LineTokenKind.KeywordFalse;
+        case Keyword.KeywordKind.If:
+            return Token.LineTokenKind.KeywordIf;
+        case Keyword.KeywordKind.In:
+            return Token.LineTokenKind.KeywordIn;
+        case Keyword.KeywordKind.Is:
+            return Token.LineTokenKind.KeywordIs;
+        case Keyword.KeywordKind.Let:
+            return Token.LineTokenKind.KeywordLet;
+        case Keyword.KeywordKind.Meta:
+            return Token.LineTokenKind.KeywordMeta;
+        case Keyword.KeywordKind.Not:
+            return Token.LineTokenKind.KeywordNot;
+        case Keyword.KeywordKind.Or:
+            return Token.LineTokenKind.KeywordOr;
+        case Keyword.KeywordKind.Otherwise:
+            return Token.LineTokenKind.KeywordOtherwise;
+        case Keyword.KeywordKind.Section:
+            return Token.LineTokenKind.KeywordSection;
+        case Keyword.KeywordKind.Shared:
+            return Token.LineTokenKind.KeywordShared;
+        case Keyword.KeywordKind.Then:
+            return Token.LineTokenKind.KeywordThen;
+        case Keyword.KeywordKind.True:
+            return Token.LineTokenKind.KeywordTrue;
+        case Keyword.KeywordKind.Try:
+            return Token.LineTokenKind.KeywordTry;
+        case Keyword.KeywordKind.Type:
+            return Token.LineTokenKind.KeywordType;
+        case Keyword.KeywordKind.HashBinary:
+            return Token.LineTokenKind.KeywordHashBinary;
+        case Keyword.KeywordKind.HashDate:
+            return Token.LineTokenKind.KeywordHashDate;
+        case Keyword.KeywordKind.HashDateTime:
+            return Token.LineTokenKind.KeywordHashDateTime;
+        case Keyword.KeywordKind.HashDateTimeZone:
+            return Token.LineTokenKind.KeywordHashDateTimeZone;
+        case Keyword.KeywordKind.HashDuration:
+            return Token.LineTokenKind.KeywordHashDuration;
+        case Keyword.KeywordKind.HashInfinity:
+            return Token.LineTokenKind.KeywordHashInfinity;
+        case Keyword.KeywordKind.HashNan:
+            return Token.LineTokenKind.KeywordHashNan;
+        case Keyword.KeywordKind.HashSections:
+            return Token.LineTokenKind.KeywordHashSections;
+        case Keyword.KeywordKind.HashShared:
+            return Token.LineTokenKind.KeywordHashShared;
+        case Keyword.KeywordKind.HashTable:
+            return Token.LineTokenKind.KeywordHashTable;
+        case Keyword.KeywordKind.HashTime:
+            return Token.LineTokenKind.KeywordHashTime;
         default:
             return undefined;
     }

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -1155,67 +1155,67 @@ function maybeIndexOfIdentifierEnd(text: string, positionStart: number): number 
 
 function maybeKeywordLineTokenKindFrom(data: string): Language.LineTokenKind | undefined {
     switch (data) {
-        case Language.KeywordKind.And:
+        case Language.Keyword.KeywordKind.And:
             return Language.LineTokenKind.KeywordAnd;
-        case Language.KeywordKind.As:
+        case Language.Keyword.KeywordKind.As:
             return Language.LineTokenKind.KeywordAs;
-        case Language.KeywordKind.Each:
+        case Language.Keyword.KeywordKind.Each:
             return Language.LineTokenKind.KeywordEach;
-        case Language.KeywordKind.Else:
+        case Language.Keyword.KeywordKind.Else:
             return Language.LineTokenKind.KeywordElse;
-        case Language.KeywordKind.Error:
+        case Language.Keyword.KeywordKind.Error:
             return Language.LineTokenKind.KeywordError;
-        case Language.KeywordKind.False:
+        case Language.Keyword.KeywordKind.False:
             return Language.LineTokenKind.KeywordFalse;
-        case Language.KeywordKind.If:
+        case Language.Keyword.KeywordKind.If:
             return Language.LineTokenKind.KeywordIf;
-        case Language.KeywordKind.In:
+        case Language.Keyword.KeywordKind.In:
             return Language.LineTokenKind.KeywordIn;
-        case Language.KeywordKind.Is:
+        case Language.Keyword.KeywordKind.Is:
             return Language.LineTokenKind.KeywordIs;
-        case Language.KeywordKind.Let:
+        case Language.Keyword.KeywordKind.Let:
             return Language.LineTokenKind.KeywordLet;
-        case Language.KeywordKind.Meta:
+        case Language.Keyword.KeywordKind.Meta:
             return Language.LineTokenKind.KeywordMeta;
-        case Language.KeywordKind.Not:
+        case Language.Keyword.KeywordKind.Not:
             return Language.LineTokenKind.KeywordNot;
-        case Language.KeywordKind.Or:
+        case Language.Keyword.KeywordKind.Or:
             return Language.LineTokenKind.KeywordOr;
-        case Language.KeywordKind.Otherwise:
+        case Language.Keyword.KeywordKind.Otherwise:
             return Language.LineTokenKind.KeywordOtherwise;
-        case Language.KeywordKind.Section:
+        case Language.Keyword.KeywordKind.Section:
             return Language.LineTokenKind.KeywordSection;
-        case Language.KeywordKind.Shared:
+        case Language.Keyword.KeywordKind.Shared:
             return Language.LineTokenKind.KeywordShared;
-        case Language.KeywordKind.Then:
+        case Language.Keyword.KeywordKind.Then:
             return Language.LineTokenKind.KeywordThen;
-        case Language.KeywordKind.True:
+        case Language.Keyword.KeywordKind.True:
             return Language.LineTokenKind.KeywordTrue;
-        case Language.KeywordKind.Try:
+        case Language.Keyword.KeywordKind.Try:
             return Language.LineTokenKind.KeywordTry;
-        case Language.KeywordKind.Type:
+        case Language.Keyword.KeywordKind.Type:
             return Language.LineTokenKind.KeywordType;
-        case Language.KeywordKind.HashBinary:
+        case Language.Keyword.KeywordKind.HashBinary:
             return Language.LineTokenKind.KeywordHashBinary;
-        case Language.KeywordKind.HashDate:
+        case Language.Keyword.KeywordKind.HashDate:
             return Language.LineTokenKind.KeywordHashDate;
-        case Language.KeywordKind.HashDateTime:
+        case Language.Keyword.KeywordKind.HashDateTime:
             return Language.LineTokenKind.KeywordHashDateTime;
-        case Language.KeywordKind.HashDateTimeZone:
+        case Language.Keyword.KeywordKind.HashDateTimeZone:
             return Language.LineTokenKind.KeywordHashDateTimeZone;
-        case Language.KeywordKind.HashDuration:
+        case Language.Keyword.KeywordKind.HashDuration:
             return Language.LineTokenKind.KeywordHashDuration;
-        case Language.KeywordKind.HashInfinity:
+        case Language.Keyword.KeywordKind.HashInfinity:
             return Language.LineTokenKind.KeywordHashInfinity;
-        case Language.KeywordKind.HashNan:
+        case Language.Keyword.KeywordKind.HashNan:
             return Language.LineTokenKind.KeywordHashNan;
-        case Language.KeywordKind.HashSections:
+        case Language.Keyword.KeywordKind.HashSections:
             return Language.LineTokenKind.KeywordHashSections;
-        case Language.KeywordKind.HashShared:
+        case Language.Keyword.KeywordKind.HashShared:
             return Language.LineTokenKind.KeywordHashShared;
-        case Language.KeywordKind.HashTable:
+        case Language.Keyword.KeywordKind.HashTable:
             return Language.LineTokenKind.KeywordHashTable;
-        case Language.KeywordKind.HashTime:
+        case Language.Keyword.KeywordKind.HashTime:
             return Language.LineTokenKind.KeywordHashTime;
         default:
             return undefined;

--- a/src/localization/localization.ts
+++ b/src/localization/localization.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Language } from "..";
 import { Assert, StringUtils } from "../common";
+import { Token } from "../language";
 import { Lexer, LexError } from "../lexer";
 import { ParseError } from "../parser";
 import { TokenWithColumnNumber } from "../parser/error";
@@ -34,7 +34,7 @@ interface ILocalization {
     ) => string;
     readonly error_parse_expectAnyTokenKind: (
         templates: ILocalizationTemplates,
-        expectedAnyTokenKinds: ReadonlyArray<Language.TokenKind>,
+        expectedAnyTokenKinds: ReadonlyArray<Token.TokenKind>,
         maybeFoundToken: TokenWithColumnNumber | undefined,
     ) => string;
     readonly error_parse_expectGeneralizedIdentifier: (
@@ -43,144 +43,141 @@ interface ILocalization {
     ) => string;
     readonly error_parse_expectTokenKind: (
         templates: ILocalizationTemplates,
-        expectedTokenKind: Language.TokenKind,
+        expectedTokenKind: Token.TokenKind,
         maybeFoundToken: TokenWithColumnNumber | undefined,
     ) => string;
-    readonly error_parse_invalidPrimitiveType: (templates: ILocalizationTemplates, token: Language.Token) => string;
+    readonly error_parse_invalidPrimitiveType: (templates: ILocalizationTemplates, token: Token.Token) => string;
     readonly error_parse_requiredParameterAfterOptional: (templates: ILocalizationTemplates) => string;
     readonly error_parse_unterminated_bracket: (templates: ILocalizationTemplates) => string;
     readonly error_parse_unterminated_parenthesis: (templates: ILocalizationTemplates) => string;
     readonly error_parse_unusedTokens: (templates: ILocalizationTemplates) => string;
 }
 
-export function localizeTokenKind(
-    localizationTemplates: ILocalizationTemplates,
-    tokenKind: Language.TokenKind,
-): string {
+export function localizeTokenKind(localizationTemplates: ILocalizationTemplates, tokenKind: Token.TokenKind): string {
     switch (tokenKind) {
-        case Language.TokenKind.Ampersand:
+        case Token.TokenKind.Ampersand:
             return localizationTemplates.tokenKind_ampersand;
-        case Language.TokenKind.Asterisk:
+        case Token.TokenKind.Asterisk:
             return localizationTemplates.tokenKind_asterisk;
-        case Language.TokenKind.AtSign:
+        case Token.TokenKind.AtSign:
             return localizationTemplates.tokenKind_atSign;
-        case Language.TokenKind.Bang:
+        case Token.TokenKind.Bang:
             return localizationTemplates.tokenKind_bang;
-        case Language.TokenKind.Comma:
+        case Token.TokenKind.Comma:
             return localizationTemplates.tokenKind_comma;
-        case Language.TokenKind.Division:
+        case Token.TokenKind.Division:
             return localizationTemplates.tokenKind_division;
-        case Language.TokenKind.DotDot:
+        case Token.TokenKind.DotDot:
             return localizationTemplates.tokenKind_dotDot;
-        case Language.TokenKind.Ellipsis:
+        case Token.TokenKind.Ellipsis:
             return localizationTemplates.tokenKind_ellipsis;
-        case Language.TokenKind.Equal:
+        case Token.TokenKind.Equal:
             return localizationTemplates.tokenKind_equal;
-        case Language.TokenKind.FatArrow:
+        case Token.TokenKind.FatArrow:
             return localizationTemplates.tokenKind_fatArrow;
-        case Language.TokenKind.GreaterThan:
+        case Token.TokenKind.GreaterThan:
             return localizationTemplates.tokenKind_greaterThan;
-        case Language.TokenKind.GreaterThanEqualTo:
+        case Token.TokenKind.GreaterThanEqualTo:
             return localizationTemplates.tokenKind_greaterThanEqualTo;
-        case Language.TokenKind.HexLiteral:
+        case Token.TokenKind.HexLiteral:
             return localizationTemplates.tokenKind_hexLiteral;
-        case Language.TokenKind.Identifier:
+        case Token.TokenKind.Identifier:
             return localizationTemplates.tokenKind_identifier;
-        case Language.TokenKind.KeywordAnd:
+        case Token.TokenKind.KeywordAnd:
             return localizationTemplates.tokenKind_keywordAnd;
-        case Language.TokenKind.KeywordAs:
+        case Token.TokenKind.KeywordAs:
             return localizationTemplates.tokenKind_keywordAs;
-        case Language.TokenKind.KeywordEach:
+        case Token.TokenKind.KeywordEach:
             return localizationTemplates.tokenKind_keywordEach;
-        case Language.TokenKind.KeywordElse:
+        case Token.TokenKind.KeywordElse:
             return localizationTemplates.tokenKind_keywordElse;
-        case Language.TokenKind.KeywordError:
+        case Token.TokenKind.KeywordError:
             return localizationTemplates.tokenKind_keywordError;
-        case Language.TokenKind.KeywordFalse:
+        case Token.TokenKind.KeywordFalse:
             return localizationTemplates.tokenKind_keywordFalse;
-        case Language.TokenKind.KeywordHashBinary:
+        case Token.TokenKind.KeywordHashBinary:
             return localizationTemplates.tokenKind_keywordHashBinary;
-        case Language.TokenKind.KeywordHashDate:
+        case Token.TokenKind.KeywordHashDate:
             return localizationTemplates.tokenKind_keywordHashDate;
-        case Language.TokenKind.KeywordHashDateTime:
+        case Token.TokenKind.KeywordHashDateTime:
             return localizationTemplates.tokenKind_keywordHashDateTime;
-        case Language.TokenKind.KeywordHashDateTimeZone:
+        case Token.TokenKind.KeywordHashDateTimeZone:
             return localizationTemplates.tokenKind_keywordHashDateTimeZone;
-        case Language.TokenKind.KeywordHashDuration:
+        case Token.TokenKind.KeywordHashDuration:
             return localizationTemplates.tokenKind_keywordHashDuration;
-        case Language.TokenKind.KeywordHashInfinity:
+        case Token.TokenKind.KeywordHashInfinity:
             return localizationTemplates.tokenKind_keywordHashInfinity;
-        case Language.TokenKind.KeywordHashNan:
+        case Token.TokenKind.KeywordHashNan:
             return localizationTemplates.tokenKind_keywordHashNan;
-        case Language.TokenKind.KeywordHashSections:
+        case Token.TokenKind.KeywordHashSections:
             return localizationTemplates.tokenKind_keywordHashSections;
-        case Language.TokenKind.KeywordHashShared:
+        case Token.TokenKind.KeywordHashShared:
             return localizationTemplates.tokenKind_keywordShared;
-        case Language.TokenKind.KeywordHashTable:
+        case Token.TokenKind.KeywordHashTable:
             return localizationTemplates.tokenKind_keywordHashTable;
-        case Language.TokenKind.KeywordHashTime:
+        case Token.TokenKind.KeywordHashTime:
             return localizationTemplates.tokenKind_keywordHashTime;
-        case Language.TokenKind.KeywordIf:
+        case Token.TokenKind.KeywordIf:
             return localizationTemplates.tokenKind_keywordIf;
-        case Language.TokenKind.KeywordIn:
+        case Token.TokenKind.KeywordIn:
             return localizationTemplates.tokenKind_keywordIn;
-        case Language.TokenKind.KeywordIs:
+        case Token.TokenKind.KeywordIs:
             return localizationTemplates.tokenKind_keywordIs;
-        case Language.TokenKind.KeywordLet:
+        case Token.TokenKind.KeywordLet:
             return localizationTemplates.tokenKind_keywordLet;
-        case Language.TokenKind.KeywordMeta:
+        case Token.TokenKind.KeywordMeta:
             return localizationTemplates.tokenKind_keywordMeta;
-        case Language.TokenKind.KeywordNot:
+        case Token.TokenKind.KeywordNot:
             return localizationTemplates.tokenKind_notEqual;
-        case Language.TokenKind.KeywordOr:
+        case Token.TokenKind.KeywordOr:
             return localizationTemplates.tokenKind_keywordOr;
-        case Language.TokenKind.KeywordOtherwise:
+        case Token.TokenKind.KeywordOtherwise:
             return localizationTemplates.tokenKind_keywordOtherwise;
-        case Language.TokenKind.KeywordSection:
+        case Token.TokenKind.KeywordSection:
             return localizationTemplates.tokenKind_keywordSection;
-        case Language.TokenKind.KeywordShared:
+        case Token.TokenKind.KeywordShared:
             return localizationTemplates.tokenKind_keywordShared;
-        case Language.TokenKind.KeywordThen:
+        case Token.TokenKind.KeywordThen:
             return localizationTemplates.tokenKind_keywordThen;
-        case Language.TokenKind.KeywordTrue:
+        case Token.TokenKind.KeywordTrue:
             return localizationTemplates.tokenKind_keywordTrue;
-        case Language.TokenKind.KeywordTry:
+        case Token.TokenKind.KeywordTry:
             return localizationTemplates.tokenKind_keywordTry;
-        case Language.TokenKind.KeywordType:
+        case Token.TokenKind.KeywordType:
             return localizationTemplates.tokenKind_keywordType;
-        case Language.TokenKind.LeftBrace:
+        case Token.TokenKind.LeftBrace:
             return localizationTemplates.tokenKind_leftBrace;
-        case Language.TokenKind.LeftBracket:
+        case Token.TokenKind.LeftBracket:
             return localizationTemplates.tokenKind_leftBracket;
-        case Language.TokenKind.LeftParenthesis:
+        case Token.TokenKind.LeftParenthesis:
             return localizationTemplates.tokenKind_leftParenthesis;
-        case Language.TokenKind.LessThan:
+        case Token.TokenKind.LessThan:
             return localizationTemplates.tokenKind_lessThan;
-        case Language.TokenKind.LessThanEqualTo:
+        case Token.TokenKind.LessThanEqualTo:
             return localizationTemplates.tokenKind_lessThanEqualTo;
-        case Language.TokenKind.Minus:
+        case Token.TokenKind.Minus:
             return localizationTemplates.tokenKind_minus;
-        case Language.TokenKind.NotEqual:
+        case Token.TokenKind.NotEqual:
             return localizationTemplates.tokenKind_notEqual;
-        case Language.TokenKind.NullCoalescingOperator:
+        case Token.TokenKind.NullCoalescingOperator:
             return localizationTemplates.tokenKind_nullCoalescingOperator;
-        case Language.TokenKind.NullLiteral:
+        case Token.TokenKind.NullLiteral:
             return localizationTemplates.tokenKind_nullLiteral;
-        case Language.TokenKind.NumericLiteral:
+        case Token.TokenKind.NumericLiteral:
             return localizationTemplates.tokenKind_numericLiteral;
-        case Language.TokenKind.Plus:
+        case Token.TokenKind.Plus:
             return localizationTemplates.tokenKind_plus;
-        case Language.TokenKind.QuestionMark:
+        case Token.TokenKind.QuestionMark:
             return localizationTemplates.tokenKind_questionMark;
-        case Language.TokenKind.RightBrace:
+        case Token.TokenKind.RightBrace:
             return localizationTemplates.tokenKind_rightBrace;
-        case Language.TokenKind.RightBracket:
+        case Token.TokenKind.RightBracket:
             return localizationTemplates.tokenKind_rightBracket;
-        case Language.TokenKind.RightParenthesis:
+        case Token.TokenKind.RightParenthesis:
             return localizationTemplates.tokenKind_rightParenthesis;
-        case Language.TokenKind.Semicolon:
+        case Token.TokenKind.Semicolon:
             return localizationTemplates.tokenKind_semicolon;
-        case Language.TokenKind.TextLiteral:
+        case Token.TokenKind.TextLiteral:
             return localizationTemplates.tokenKind_textLiteral;
 
         default:
@@ -324,11 +321,11 @@ export const Localization: ILocalization = {
 
     error_parse_expectAnyTokenKind: (
         templates: ILocalizationTemplates,
-        expectedAnyTokenKinds: ReadonlyArray<Language.TokenKind>,
+        expectedAnyTokenKinds: ReadonlyArray<Token.TokenKind>,
         maybeFoundToken: TokenWithColumnNumber | undefined,
     ) => {
         const localizedExpectedAnyTokenKinds: string = expectedAnyTokenKinds
-            .map((tokenKind: Language.TokenKind) => localizeTokenKind(templates, tokenKind))
+            .map((tokenKind: Token.TokenKind) => localizeTokenKind(templates, tokenKind))
             .join(", ");
 
         if (maybeFoundToken !== undefined) {
@@ -360,7 +357,7 @@ export const Localization: ILocalization = {
 
     error_parse_expectTokenKind: (
         templates: ILocalizationTemplates,
-        expectedTokenKind: Language.TokenKind,
+        expectedTokenKind: Token.TokenKind,
         maybeFoundToken: TokenWithColumnNumber | undefined,
     ) => {
         const localizedExpectedTokenKind: string = localizeTokenKind(templates, expectedTokenKind);
@@ -381,7 +378,7 @@ export const Localization: ILocalization = {
         }
     },
 
-    error_parse_invalidPrimitiveType: (templates: ILocalizationTemplates, token: Language.Token) => {
+    error_parse_invalidPrimitiveType: (templates: ILocalizationTemplates, token: Token.Token) => {
         return StringUtils.assertFormat(
             templates.error_parse_invalidPrimitiveType,
             new Map([["foundTokenKind", localizeTokenKind(templates, token.kind)]]),

--- a/src/parser/IParserState/IParserState.ts
+++ b/src/parser/IParserState/IParserState.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import { ParseContext } from "..";
-import { Language } from "../..";
 import { ICancellationToken } from "../../common";
+import { Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 import { ILocalizationTemplates } from "../../localization";
 import { CommonSettings, ParseSettings } from "../../settings";
@@ -18,8 +18,8 @@ export interface IParserState extends CommonSettings {
     readonly localizationTemplates: ILocalizationTemplates;
     readonly maybeCancellationToken: ICancellationToken | undefined;
     tokenIndex: number;
-    maybeCurrentToken: Language.Token | undefined;
-    maybeCurrentTokenKind: Language.TokenKind | undefined;
+    maybeCurrentToken: Token.Token | undefined;
+    maybeCurrentTokenKind: Token.TokenKind | undefined;
     contextState: ParseContext.State;
     maybeCurrentContextNode: ParseContext.Node | undefined;
 }

--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -4,7 +4,7 @@
 import { NodeIdMap, ParseContext, ParseContextUtils, ParseError } from "..";
 import { Language } from "../..";
 import { Assert, CommonError } from "../../common";
-import { Ast } from "../../language";
+import { Ast, Constant } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 import { getLocalizationTemplates } from "../../localization";
 import { ParseSettings } from "../../settings";
@@ -169,7 +169,7 @@ export function isOnTokenKind(
     return isTokenKind(state, tokenKind, tokenIndex);
 }
 
-export function isOnConstantKind(state: IParserState, constantKind: Ast.TConstantKind): boolean {
+export function isOnConstantKind(state: IParserState, constantKind: Constant.TConstantKind): boolean {
     if (isOnTokenKind(state, Language.TokenKind.Identifier)) {
         const currentToken: Language.Token = state.lexerSnapshot.tokens[state.tokenIndex];
         if (currentToken?.data === undefined) {

--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -2,9 +2,8 @@
 // Licensed under the MIT license.
 
 import { NodeIdMap, ParseContext, ParseContextUtils, ParseError } from "..";
-import { Language } from "../..";
 import { Assert, CommonError } from "../../common";
-import { Ast, Constant } from "../../language";
+import { Ast, Constant, Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 import { getLocalizationTemplates } from "../../localization";
 import { ParseSettings } from "../../settings";
@@ -27,7 +26,7 @@ export function stateFactory<S extends IParserState = IParserState>(
     settings: ParseSettings<S>,
     lexerSnapshot: LexerSnapshot,
 ): IParserState {
-    const maybeCurrentToken: Language.Token | undefined = lexerSnapshot.tokens[0];
+    const maybeCurrentToken: Token.Token | undefined = lexerSnapshot.tokens[0];
 
     return {
         ...settings,
@@ -153,25 +152,25 @@ export function incrementAttributeCounter(state: IParserState): void {
 // ---------- IsX ----------
 // -------------------------
 
-export function isTokenKind(state: IParserState, tokenKind: Language.TokenKind, tokenIndex: number): boolean {
+export function isTokenKind(state: IParserState, tokenKind: Token.TokenKind, tokenIndex: number): boolean {
     return state.lexerSnapshot.tokens[tokenIndex]?.kind === tokenKind ?? false;
 }
 
-export function isNextTokenKind(state: IParserState, tokenKind: Language.TokenKind): boolean {
+export function isNextTokenKind(state: IParserState, tokenKind: Token.TokenKind): boolean {
     return isTokenKind(state, tokenKind, state.tokenIndex + 1);
 }
 
 export function isOnTokenKind(
     state: IParserState,
-    tokenKind: Language.TokenKind,
+    tokenKind: Token.TokenKind,
     tokenIndex: number = state.tokenIndex,
 ): boolean {
     return isTokenKind(state, tokenKind, tokenIndex);
 }
 
 export function isOnConstantKind(state: IParserState, constantKind: Constant.TConstantKind): boolean {
-    if (isOnTokenKind(state, Language.TokenKind.Identifier)) {
-        const currentToken: Language.Token = state.lexerSnapshot.tokens[state.tokenIndex];
+    if (isOnTokenKind(state, Token.TokenKind.Identifier)) {
+        const currentToken: Token.Token = state.lexerSnapshot.tokens[state.tokenIndex];
         if (currentToken?.data === undefined) {
             const details: {} = { currentToken };
             throw new CommonError.InvariantError(`expected data on Token`, details);
@@ -185,44 +184,44 @@ export function isOnConstantKind(state: IParserState, constantKind: Constant.TCo
 }
 
 export function isOnGeneralizedIdentifierStart(state: IParserState, tokenIndex: number = state.tokenIndex): boolean {
-    const maybeTokenKind: Language.TokenKind | undefined = state.lexerSnapshot.tokens[tokenIndex]?.kind;
+    const maybeTokenKind: Token.TokenKind | undefined = state.lexerSnapshot.tokens[tokenIndex]?.kind;
     if (maybeTokenKind === undefined) {
         return false;
     }
 
     switch (maybeTokenKind) {
-        case Language.TokenKind.Identifier:
-        case Language.TokenKind.KeywordAnd:
-        case Language.TokenKind.KeywordAs:
-        case Language.TokenKind.KeywordEach:
-        case Language.TokenKind.KeywordElse:
-        case Language.TokenKind.KeywordError:
-        case Language.TokenKind.KeywordFalse:
-        case Language.TokenKind.KeywordHashBinary:
-        case Language.TokenKind.KeywordHashDate:
-        case Language.TokenKind.KeywordHashDateTime:
-        case Language.TokenKind.KeywordHashDateTimeZone:
-        case Language.TokenKind.KeywordHashDuration:
-        case Language.TokenKind.KeywordHashInfinity:
-        case Language.TokenKind.KeywordHashNan:
-        case Language.TokenKind.KeywordHashSections:
-        case Language.TokenKind.KeywordHashShared:
-        case Language.TokenKind.KeywordHashTable:
-        case Language.TokenKind.KeywordHashTime:
-        case Language.TokenKind.KeywordIf:
-        case Language.TokenKind.KeywordIn:
-        case Language.TokenKind.KeywordIs:
-        case Language.TokenKind.KeywordLet:
-        case Language.TokenKind.KeywordMeta:
-        case Language.TokenKind.KeywordNot:
-        case Language.TokenKind.KeywordOr:
-        case Language.TokenKind.KeywordOtherwise:
-        case Language.TokenKind.KeywordSection:
-        case Language.TokenKind.KeywordShared:
-        case Language.TokenKind.KeywordThen:
-        case Language.TokenKind.KeywordTrue:
-        case Language.TokenKind.KeywordTry:
-        case Language.TokenKind.KeywordType:
+        case Token.TokenKind.Identifier:
+        case Token.TokenKind.KeywordAnd:
+        case Token.TokenKind.KeywordAs:
+        case Token.TokenKind.KeywordEach:
+        case Token.TokenKind.KeywordElse:
+        case Token.TokenKind.KeywordError:
+        case Token.TokenKind.KeywordFalse:
+        case Token.TokenKind.KeywordHashBinary:
+        case Token.TokenKind.KeywordHashDate:
+        case Token.TokenKind.KeywordHashDateTime:
+        case Token.TokenKind.KeywordHashDateTimeZone:
+        case Token.TokenKind.KeywordHashDuration:
+        case Token.TokenKind.KeywordHashInfinity:
+        case Token.TokenKind.KeywordHashNan:
+        case Token.TokenKind.KeywordHashSections:
+        case Token.TokenKind.KeywordHashShared:
+        case Token.TokenKind.KeywordHashTable:
+        case Token.TokenKind.KeywordHashTime:
+        case Token.TokenKind.KeywordIf:
+        case Token.TokenKind.KeywordIn:
+        case Token.TokenKind.KeywordIs:
+        case Token.TokenKind.KeywordLet:
+        case Token.TokenKind.KeywordMeta:
+        case Token.TokenKind.KeywordNot:
+        case Token.TokenKind.KeywordOr:
+        case Token.TokenKind.KeywordOtherwise:
+        case Token.TokenKind.KeywordSection:
+        case Token.TokenKind.KeywordShared:
+        case Token.TokenKind.KeywordThen:
+        case Token.TokenKind.KeywordTrue:
+        case Token.TokenKind.KeywordTry:
+        case Token.TokenKind.KeywordType:
             return true;
 
         default:
@@ -239,11 +238,11 @@ export function isRecursivePrimaryExpressionNext(
         // section-access-expression
         // this.isOnTokenKind(TokenKind.Bang)
         // field-access-expression
-        isTokenKind(state, Language.TokenKind.LeftBrace, tokenIndexStart) ||
+        isTokenKind(state, Token.TokenKind.LeftBrace, tokenIndexStart) ||
         // item-access-expression
-        isTokenKind(state, Language.TokenKind.LeftBracket, tokenIndexStart) ||
+        isTokenKind(state, Token.TokenKind.LeftBracket, tokenIndexStart) ||
         // invoke-expression
-        isTokenKind(state, Language.TokenKind.LeftParenthesis, tokenIndexStart)
+        isTokenKind(state, Token.TokenKind.LeftParenthesis, tokenIndexStart)
     );
 }
 
@@ -256,14 +255,14 @@ export function assertContextNodeMetadata(state: IParserState): ContextNodeMetad
     const currentContextNode: ParseContext.Node = state.maybeCurrentContextNode;
 
     Assert.isDefined(currentContextNode.maybeTokenStart);
-    const tokenStart: Language.Token = currentContextNode.maybeTokenStart;
+    const tokenStart: Token.Token = currentContextNode.maybeTokenStart;
 
     // inclusive token index
     const tokenIndexEnd: number = state.tokenIndex - 1;
-    const maybeTokenEnd: Language.Token | undefined = state.lexerSnapshot.tokens[tokenIndexEnd];
+    const maybeTokenEnd: Token.Token | undefined = state.lexerSnapshot.tokens[tokenIndexEnd];
     Assert.isDefined(maybeTokenEnd);
 
-    const tokenRange: Language.TokenRange = {
+    const tokenRange: Token.TokenRange = {
         tokenIndexStart: currentContextNode.tokenIndexStart,
         tokenIndexEnd,
         positionStart: tokenStart.positionStart,
@@ -278,9 +277,9 @@ export function assertContextNodeMetadata(state: IParserState): ContextNodeMetad
     };
 }
 
-export function assertTokenAt(state: IParserState, tokenIndex: number): Language.Token {
+export function assertTokenAt(state: IParserState, tokenIndex: number): Token.Token {
     const lexerSnapshot: LexerSnapshot = state.lexerSnapshot;
-    const maybeToken: Language.Token | undefined = lexerSnapshot.tokens[tokenIndex];
+    const maybeToken: Token.Token | undefined = lexerSnapshot.tokens[tokenIndex];
     Assert.isDefined(maybeToken, undefined, { tokenIndex });
 
     return maybeToken;
@@ -296,7 +295,7 @@ export function assertTokenAt(state: IParserState, tokenIndex: number): Language
 export function testCsvContinuationLetExpression(
     state: IParserState,
 ): ParseError.ExpectedCsvContinuationError | undefined {
-    if (state.maybeCurrentTokenKind === Language.TokenKind.KeywordIn) {
+    if (state.maybeCurrentTokenKind === Token.TokenKind.KeywordIn) {
         return new ParseError.ExpectedCsvContinuationError(
             state.localizationTemplates,
             ParseError.CsvContinuationKind.LetExpression,
@@ -309,7 +308,7 @@ export function testCsvContinuationLetExpression(
 
 export function testCsvContinuationDanglingComma(
     state: IParserState,
-    tokenKind: Language.TokenKind,
+    tokenKind: Token.TokenKind,
 ): ParseError.ExpectedCsvContinuationError | undefined {
     if (state.maybeCurrentTokenKind === tokenKind) {
         return new ParseError.ExpectedCsvContinuationError(
@@ -328,7 +327,7 @@ export function testCsvContinuationDanglingComma(
 
 export function testIsOnTokenKind(
     state: IParserState,
-    expectedTokenKind: Language.TokenKind,
+    expectedTokenKind: Token.TokenKind,
 ): ParseError.ExpectedTokenKindError | undefined {
     if (expectedTokenKind !== state.maybeCurrentTokenKind) {
         const maybeToken: ParseError.TokenWithColumnNumber | undefined = maybeCurrentTokenWithColumnNumber(state);
@@ -340,7 +339,7 @@ export function testIsOnTokenKind(
 
 export function testIsOnAnyTokenKind(
     state: IParserState,
-    expectedAnyTokenKinds: ReadonlyArray<Language.TokenKind>,
+    expectedAnyTokenKinds: ReadonlyArray<Token.TokenKind>,
 ): ParseError.ExpectedAnyTokenKindError | undefined {
     const isError: boolean =
         state.maybeCurrentTokenKind === undefined || expectedAnyTokenKinds.indexOf(state.maybeCurrentTokenKind) === -1;
@@ -358,7 +357,7 @@ export function assertNoMoreTokens(state: IParserState): void {
         return;
     }
 
-    const token: Language.Token = assertTokenAt(state, state.tokenIndex);
+    const token: Token.Token = assertTokenAt(state, state.tokenIndex);
     throw new ParseError.UnusedTokensRemainError(
         state.localizationTemplates,
         token,
@@ -377,7 +376,7 @@ export function assertNoOpenContext(state: IParserState): void {
 // -------------------------------------
 
 export function unterminatedParenthesesError(state: IParserState): ParseError.UnterminatedParenthesesError {
-    const token: Language.Token = assertTokenAt(state, state.tokenIndex);
+    const token: Token.Token = assertTokenAt(state, state.tokenIndex);
     return new ParseError.UnterminatedParenthesesError(
         state.localizationTemplates,
         token,
@@ -386,7 +385,7 @@ export function unterminatedParenthesesError(state: IParserState): ParseError.Un
 }
 
 export function unterminatedBracketError(state: IParserState): ParseError.UnterminatedBracketError {
-    const token: Language.Token = assertTokenAt(state, state.tokenIndex);
+    const token: Token.Token = assertTokenAt(state, state.tokenIndex);
     return new ParseError.UnterminatedBracketError(
         state.localizationTemplates,
         token,
@@ -406,11 +405,11 @@ export function maybeTokenWithColumnNumber(
     state: IParserState,
     tokenIndex: number,
 ): ParseError.TokenWithColumnNumber | undefined {
-    const maybeToken: Language.Token | undefined = state.lexerSnapshot.tokens[tokenIndex];
+    const maybeToken: Token.Token | undefined = state.lexerSnapshot.tokens[tokenIndex];
     if (maybeToken === undefined) {
         return undefined;
     }
-    const currentToken: Language.Token = maybeToken;
+    const currentToken: Token.Token = maybeToken;
 
     return {
         token: currentToken,
@@ -421,5 +420,5 @@ export function maybeTokenWithColumnNumber(
 interface ContextNodeMetadata {
     readonly id: number;
     readonly maybeAttributeIndex: number | undefined;
-    readonly tokenRange: Language.TokenRange;
+    readonly tokenRange: Token.TokenRange;
 }

--- a/src/parser/context/context.ts
+++ b/src/parser/context/context.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT license.
 
 import { NodeIdMap } from "../";
-import { Language } from "../..";
-import { Ast } from "../../language";
+import { Ast, Token } from "../../language";
 
 // Parsing use to be one giant evaluation, leading to an all-or-nothing outcome which was unsuitable for a
 // document that was being live edited.
@@ -37,7 +36,7 @@ export interface Node {
     readonly id: number;
     readonly kind: Ast.NodeKind;
     readonly tokenIndexStart: number;
-    readonly maybeTokenStart: Language.Token | undefined;
+    readonly maybeTokenStart: Token.Token | undefined;
     // Incremented for each child context created with the Node as its parent,
     // and decremented for each child context deleted.
     attributeCounter: number;

--- a/src/parser/context/contextUtils.ts
+++ b/src/parser/context/contextUtils.ts
@@ -2,9 +2,8 @@
 // Licensed under the MIT license.
 
 import { NodeIdMap, ParseContext } from "../";
-import { Language } from "../..";
 import { ArrayUtils, Assert, CommonError, MapUtils, TypeScriptUtils } from "../../common";
-import { Ast } from "../../language";
+import { Ast, Token } from "../../language";
 import { NodeIdMapIterator, NodeIdMapUtils, TXorNode } from "../nodeIdMap";
 import { Node, State } from "./context";
 
@@ -38,7 +37,7 @@ export function startContext(
     state: State,
     nodeKind: Ast.NodeKind,
     tokenIndexStart: number,
-    maybeTokenStart: Language.Token | undefined,
+    maybeTokenStart: Token.Token | undefined,
     maybeParentNode: Node | undefined,
 ): Node {
     const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;

--- a/src/parser/error.ts
+++ b/src/parser/error.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Language } from "..";
 import { Assert, CommonError, StringUtils } from "../common";
+import { Token } from "../language";
 import { ILocalizationTemplates, Localization } from "../localization";
 import { IParserState } from "./IParserState";
 
@@ -50,7 +50,7 @@ export class ExpectedCsvContinuationError extends Error {
 export class ExpectedAnyTokenKindError extends Error {
     constructor(
         templates: ILocalizationTemplates,
-        readonly expectedAnyTokenKinds: ReadonlyArray<Language.TokenKind>,
+        readonly expectedAnyTokenKinds: ReadonlyArray<Token.TokenKind>,
         readonly maybeFoundToken: TokenWithColumnNumber | undefined,
     ) {
         super(Localization.error_parse_expectAnyTokenKind(templates, expectedAnyTokenKinds, maybeFoundToken));
@@ -61,7 +61,7 @@ export class ExpectedAnyTokenKindError extends Error {
 export class ExpectedTokenKindError extends Error {
     constructor(
         templates: ILocalizationTemplates,
-        readonly expectedTokenKind: Language.TokenKind,
+        readonly expectedTokenKind: Token.TokenKind,
         readonly maybeFoundToken: TokenWithColumnNumber | undefined,
     ) {
         super(Localization.error_parse_expectTokenKind(templates, expectedTokenKind, maybeFoundToken));
@@ -79,7 +79,7 @@ export class ExpectedGeneralizedIdentifierError extends Error {
 export class InvalidPrimitiveTypeError extends Error {
     constructor(
         templates: ILocalizationTemplates,
-        readonly token: Language.Token,
+        readonly token: Token.Token,
         readonly positionStart: StringUtils.GraphemePosition,
     ) {
         super(Localization.error_parse_invalidPrimitiveType(templates, token));
@@ -90,7 +90,7 @@ export class InvalidPrimitiveTypeError extends Error {
 export class RequiredParameterAfterOptionalParameterError extends Error {
     constructor(
         templates: ILocalizationTemplates,
-        readonly missingOptionalToken: Language.Token,
+        readonly missingOptionalToken: Token.Token,
         readonly positionStart: StringUtils.GraphemePosition,
     ) {
         super(Localization.error_parse_requiredParameterAfterOptional(templates));
@@ -101,7 +101,7 @@ export class RequiredParameterAfterOptionalParameterError extends Error {
 export class UnterminatedBracketError extends Error {
     constructor(
         templates: ILocalizationTemplates,
-        readonly openBracketToken: Language.Token,
+        readonly openBracketToken: Token.Token,
         readonly positionStart: StringUtils.GraphemePosition,
     ) {
         super(Localization.error_parse_unterminated_bracket(templates));
@@ -112,7 +112,7 @@ export class UnterminatedBracketError extends Error {
 export class UnterminatedParenthesesError extends Error {
     constructor(
         templates: ILocalizationTemplates,
-        readonly openParenthesesToken: Language.Token,
+        readonly openParenthesesToken: Token.Token,
         readonly positionStart: StringUtils.GraphemePosition,
     ) {
         super(Localization.error_parse_unterminated_parenthesis(templates));
@@ -123,7 +123,7 @@ export class UnterminatedParenthesesError extends Error {
 export class UnusedTokensRemainError extends Error {
     constructor(
         templates: ILocalizationTemplates,
-        readonly firstUnusedToken: Language.Token,
+        readonly firstUnusedToken: Token.Token,
         readonly positionStart: StringUtils.GraphemePosition,
     ) {
         super(Localization.error_parse_unusedTokens(templates));
@@ -132,7 +132,7 @@ export class UnusedTokensRemainError extends Error {
 }
 
 export interface TokenWithColumnNumber {
-    readonly token: Language.Token;
+    readonly token: Token.Token;
     readonly columnNumber: number;
 }
 
@@ -163,7 +163,7 @@ export function isTInnerParseError(x: any): x is TInnerParseError {
     );
 }
 
-export function maybeTokenFrom(err: TInnerParseError): Language.Token | undefined {
+export function maybeTokenFrom(err: TInnerParseError): Token.Token | undefined {
     if (
         (err instanceof ExpectedAnyTokenKindError ||
             err instanceof ExpectedCsvContinuationError ||

--- a/src/parser/nodeIdMap/nodeIdMapUtils/nodeIdMapUtils.ts
+++ b/src/parser/nodeIdMap/nodeIdMapUtils/nodeIdMapUtils.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Language } from "../../..";
 import { Assert } from "../../../common";
-import { Ast } from "../../../language";
+import { Ast, Token } from "../../../language";
 import { ParseContext } from "../../context";
 import { Collection } from "../nodeIdMap";
 import { TXorNode, XorNodeKind, XorNodeTokenRange } from "../xorNode";
@@ -46,7 +45,7 @@ export function hasParsedToken(nodeIdMapCollection: Collection, nodeId: number):
 export function xorNodeTokenRange(nodeIdMapCollection: Collection, xorNode: TXorNode): XorNodeTokenRange {
     switch (xorNode.kind) {
         case XorNodeKind.Ast: {
-            const tokenRange: Language.TokenRange = xorNode.node.tokenRange;
+            const tokenRange: Token.TokenRange = xorNode.node.tokenRange;
             return {
                 tokenIndexStart: tokenRange.tokenIndexStart,
                 tokenIndexEnd: tokenRange.tokenIndexEnd,

--- a/src/parser/parsers/combinatorialParser.ts
+++ b/src/parser/parsers/combinatorialParser.ts
@@ -3,9 +3,8 @@
 
 import { Naive } from ".";
 import { NodeIdMap, ParseContextUtils } from "..";
-import { Language } from "../..";
 import { ArrayUtils, Assert, TypeScriptUtils } from "../../common";
-import { Ast, AstUtils, Constant, ConstantUtils } from "../../language";
+import { Ast, AstUtils, Constant, ConstantUtils, Token } from "../../language";
 import { BracketDisambiguation, IParser } from "../IParser";
 import { IParserState, IParserStateUtils } from "../IParserState";
 
@@ -140,8 +139,8 @@ function readBinOpExpression<S extends IParserState = IParserState>(
         operatorConstant.maybeAttributeIndex = 1;
         right.maybeAttributeIndex = 2;
 
-        const leftTokenRange: Language.TokenRange = left.tokenRange;
-        const rightTokenRange: Language.TokenRange = right.tokenRange;
+        const leftTokenRange: Token.TokenRange = left.tokenRange;
+        const rightTokenRange: Token.TokenRange = right.tokenRange;
         const newBinOpExpression: Ast.TBinOpExpression = {
             kind: binOpExpressionNodeKindFrom(operator),
             id: newBinOpExpressionId,
@@ -248,16 +247,16 @@ function readUnaryExpression(state: IParserState, parser: IParser<IParserState>)
     // LL(1)
     switch (state.maybeCurrentTokenKind) {
         // PrimaryExpression
-        case Language.TokenKind.AtSign:
-        case Language.TokenKind.Identifier:
+        case Token.TokenKind.AtSign:
+        case Token.TokenKind.Identifier:
             maybePrimaryExpression = Naive.readIdentifierExpression(state, parser);
             break;
 
-        case Language.TokenKind.LeftParenthesis:
+        case Token.TokenKind.LeftParenthesis:
             maybePrimaryExpression = Naive.readParenthesizedExpression(state, parser);
             break;
 
-        case Language.TokenKind.LeftBracket:
+        case Token.TokenKind.LeftBracket:
             maybePrimaryExpression = Naive.readBracketDisambiguation(state, parser, [
                 BracketDisambiguation.FieldProjection,
                 BracketDisambiguation.FieldSelection,
@@ -265,36 +264,36 @@ function readUnaryExpression(state: IParserState, parser: IParser<IParserState>)
             ]);
             break;
 
-        case Language.TokenKind.LeftBrace:
+        case Token.TokenKind.LeftBrace:
             maybePrimaryExpression = Naive.readListExpression(state, parser);
             break;
 
-        case Language.TokenKind.Ellipsis:
+        case Token.TokenKind.Ellipsis:
             maybePrimaryExpression = Naive.readNotImplementedExpression(state, parser);
             break;
 
         // LiteralExpression
-        case Language.TokenKind.HexLiteral:
-        case Language.TokenKind.KeywordFalse:
-        case Language.TokenKind.KeywordTrue:
-        case Language.TokenKind.NumericLiteral:
-        case Language.TokenKind.NullLiteral:
-        case Language.TokenKind.TextLiteral:
+        case Token.TokenKind.HexLiteral:
+        case Token.TokenKind.KeywordFalse:
+        case Token.TokenKind.KeywordTrue:
+        case Token.TokenKind.NumericLiteral:
+        case Token.TokenKind.NullLiteral:
+        case Token.TokenKind.TextLiteral:
             return Naive.readLiteralExpression(state, parser);
 
         // TypeExpression
-        case Language.TokenKind.KeywordType:
+        case Token.TokenKind.KeywordType:
             return Naive.readTypeExpression(state, parser);
 
-        case Language.TokenKind.KeywordHashSections:
-        case Language.TokenKind.KeywordHashShared:
-        case Language.TokenKind.KeywordHashBinary:
-        case Language.TokenKind.KeywordHashDate:
-        case Language.TokenKind.KeywordHashDateTime:
-        case Language.TokenKind.KeywordHashDateTimeZone:
-        case Language.TokenKind.KeywordHashDuration:
-        case Language.TokenKind.KeywordHashTable:
-        case Language.TokenKind.KeywordHashTime:
+        case Token.TokenKind.KeywordHashSections:
+        case Token.TokenKind.KeywordHashShared:
+        case Token.TokenKind.KeywordHashBinary:
+        case Token.TokenKind.KeywordHashDate:
+        case Token.TokenKind.KeywordHashDateTime:
+        case Token.TokenKind.KeywordHashDateTimeZone:
+        case Token.TokenKind.KeywordHashDuration:
+        case Token.TokenKind.KeywordHashTable:
+        case Token.TokenKind.KeywordHashTime:
             maybePrimaryExpression = parser.readKeyword(state, parser);
             break;
 

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { NodeIdMap, ParseContext, ParseContextUtils, ParseError } from "..";
-import { Language } from "../..";
 import {
     ArrayUtils,
     Assert,
@@ -13,7 +12,7 @@ import {
     StringUtils,
     TypeScriptUtils,
 } from "../../common";
-import { Ast, Constant, ConstantUtils } from "../../language";
+import { Ast, Constant, ConstantUtils, Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 import { BracketDisambiguation, IParser, ParenthesisDisambiguation } from "../IParser";
 import { IParserState, IParserStateUtils } from "../IParserState";
@@ -38,10 +37,10 @@ interface WrappedRead<
     readonly maybeOptionalConstant: Ast.IConstant<Constant.MiscConstantKind.QuestionMark> | undefined;
 }
 
-const GeneralizedIdentifierTerminatorTokenKinds: ReadonlyArray<Language.TokenKind> = [
-    Language.TokenKind.Comma,
-    Language.TokenKind.Equal,
-    Language.TokenKind.RightBracket,
+const GeneralizedIdentifierTerminatorTokenKinds: ReadonlyArray<Token.TokenKind> = [
+    Token.TokenKind.Comma,
+    Token.TokenKind.Equal,
+    Token.TokenKind.RightBracket,
 ];
 
 // ----------------------------------------
@@ -55,7 +54,7 @@ export function readIdentifier<S extends IParserState = IParserState>(
     const nodeKind: Ast.NodeKind.Identifier = Ast.NodeKind.Identifier;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const literal: string = readTokenKind(state, Language.TokenKind.Identifier);
+    const literal: string = readTokenKind(state, Token.TokenKind.Identifier);
 
     const astNode: Ast.Identifier = {
         ...IParserStateUtils.assertContextNodeMetadata(state),
@@ -93,7 +92,7 @@ export function readGeneralizedIdentifier<S extends IParserState = IParserState>
     }
 
     const lexerSnapshot: LexerSnapshot = state.lexerSnapshot;
-    const tokens: ReadonlyArray<Language.Token> = lexerSnapshot.tokens;
+    const tokens: ReadonlyArray<Token.Token> = lexerSnapshot.tokens;
     const contiguousIdentifierStartIndex: number = tokens[tokenRangeStartIndex].positionStart.codeUnit;
     const contiguousIdentifierEndIndex: number = tokens[tokenRangeEndIndex - 1].positionEnd.codeUnit;
     const literal: string = lexerSnapshot.text.slice(contiguousIdentifierStartIndex, contiguousIdentifierEndIndex);
@@ -216,12 +215,12 @@ export function readSectionDocument<S extends IParserState = IParserState>(state
     const maybeLiteralAttributes: Ast.RecordLiteral | undefined = maybeReadLiteralAttributes(state, parser);
     const sectionConstant: Ast.IConstant<Constant.KeywordConstantKind.Section> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.KeywordSection,
+        Token.TokenKind.KeywordSection,
         Constant.KeywordConstantKind.Section,
     );
 
     let maybeName: Ast.Identifier | undefined;
-    if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.Identifier)) {
+    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.Identifier)) {
         maybeName = parser.readIdentifier(state, parser);
     } else {
         IParserStateUtils.incrementAttributeCounter(state);
@@ -229,7 +228,7 @@ export function readSectionDocument<S extends IParserState = IParserState>(state
 
     const semicolonConstant: Ast.IConstant<Constant.MiscConstantKind.Semicolon> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.Semicolon,
+        Token.TokenKind.Semicolon,
         Constant.MiscConstantKind.Semicolon,
     );
     const sectionMembers: Ast.IArrayWrapper<Ast.SectionMember> = parser.readSectionMembers(state, parser);
@@ -285,13 +284,13 @@ export function readSectionMember<S extends IParserState = IParserState>(
         | Ast.IConstant<Constant.KeywordConstantKind.Shared>
         | undefined = maybeReadTokenKindAsConstant(
         state,
-        Language.TokenKind.KeywordShared,
+        Token.TokenKind.KeywordShared,
         Constant.KeywordConstantKind.Shared,
     );
     const namePairedExpression: Ast.IdentifierPairedExpression = parser.readIdentifierPairedExpression(state, parser);
     const semicolonConstant: Ast.IConstant<Constant.MiscConstantKind.Semicolon> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.Semicolon,
+        Token.TokenKind.Semicolon,
         Constant.MiscConstantKind.Semicolon,
     );
 
@@ -332,8 +331,8 @@ export function readNullCoalescingExpression<S extends IParserState = IParserSta
         state,
         Ast.NodeKind.NullCoalescingExpression,
         () => parser.readLogicalExpression(state, parser),
-        (maybeCurrentTokenKind: Language.TokenKind | undefined) =>
-            maybeCurrentTokenKind === Language.TokenKind.NullCoalescingOperator
+        (maybeCurrentTokenKind: Token.TokenKind | undefined) =>
+            maybeCurrentTokenKind === Token.TokenKind.NullCoalescingOperator
                 ? Constant.MiscConstantKind.NullCoalescingOperator
                 : undefined,
         () => parser.readLogicalExpression(state, parser),
@@ -344,22 +343,22 @@ export function readExpression<S extends IParserState = IParserState>(state: S, 
     state.maybeCancellationToken?.throwIfCancelled();
 
     switch (state.maybeCurrentTokenKind) {
-        case Language.TokenKind.KeywordEach:
+        case Token.TokenKind.KeywordEach:
             return parser.readEachExpression(state, parser);
 
-        case Language.TokenKind.KeywordLet:
+        case Token.TokenKind.KeywordLet:
             return parser.readLetExpression(state, parser);
 
-        case Language.TokenKind.KeywordIf:
+        case Token.TokenKind.KeywordIf:
             return parser.readIfExpression(state, parser);
 
-        case Language.TokenKind.KeywordError:
+        case Token.TokenKind.KeywordError:
             return parser.readErrorRaisingExpression(state, parser);
 
-        case Language.TokenKind.KeywordTry:
+        case Token.TokenKind.KeywordTry:
             return parser.readErrorHandlingExpression(state, parser);
 
-        case Language.TokenKind.LeftParenthesis:
+        case Token.TokenKind.LeftParenthesis:
             const triedDisambiguation: Result<
                 ParenthesisDisambiguation,
                 ParseError.UnterminatedParenthesesError
@@ -431,7 +430,7 @@ export function readIsExpression<S extends IParserState = IParserState>(
         Ast.NodeKind.IsExpression,
         () => parser.readAsExpression(state, parser),
         maybeCurrentTokenKind =>
-            maybeCurrentTokenKind === Language.TokenKind.KeywordIs ? Constant.KeywordConstantKind.Is : undefined,
+            maybeCurrentTokenKind === Token.TokenKind.KeywordIs ? Constant.KeywordConstantKind.Is : undefined,
         () => parser.readNullablePrimitiveType(state, parser),
     );
 }
@@ -476,7 +475,7 @@ export function readAsExpression<S extends IParserState = IParserState>(
         Ast.NodeKind.AsExpression,
         () => parser.readEqualityExpression(state, parser),
         maybeCurrentTokenKind =>
-            maybeCurrentTokenKind === Language.TokenKind.KeywordAs ? Constant.KeywordConstantKind.As : undefined,
+            maybeCurrentTokenKind === Token.TokenKind.KeywordAs ? Constant.KeywordConstantKind.As : undefined,
         () => parser.readNullablePrimitiveType(state, parser),
     );
 }
@@ -573,7 +572,7 @@ export function readMetadataExpression<S extends IParserState = IParserState>(
         | Ast.IConstant<Constant.KeywordConstantKind.Meta>
         | undefined = maybeReadTokenKindAsConstant(
         state,
-        Language.TokenKind.KeywordMeta,
+        Token.TokenKind.KeywordMeta,
         Constant.KeywordConstantKind.Meta,
     );
 
@@ -624,7 +623,7 @@ export function readUnaryExpression<S extends IParserState = IParserState>(
     const operatorConstants: Ast.IConstant<Constant.UnaryOperatorKind>[] = [];
     while (maybeOperator) {
         operatorConstants.push(
-            readTokenKindAsConstant(state, state.maybeCurrentTokenKind as Language.TokenKind, maybeOperator),
+            readTokenKindAsConstant(state, state.maybeCurrentTokenKind as Token.TokenKind, maybeOperator),
         );
         maybeOperator = ConstantUtils.maybeUnaryOperatorKindFrom(state.maybeCurrentTokenKind);
     }
@@ -660,19 +659,19 @@ export function readPrimaryExpression<S extends IParserState = IParserState>(
     state.maybeCancellationToken?.throwIfCancelled();
 
     let primaryExpression: Ast.TPrimaryExpression | undefined;
-    const maybeCurrentTokenKind: Language.TokenKind | undefined = state.maybeCurrentTokenKind;
+    const maybeCurrentTokenKind: Token.TokenKind | undefined = state.maybeCurrentTokenKind;
     const isIdentifierExpressionNext: boolean =
-        maybeCurrentTokenKind === Language.TokenKind.AtSign || maybeCurrentTokenKind === Language.TokenKind.Identifier;
+        maybeCurrentTokenKind === Token.TokenKind.AtSign || maybeCurrentTokenKind === Token.TokenKind.Identifier;
 
     if (isIdentifierExpressionNext) {
         primaryExpression = parser.readIdentifierExpression(state, parser);
     } else {
         switch (maybeCurrentTokenKind) {
-            case Language.TokenKind.LeftParenthesis:
+            case Token.TokenKind.LeftParenthesis:
                 primaryExpression = parser.readParenthesizedExpression(state, parser);
                 break;
 
-            case Language.TokenKind.LeftBracket:
+            case Token.TokenKind.LeftBracket:
                 primaryExpression = readBracketDisambiguation(state, parser, [
                     BracketDisambiguation.FieldProjection,
                     BracketDisambiguation.FieldSelection,
@@ -680,23 +679,23 @@ export function readPrimaryExpression<S extends IParserState = IParserState>(
                 ]);
                 break;
 
-            case Language.TokenKind.LeftBrace:
+            case Token.TokenKind.LeftBrace:
                 primaryExpression = parser.readListExpression(state, parser);
                 break;
 
-            case Language.TokenKind.Ellipsis:
+            case Token.TokenKind.Ellipsis:
                 primaryExpression = parser.readNotImplementedExpression(state, parser);
                 break;
 
-            case Language.TokenKind.KeywordHashSections:
-            case Language.TokenKind.KeywordHashShared:
-            case Language.TokenKind.KeywordHashBinary:
-            case Language.TokenKind.KeywordHashDate:
-            case Language.TokenKind.KeywordHashDateTime:
-            case Language.TokenKind.KeywordHashDateTimeZone:
-            case Language.TokenKind.KeywordHashDuration:
-            case Language.TokenKind.KeywordHashTable:
-            case Language.TokenKind.KeywordHashTime:
+            case Token.TokenKind.KeywordHashSections:
+            case Token.TokenKind.KeywordHashShared:
+            case Token.TokenKind.KeywordHashBinary:
+            case Token.TokenKind.KeywordHashDate:
+            case Token.TokenKind.KeywordHashDateTime:
+            case Token.TokenKind.KeywordHashDateTimeZone:
+            case Token.TokenKind.KeywordHashDuration:
+            case Token.TokenKind.KeywordHashTable:
+            case Token.TokenKind.KeywordHashTime:
                 primaryExpression = parser.readKeyword(state, parser);
                 break;
 
@@ -771,13 +770,13 @@ export function readRecursivePrimaryExpression<S extends IParserState = IParserS
     const recursiveExpressions: (Ast.InvokeExpression | Ast.ItemAccessExpression | Ast.TFieldAccessExpression)[] = [];
     let continueReadingValues: boolean = true;
     while (continueReadingValues) {
-        const maybeCurrentTokenKind: Language.TokenKind | undefined = state.maybeCurrentTokenKind;
+        const maybeCurrentTokenKind: Token.TokenKind | undefined = state.maybeCurrentTokenKind;
 
-        if (maybeCurrentTokenKind === Language.TokenKind.LeftParenthesis) {
+        if (maybeCurrentTokenKind === Token.TokenKind.LeftParenthesis) {
             recursiveExpressions.push(parser.readInvokeExpression(state, parser));
-        } else if (maybeCurrentTokenKind === Language.TokenKind.LeftBrace) {
+        } else if (maybeCurrentTokenKind === Token.TokenKind.LeftBrace) {
             recursiveExpressions.push(parser.readItemAccessExpression(state, parser));
-        } else if (maybeCurrentTokenKind === Language.TokenKind.LeftBracket) {
+        } else if (maybeCurrentTokenKind === Token.TokenKind.LeftBracket) {
             const bracketExpression: Ast.TFieldAccessExpression = readBracketDisambiguation(state, parser, [
                 BracketDisambiguation.FieldProjection,
                 BracketDisambiguation.FieldSelection,
@@ -821,15 +820,15 @@ export function readLiteralExpression<S extends IParserState = IParserState>(
     const nodeKind: Ast.NodeKind.LiteralExpression = Ast.NodeKind.LiteralExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const expectedTokenKinds: ReadonlyArray<Language.TokenKind> = [
-        Language.TokenKind.HexLiteral,
-        Language.TokenKind.KeywordFalse,
-        Language.TokenKind.KeywordHashInfinity,
-        Language.TokenKind.KeywordHashNan,
-        Language.TokenKind.KeywordTrue,
-        Language.TokenKind.NumericLiteral,
-        Language.TokenKind.NullLiteral,
-        Language.TokenKind.TextLiteral,
+    const expectedTokenKinds: ReadonlyArray<Token.TokenKind> = [
+        Token.TokenKind.HexLiteral,
+        Token.TokenKind.KeywordFalse,
+        Token.TokenKind.KeywordHashInfinity,
+        Token.TokenKind.KeywordHashNan,
+        Token.TokenKind.KeywordTrue,
+        Token.TokenKind.NumericLiteral,
+        Token.TokenKind.NullLiteral,
+        Token.TokenKind.TextLiteral,
     ];
     const maybeErr: ParseError.ExpectedAnyTokenKindError | undefined = IParserStateUtils.testIsOnAnyTokenKind(
         state,
@@ -876,7 +875,7 @@ export function readIdentifierExpression<S extends IParserState = IParserState>(
 
     const maybeInclusiveConstant:
         | Ast.IConstant<Constant.MiscConstantKind.AtSign>
-        | undefined = maybeReadTokenKindAsConstant(state, Language.TokenKind.AtSign, Constant.MiscConstantKind.AtSign);
+        | undefined = maybeReadTokenKindAsConstant(state, Token.TokenKind.AtSign, Constant.MiscConstantKind.AtSign);
     const identifier: Ast.Identifier = parser.readIdentifier(state, parser);
 
     const astNode: Ast.IdentifierExpression = {
@@ -906,14 +905,14 @@ export function readParenthesizedExpression<S extends IParserState = IParserStat
         () =>
             readTokenKindAsConstant(
                 state,
-                Language.TokenKind.LeftParenthesis,
+                Token.TokenKind.LeftParenthesis,
                 Constant.WrapperConstantKind.LeftParenthesis,
             ),
         () => parser.readExpression(state, parser),
         () =>
             readTokenKindAsConstant(
                 state,
-                Language.TokenKind.RightParenthesis,
+                Token.TokenKind.RightParenthesis,
                 Constant.WrapperConstantKind.RightParenthesis,
             ),
         false,
@@ -934,7 +933,7 @@ export function readNotImplementedExpression<S extends IParserState = IParserSta
 
     const ellipsisConstant: Ast.IConstant<Constant.MiscConstantKind.Ellipsis> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.Ellipsis,
+        Token.TokenKind.Ellipsis,
         Constant.MiscConstantKind.Ellipsis,
     );
 
@@ -958,17 +957,14 @@ export function readInvokeExpression<S extends IParserState = IParserState>(
 ): Ast.InvokeExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(
-        state,
-        Language.TokenKind.RightParenthesis,
-    );
+    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.RightParenthesis);
     return readWrapped(
         state,
         Ast.NodeKind.InvokeExpression,
         () =>
             readTokenKindAsConstant(
                 state,
-                Language.TokenKind.LeftParenthesis,
+                Token.TokenKind.LeftParenthesis,
                 Constant.WrapperConstantKind.LeftParenthesis,
             ),
         () =>
@@ -983,7 +979,7 @@ export function readInvokeExpression<S extends IParserState = IParserState>(
         () =>
             readTokenKindAsConstant(
                 state,
-                Language.TokenKind.RightParenthesis,
+                Token.TokenKind.RightParenthesis,
                 Constant.WrapperConstantKind.RightParenthesis,
             ),
         false,
@@ -1000,11 +996,11 @@ export function readListExpression<S extends IParserState = IParserState>(
 ): Ast.ListExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.RightBrace);
+    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.RightBrace);
     return readWrapped(
         state,
         Ast.NodeKind.ListExpression,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, Token.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
         () =>
             readCsvArray<S, Ast.TListItem>(
                 state,
@@ -1012,7 +1008,7 @@ export function readListExpression<S extends IParserState = IParserState>(
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBrace,
             ),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, Token.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
         false,
     );
 }
@@ -1023,10 +1019,10 @@ export function readListItem<S extends IParserState = IParserState>(state: S, pa
     IParserStateUtils.startContext(state, nodeKind);
 
     const left: Ast.TExpression = parser.readExpression(state, parser);
-    if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.DotDot)) {
+    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.DotDot)) {
         const rangeConstant: Ast.IConstant<Constant.MiscConstantKind.DotDot> = readTokenKindAsConstant(
             state,
-            Language.TokenKind.DotDot,
+            Token.TokenKind.DotDot,
             Constant.MiscConstantKind.DotDot,
         );
         const right: Ast.TExpression = parser.readExpression(state, parser);
@@ -1057,11 +1053,11 @@ export function readRecordExpression<S extends IParserState = IParserState>(
 ): Ast.RecordExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.RightBracket);
+    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.RightBracket);
     return readWrapped(
         state,
         Ast.NodeKind.RecordExpression,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, Token.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
         () =>
             parser.readGeneralizedIdentifierPairedExpressions(
                 state,
@@ -1069,8 +1065,7 @@ export function readRecordExpression<S extends IParserState = IParserState>(
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () =>
-            readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
+        () => readTokenKindAsConstant(state, Token.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
         false,
     );
 }
@@ -1088,9 +1083,9 @@ export function readItemAccessExpression<S extends IParserState = IParserState>(
     return readWrapped(
         state,
         Ast.NodeKind.ItemAccessExpression,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, Token.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
         () => parser.readExpression(state, parser),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, Token.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
         true,
     );
 }
@@ -1116,7 +1111,7 @@ export function readFieldProjection<S extends IParserState = IParserState>(
     return readWrapped(
         state,
         Ast.NodeKind.FieldProjection,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, Token.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
         () =>
             readCsvArray(
                 state,
@@ -1124,8 +1119,7 @@ export function readFieldProjection<S extends IParserState = IParserState>(
                 true,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () =>
-            readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
+        () => readTokenKindAsConstant(state, Token.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
         true,
     );
 }
@@ -1140,10 +1134,9 @@ export function readFieldSelector<S extends IParserState = IParserState>(
     return readWrapped(
         state,
         Ast.NodeKind.FieldSelector,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, Token.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
         () => parser.readGeneralizedIdentifier(state, parser),
-        () =>
-            readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
+        () => readTokenKindAsConstant(state, Token.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
         allowOptional,
     );
 }
@@ -1170,7 +1163,7 @@ export function readFunctionExpression<S extends IParserState = IParserState>(
     );
     const fatArrowConstant: Ast.IConstant<Constant.MiscConstantKind.FatArrow> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.FatArrow,
+        Token.TokenKind.FatArrow,
         Constant.MiscConstantKind.FatArrow,
     );
     const expression: Ast.TExpression = parser.readExpression(state, parser);
@@ -1206,8 +1199,8 @@ function maybeReadAsNullablePrimitiveType<S extends IParserState = IParserState>
     return maybeReadPairedConstant(
         state,
         Ast.NodeKind.AsNullablePrimitiveType,
-        () => IParserStateUtils.isOnTokenKind(state, Language.TokenKind.KeywordAs),
-        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordAs, Constant.KeywordConstantKind.As),
+        () => IParserStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordAs),
+        () => readTokenKindAsConstant(state, Token.TokenKind.KeywordAs, Constant.KeywordConstantKind.As),
         () => parser.readNullablePrimitiveType(state, parser),
     );
 }
@@ -1218,7 +1211,7 @@ export function readAsType<S extends IParserState = IParserState>(state: S, pars
     return readPairedConstant(
         state,
         Ast.NodeKind.AsType,
-        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordAs, Constant.KeywordConstantKind.As),
+        () => readTokenKindAsConstant(state, Token.TokenKind.KeywordAs, Constant.KeywordConstantKind.As),
         () => parser.readType(state, parser),
     );
 }
@@ -1236,7 +1229,7 @@ export function readEachExpression<S extends IParserState = IParserState>(
     return readPairedConstant(
         state,
         Ast.NodeKind.EachExpression,
-        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordEach, Constant.KeywordConstantKind.Each),
+        () => readTokenKindAsConstant(state, Token.TokenKind.KeywordEach, Constant.KeywordConstantKind.Each),
         () => parser.readExpression(state, parser),
     );
 }
@@ -1255,18 +1248,18 @@ export function readLetExpression<S extends IParserState = IParserState>(
 
     const letConstant: Ast.IConstant<Constant.KeywordConstantKind.Let> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.KeywordLet,
+        Token.TokenKind.KeywordLet,
         Constant.KeywordConstantKind.Let,
     );
     const identifierPairedExpression: Ast.ICsvArray<Ast.IdentifierPairedExpression> = parser.readIdentifierPairedExpressions(
         state,
         parser,
-        !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.KeywordIn),
+        !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.KeywordIn),
         IParserStateUtils.testCsvContinuationLetExpression,
     );
     const inConstant: Ast.IConstant<Constant.KeywordConstantKind.In> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.KeywordIn,
+        Token.TokenKind.KeywordIn,
         Constant.KeywordConstantKind.In,
     );
     const expression: Ast.TExpression = parser.readExpression(state, parser);
@@ -1298,21 +1291,21 @@ export function readIfExpression<S extends IParserState = IParserState>(
 
     const ifConstant: Ast.IConstant<Constant.KeywordConstantKind.If> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.KeywordIf,
+        Token.TokenKind.KeywordIf,
         Constant.KeywordConstantKind.If,
     );
     const condition: Ast.TExpression = parser.readExpression(state, parser);
 
     const thenConstant: Ast.IConstant<Constant.KeywordConstantKind.Then> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.KeywordThen,
+        Token.TokenKind.KeywordThen,
         Constant.KeywordConstantKind.Then,
     );
     const trueExpression: Ast.TExpression = parser.readExpression(state, parser);
 
     const elseConstant: Ast.IConstant<Constant.KeywordConstantKind.Else> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.KeywordElse,
+        Token.TokenKind.KeywordElse,
         Constant.KeywordConstantKind.Else,
     );
     const falseExpression: Ast.TExpression = parser.readExpression(state, parser);
@@ -1342,11 +1335,11 @@ export function readTypeExpression<S extends IParserState = IParserState>(
 ): Ast.TTypeExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.KeywordType)) {
+    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordType)) {
         return readPairedConstant(
             state,
             Ast.NodeKind.TypePrimaryType,
-            () => readTokenKindAsConstant(state, Language.TokenKind.KeywordType, Constant.KeywordConstantKind.Type),
+            () => readTokenKindAsConstant(state, Token.TokenKind.KeywordType, Constant.KeywordConstantKind.Type),
             () => parser.readPrimaryType(state, parser),
         );
     } else {
@@ -1407,11 +1400,11 @@ export function readTableType<S extends IParserState = IParserState>(state: S, p
         state,
         Constant.PrimitiveTypeConstantKind.Table,
     );
-    const maybeCurrentTokenKind: Language.TokenKind | undefined = state.maybeCurrentTokenKind;
+    const maybeCurrentTokenKind: Token.TokenKind | undefined = state.maybeCurrentTokenKind;
     const isPrimaryExpressionExpected: boolean =
-        maybeCurrentTokenKind === Language.TokenKind.AtSign ||
-        maybeCurrentTokenKind === Language.TokenKind.Identifier ||
-        maybeCurrentTokenKind === Language.TokenKind.LeftParenthesis;
+        maybeCurrentTokenKind === Token.TokenKind.AtSign ||
+        maybeCurrentTokenKind === Token.TokenKind.Identifier ||
+        maybeCurrentTokenKind === Token.TokenKind.LeftParenthesis;
 
     let rowType: Ast.FieldSpecificationList | Ast.TPrimaryExpression;
     if (isPrimaryExpressionExpected) {
@@ -1443,7 +1436,7 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
 
     const leftBracketConstant: Ast.IConstant<Constant.WrapperConstantKind.LeftBracket> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.LeftBracket,
+        Token.TokenKind.LeftBracket,
         Constant.WrapperConstantKind.LeftBracket,
     );
     const fields: Ast.ICsv<Ast.FieldSpecification>[] = [];
@@ -1459,7 +1452,7 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
             throw maybeErr;
         }
 
-        if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.Ellipsis)) {
+        if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.Ellipsis)) {
             if (allowOpenMarker) {
                 if (isOnOpenRecordMarker) {
                     throw fieldSpecificationListReadError(state, false);
@@ -1502,7 +1495,7 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
                 | Ast.IConstant<Constant.MiscConstantKind.Comma>
                 | undefined = maybeReadTokenKindAsConstant(
                 state,
-                Language.TokenKind.Comma,
+                Token.TokenKind.Comma,
                 Constant.MiscConstantKind.Comma,
             );
             continueReadingValues = maybeCommaConstant !== undefined;
@@ -1533,14 +1526,14 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
     if (isOnOpenRecordMarker) {
         maybeOpenRecordMarkerConstant = readTokenKindAsConstant(
             state,
-            Language.TokenKind.Ellipsis,
+            Token.TokenKind.Ellipsis,
             Constant.MiscConstantKind.Ellipsis,
         );
     }
 
     const rightBracketConstant: Ast.IConstant<Constant.WrapperConstantKind.RightBracket> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.RightBracket,
+        Token.TokenKind.RightBracket,
         Constant.WrapperConstantKind.RightBracket,
     );
 
@@ -1567,7 +1560,7 @@ function maybeReadFieldTypeSpecification<S extends IParserState = IParserState>(
 
     const maybeEqualConstant: Ast.IConstant<Constant.MiscConstantKind.Equal> | undefined = maybeReadTokenKindAsConstant(
         state,
-        Language.TokenKind.Equal,
+        Token.TokenKind.Equal,
         Constant.MiscConstantKind.Equal,
     );
     if (maybeEqualConstant) {
@@ -1591,13 +1584,13 @@ function maybeReadFieldTypeSpecification<S extends IParserState = IParserState>(
 
 function fieldSpecificationListReadError(state: IParserState, allowOpenMarker: boolean): Error | undefined {
     if (allowOpenMarker) {
-        const expectedTokenKinds: ReadonlyArray<Language.TokenKind> = [
-            Language.TokenKind.Identifier,
-            Language.TokenKind.Ellipsis,
+        const expectedTokenKinds: ReadonlyArray<Token.TokenKind> = [
+            Token.TokenKind.Identifier,
+            Token.TokenKind.Ellipsis,
         ];
         return IParserStateUtils.testIsOnAnyTokenKind(state, expectedTokenKinds);
     } else {
-        return IParserStateUtils.testIsOnTokenKind(state, Language.TokenKind.Identifier);
+        return IParserStateUtils.testIsOnTokenKind(state, Token.TokenKind.Identifier);
     }
 }
 
@@ -1607,9 +1600,9 @@ export function readListType<S extends IParserState = IParserState>(state: S, pa
     return readWrapped(
         state,
         Ast.NodeKind.ListType,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, Token.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
         () => parser.readType(state, parser),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, Token.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
         false,
     );
 }
@@ -1644,17 +1637,17 @@ export function readFunctionType<S extends IParserState = IParserState>(
 function tryReadPrimaryType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): TriedReadPrimaryType {
     const isTableTypeNext: boolean =
         IParserStateUtils.isOnConstantKind(state, Constant.PrimitiveTypeConstantKind.Table) &&
-        (IParserStateUtils.isNextTokenKind(state, Language.TokenKind.LeftBracket) ||
-            IParserStateUtils.isNextTokenKind(state, Language.TokenKind.LeftParenthesis) ||
-            IParserStateUtils.isNextTokenKind(state, Language.TokenKind.AtSign) ||
-            IParserStateUtils.isNextTokenKind(state, Language.TokenKind.Identifier));
+        (IParserStateUtils.isNextTokenKind(state, Token.TokenKind.LeftBracket) ||
+            IParserStateUtils.isNextTokenKind(state, Token.TokenKind.LeftParenthesis) ||
+            IParserStateUtils.isNextTokenKind(state, Token.TokenKind.AtSign) ||
+            IParserStateUtils.isNextTokenKind(state, Token.TokenKind.Identifier));
     const isFunctionTypeNext: boolean =
         IParserStateUtils.isOnConstantKind(state, Constant.PrimitiveTypeConstantKind.Function) &&
-        IParserStateUtils.isNextTokenKind(state, Language.TokenKind.LeftParenthesis);
+        IParserStateUtils.isNextTokenKind(state, Token.TokenKind.LeftParenthesis);
 
-    if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.LeftBracket)) {
+    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBracket)) {
         return ResultUtils.okFactory(parser.readRecordType(state, parser));
-    } else if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.LeftBrace)) {
+    } else if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBrace)) {
         return ResultUtils.okFactory(parser.readListType(state, parser));
     } else if (isTableTypeNext) {
         return ResultUtils.okFactory(parser.readTableType(state, parser));
@@ -1709,7 +1702,7 @@ export function readErrorRaisingExpression<S extends IParserState = IParserState
     return readPairedConstant(
         state,
         Ast.NodeKind.ErrorRaisingExpression,
-        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordError, Constant.KeywordConstantKind.Error),
+        () => readTokenKindAsConstant(state, Token.TokenKind.KeywordError, Constant.KeywordConstantKind.Error),
         () => parser.readExpression(state, parser),
     );
 }
@@ -1728,7 +1721,7 @@ export function readErrorHandlingExpression<S extends IParserState = IParserStat
 
     const tryConstant: Ast.IConstant<Constant.KeywordConstantKind.Try> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.KeywordTry,
+        Token.TokenKind.KeywordTry,
         Constant.KeywordConstantKind.Try,
     );
     const protectedExpression: Ast.TExpression = parser.readExpression(state, parser);
@@ -1737,9 +1730,8 @@ export function readErrorHandlingExpression<S extends IParserState = IParserStat
     const maybeOtherwiseExpression: Ast.OtherwiseExpression | undefined = maybeReadPairedConstant(
         state,
         otherwiseExpressionNodeKind,
-        () => IParserStateUtils.isOnTokenKind(state, Language.TokenKind.KeywordOtherwise),
-        () =>
-            readTokenKindAsConstant(state, Language.TokenKind.KeywordOtherwise, Constant.KeywordConstantKind.Otherwise),
+        () => IParserStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordOtherwise),
+        () => readTokenKindAsConstant(state, Token.TokenKind.KeywordOtherwise, Constant.KeywordConstantKind.Otherwise),
         () => parser.readExpression(state, parser),
     );
 
@@ -1765,7 +1757,7 @@ export function readRecordLiteral<S extends IParserState = IParserState>(
 ): Ast.RecordLiteral {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.RightBracket);
+    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.RightBracket);
     const wrappedRead: Ast.IWrapped<
         Ast.NodeKind.RecordLiteral,
         Constant.WrapperConstantKind.LeftBracket,
@@ -1774,7 +1766,7 @@ export function readRecordLiteral<S extends IParserState = IParserState>(
     > = readWrapped(
         state,
         Ast.NodeKind.RecordLiteral,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, Token.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
         () =>
             parser.readFieldNamePairedAnyLiterals(
                 state,
@@ -1782,8 +1774,7 @@ export function readRecordLiteral<S extends IParserState = IParserState>(
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () =>
-            readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
+        () => readTokenKindAsConstant(state, Token.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
         false,
     );
     return {
@@ -1822,7 +1813,7 @@ export function readFieldNamePairedAnyLiterals<S extends IParserState = IParserS
 export function readListLiteral<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.ListLiteral {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.RightBrace);
+    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.RightBrace);
     const wrappedRead: Ast.IWrapped<
         Ast.NodeKind.ListLiteral,
         Constant.WrapperConstantKind.LeftBrace,
@@ -1831,7 +1822,7 @@ export function readListLiteral<S extends IParserState = IParserState>(state: S,
     > = readWrapped(
         state,
         Ast.NodeKind.ListLiteral,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, Token.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
         () =>
             readCsvArray<S, Ast.TAnyLiteral>(
                 state,
@@ -1839,7 +1830,7 @@ export function readListLiteral<S extends IParserState = IParserState>(state: S,
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBrace,
             ),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, Token.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
         false,
     );
     return {
@@ -1851,9 +1842,9 @@ export function readListLiteral<S extends IParserState = IParserState>(state: S,
 export function readAnyLiteral<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TAnyLiteral {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.LeftBracket)) {
+    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBracket)) {
         return parser.readRecordLiteral(state, parser);
-    } else if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.LeftBrace)) {
+    } else if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBrace)) {
         return parser.readListLiteral(state, parser);
     } else {
         return parser.readLiteralExpression(state, parser);
@@ -1882,10 +1873,10 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
     IParserStateUtils.startContext(state, nodeKind);
 
     const stateBackup: IParserStateUtils.FastStateBackup = IParserStateUtils.fastStateBackup(state);
-    const expectedTokenKinds: ReadonlyArray<Language.TokenKind> = [
-        Language.TokenKind.Identifier,
-        Language.TokenKind.KeywordType,
-        Language.TokenKind.NullLiteral,
+    const expectedTokenKinds: ReadonlyArray<Token.TokenKind> = [
+        Token.TokenKind.Identifier,
+        Token.TokenKind.KeywordType,
+        Token.TokenKind.NullLiteral,
     ];
     const maybeErr: ParseError.ExpectedAnyTokenKindError | undefined = IParserStateUtils.testIsOnAnyTokenKind(
         state,
@@ -1897,7 +1888,7 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
     }
 
     let primitiveType: Ast.IConstant<Constant.PrimitiveTypeConstantKind>;
-    if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.Identifier)) {
+    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.Identifier)) {
         const currentTokenData: string = state.lexerSnapshot.tokens[state.tokenIndex].data;
         switch (currentTokenData) {
             case Constant.PrimitiveTypeConstantKind.Action:
@@ -1921,7 +1912,7 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
                 break;
 
             default:
-                const token: Language.Token = IParserStateUtils.assertTokenAt(state, state.tokenIndex);
+                const token: Token.Token = IParserStateUtils.assertTokenAt(state, state.tokenIndex);
                 IParserStateUtils.applyFastStateBackup(state, stateBackup);
                 return ResultUtils.errFactory(
                     new ParseError.InvalidPrimitiveTypeError(
@@ -1931,16 +1922,16 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
                     ),
                 );
         }
-    } else if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.KeywordType)) {
+    } else if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordType)) {
         primitiveType = readTokenKindAsConstant(
             state,
-            Language.TokenKind.KeywordType,
+            Token.TokenKind.KeywordType,
             Constant.PrimitiveTypeConstantKind.Type,
         );
-    } else if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.NullLiteral)) {
+    } else if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.NullLiteral)) {
         primitiveType = readTokenKindAsConstant(
             state,
-            Language.TokenKind.NullLiteral,
+            Token.TokenKind.NullLiteral,
             Constant.PrimitiveTypeConstantKind.Null,
         );
     } else {
@@ -1972,24 +1963,24 @@ export function disambiguateParenthesis<S extends IParserState = IParserState>(
     state.maybeCancellationToken?.throwIfCancelled();
 
     const initialTokenIndex: number = state.tokenIndex;
-    const tokens: ReadonlyArray<Language.Token> = state.lexerSnapshot.tokens;
+    const tokens: ReadonlyArray<Token.Token> = state.lexerSnapshot.tokens;
     const totalTokens: number = tokens.length;
     let nestedDepth: number = 1;
     let offsetTokenIndex: number = initialTokenIndex + 1;
 
     while (offsetTokenIndex < totalTokens) {
-        const offsetTokenKind: Language.TokenKind = tokens[offsetTokenIndex].kind;
+        const offsetTokenKind: Token.TokenKind = tokens[offsetTokenIndex].kind;
 
-        if (offsetTokenKind === Language.TokenKind.LeftParenthesis) {
+        if (offsetTokenKind === Token.TokenKind.LeftParenthesis) {
             nestedDepth += 1;
-        } else if (offsetTokenKind === Language.TokenKind.RightParenthesis) {
+        } else if (offsetTokenKind === Token.TokenKind.RightParenthesis) {
             nestedDepth -= 1;
         }
 
         if (nestedDepth === 0) {
             // '(x as number) as number' could either be either case,
             // so we need to consume test if the trailing 'as number' is followed by a FatArrow.
-            if (IParserStateUtils.isTokenKind(state, Language.TokenKind.KeywordAs, offsetTokenIndex + 1)) {
+            if (IParserStateUtils.isTokenKind(state, Token.TokenKind.KeywordAs, offsetTokenIndex + 1)) {
                 const stateBackup: IParserStateUtils.FastStateBackup = IParserStateUtils.fastStateBackup(state);
                 unsafeMoveTo(state, offsetTokenIndex + 2);
 
@@ -1997,7 +1988,7 @@ export function disambiguateParenthesis<S extends IParserState = IParserState>(
                     parser.readNullablePrimitiveType(state, parser);
                 } catch {
                     IParserStateUtils.applyFastStateBackup(state, stateBackup);
-                    if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.FatArrow)) {
+                    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.FatArrow)) {
                         return ResultUtils.okFactory(ParenthesisDisambiguation.FunctionExpression);
                     } else {
                         return ResultUtils.okFactory(ParenthesisDisambiguation.ParenthesizedExpression);
@@ -2005,7 +1996,7 @@ export function disambiguateParenthesis<S extends IParserState = IParserState>(
                 }
 
                 let disambiguation: ParenthesisDisambiguation;
-                if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.FatArrow)) {
+                if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.FatArrow)) {
                     disambiguation = ParenthesisDisambiguation.FunctionExpression;
                 } else {
                     disambiguation = ParenthesisDisambiguation.ParenthesizedExpression;
@@ -2014,7 +2005,7 @@ export function disambiguateParenthesis<S extends IParserState = IParserState>(
                 IParserStateUtils.applyFastStateBackup(state, stateBackup);
                 return ResultUtils.okFactory(disambiguation);
             } else {
-                if (IParserStateUtils.isTokenKind(state, Language.TokenKind.FatArrow, offsetTokenIndex + 1)) {
+                if (IParserStateUtils.isTokenKind(state, Token.TokenKind.FatArrow, offsetTokenIndex + 1)) {
                     return ResultUtils.okFactory(ParenthesisDisambiguation.FunctionExpression);
                 } else {
                     return ResultUtils.okFactory(ParenthesisDisambiguation.ParenthesizedExpression);
@@ -2032,7 +2023,7 @@ export function disambiguateParenthesis<S extends IParserState = IParserState>(
 //          Manual management of TokenRangeStack is assumed.
 //          Best used in conjunction with backup/restore using ParserState.
 function unsafeMoveTo(state: IParserState, tokenIndex: number): void {
-    const tokens: ReadonlyArray<Language.Token> = state.lexerSnapshot.tokens;
+    const tokens: ReadonlyArray<Token.Token> = state.lexerSnapshot.tokens;
     state.tokenIndex = tokenIndex;
 
     if (tokenIndex < tokens.length) {
@@ -2050,18 +2041,18 @@ export function disambiguateBracket<S extends IParserState = IParserState>(
 ): Result<BracketDisambiguation, ParseError.UnterminatedBracketError> {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const tokens: ReadonlyArray<Language.Token> = state.lexerSnapshot.tokens;
+    const tokens: ReadonlyArray<Token.Token> = state.lexerSnapshot.tokens;
     let offsetTokenIndex: number = state.tokenIndex + 1;
-    const offsetToken: Language.Token = tokens[offsetTokenIndex];
+    const offsetToken: Token.Token = tokens[offsetTokenIndex];
 
     if (!offsetToken) {
         return ResultUtils.errFactory(IParserStateUtils.unterminatedBracketError(state));
     }
 
-    let offsetTokenKind: Language.TokenKind = offsetToken.kind;
-    if (offsetTokenKind === Language.TokenKind.LeftBracket) {
+    let offsetTokenKind: Token.TokenKind = offsetToken.kind;
+    if (offsetTokenKind === Token.TokenKind.LeftBracket) {
         return ResultUtils.okFactory(BracketDisambiguation.FieldProjection);
-    } else if (offsetTokenKind === Language.TokenKind.RightBracket) {
+    } else if (offsetTokenKind === Token.TokenKind.RightBracket) {
         return ResultUtils.okFactory(BracketDisambiguation.Record);
     } else {
         const totalTokens: number = tokens.length;
@@ -2069,9 +2060,9 @@ export function disambiguateBracket<S extends IParserState = IParserState>(
         while (offsetTokenIndex < totalTokens) {
             offsetTokenKind = tokens[offsetTokenIndex].kind;
 
-            if (offsetTokenKind === Language.TokenKind.Equal) {
+            if (offsetTokenKind === Token.TokenKind.Equal) {
                 return ResultUtils.okFactory(BracketDisambiguation.Record);
-            } else if (offsetTokenKind === Language.TokenKind.RightBracket) {
+            } else if (offsetTokenKind === Token.TokenKind.RightBracket) {
                 return ResultUtils.okFactory(BracketDisambiguation.FieldSelection);
             }
 
@@ -2170,7 +2161,7 @@ function recursiveReadBinOpExpression<
     state: S,
     nodeKind: Kind,
     leftReader: () => Left,
-    maybeOperatorFrom: (tokenKind: Language.TokenKind | undefined) => Op | undefined,
+    maybeOperatorFrom: (tokenKind: Token.TokenKind | undefined) => Op | undefined,
     rightReader: () => Right,
 ): Left | Ast.IBinOpExpression<Kind, Left, Op, Right> {
     IParserStateUtils.startContext(state, nodeKind);
@@ -2218,7 +2209,7 @@ function recursiveReadBinOpExpressionHelper<
 >(
     state: S,
     nodeKind: Kind,
-    maybeOperatorFrom: (tokenKind: Language.TokenKind | undefined) => OperatorKind | undefined,
+    maybeOperatorFrom: (tokenKind: Token.TokenKind | undefined) => OperatorKind | undefined,
     rightReader: () => Right,
 ): Right | Ast.IBinOpExpression<Kind, Right, OperatorKind, Right> {
     IParserStateUtils.startContext(state, nodeKind);
@@ -2277,11 +2268,7 @@ function readCsvArray<S extends IParserState, T extends Ast.TCsvType>(
         const node: T = valueReader();
         const maybeCommaConstant:
             | Ast.IConstant<Constant.MiscConstantKind.Comma>
-            | undefined = maybeReadTokenKindAsConstant(
-            state,
-            Language.TokenKind.Comma,
-            Constant.MiscConstantKind.Comma,
-        );
+            | undefined = maybeReadTokenKindAsConstant(state, Token.TokenKind.Comma, Constant.MiscConstantKind.Comma);
 
         const element: Ast.TCsv & Ast.ICsv<T> = {
             ...IParserStateUtils.assertContextNodeMetadata(state),
@@ -2317,7 +2304,7 @@ function readKeyValuePair<S extends IParserState, Kind extends Ast.TKeyValuePair
     const key: Key = keyReader();
     const equalConstant: Ast.IConstant<Constant.MiscConstantKind.Equal> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.Equal,
+        Token.TokenKind.Equal,
         Constant.MiscConstantKind.Equal,
     );
     const value: Value = valueReader();
@@ -2393,10 +2380,10 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
 
     const leftParenthesisConstant: Ast.IConstant<Constant.WrapperConstantKind.LeftParenthesis> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.LeftParenthesis,
+        Token.TokenKind.LeftParenthesis,
         Constant.WrapperConstantKind.LeftParenthesis,
     );
-    let continueReadingValues: boolean = !IParserStateUtils.isOnTokenKind(state, Language.TokenKind.RightParenthesis);
+    let continueReadingValues: boolean = !IParserStateUtils.isOnTokenKind(state, Token.TokenKind.RightParenthesis);
     let reachedOptionalParameter: boolean = false;
 
     const paramterArrayNodeKind: Ast.NodeKind.ArrayWrapper = Ast.NodeKind.ArrayWrapper;
@@ -2417,7 +2404,7 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
             | undefined = maybeReadConstantKind(state, Constant.IdentifierConstantKind.Optional);
 
         if (reachedOptionalParameter && !maybeOptionalConstant) {
-            const token: Language.Token = IParserStateUtils.assertTokenAt(state, state.tokenIndex);
+            const token: Token.Token = IParserStateUtils.assertTokenAt(state, state.tokenIndex);
             throw new ParseError.RequiredParameterAfterOptionalParameterError(
                 state.localizationTemplates,
                 token,
@@ -2442,11 +2429,7 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
 
         const maybeCommaConstant:
             | Ast.IConstant<Constant.MiscConstantKind.Comma>
-            | undefined = maybeReadTokenKindAsConstant(
-            state,
-            Language.TokenKind.Comma,
-            Constant.MiscConstantKind.Comma,
-        );
+            | undefined = maybeReadTokenKindAsConstant(state, Token.TokenKind.Comma, Constant.MiscConstantKind.Comma);
         continueReadingValues = maybeCommaConstant !== undefined;
 
         const csv: Ast.ICsv<Ast.IParameter<T>> = {
@@ -2471,7 +2454,7 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
 
     const rightParenthesisConstant: Ast.IConstant<Constant.WrapperConstantKind.RightParenthesis> = readTokenKindAsConstant(
         state,
-        Language.TokenKind.RightParenthesis,
+        Token.TokenKind.RightParenthesis,
         Constant.WrapperConstantKind.RightParenthesis,
     );
 
@@ -2511,7 +2494,7 @@ function readWrapped<
     if (allowOptionalConstant) {
         maybeOptionalConstant = maybeReadTokenKindAsConstant(
             state,
-            Language.TokenKind.QuestionMark,
+            Token.TokenKind.QuestionMark,
             Constant.MiscConstantKind.QuestionMark,
         );
     }
@@ -2536,7 +2519,7 @@ function readWrapped<
 export function readToken<S extends IParserState = IParserState>(state: S): string {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const tokens: ReadonlyArray<Language.Token> = state.lexerSnapshot.tokens;
+    const tokens: ReadonlyArray<Token.Token> = state.lexerSnapshot.tokens;
     Assert.isFalse(state.tokenIndex >= tokens.length, `index is beyond tokens.length`, {
         tokenIndex: state.tokenIndex,
         tokensLength: tokens.length,
@@ -2557,7 +2540,7 @@ export function readToken<S extends IParserState = IParserState>(state: S): stri
 
 export function readTokenKindAsConstant<S extends IParserState, ConstantKind extends Constant.TConstantKind>(
     state: S,
-    tokenKind: Language.TokenKind,
+    tokenKind: Token.TokenKind,
     constantKind: ConstantKind,
 ): Ast.TConstant & Ast.IConstant<ConstantKind> {
     state.maybeCancellationToken?.throwIfCancelled();
@@ -2587,7 +2570,7 @@ export function readTokenKindAsConstant<S extends IParserState, ConstantKind ext
 
 export function maybeReadTokenKindAsConstant<S extends IParserState, ConstantKind extends Constant.TConstantKind>(
     state: S,
-    tokenKind: Language.TokenKind,
+    tokenKind: Token.TokenKind,
     constantKind: ConstantKind,
 ): (Ast.TConstant & Ast.IConstant<ConstantKind>) | undefined {
     state.maybeCancellationToken?.throwIfCancelled();
@@ -2617,7 +2600,7 @@ export function maybeReadTokenKindAsConstant<S extends IParserState, ConstantKin
     }
 }
 
-function readTokenKind(state: IParserState, tokenKind: Language.TokenKind): string {
+function readTokenKind(state: IParserState, tokenKind: Token.TokenKind): string {
     const maybeErr: ParseError.ExpectedTokenKindError | undefined = IParserStateUtils.testIsOnTokenKind(
         state,
         tokenKind,
@@ -2669,7 +2652,7 @@ function maybeReadLiteralAttributes<S extends IParserState = IParserState>(
     state: S,
     parser: IParser<S>,
 ): Ast.RecordLiteral | undefined {
-    if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.LeftBracket)) {
+    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBracket)) {
         return parser.readRecordLiteral(state, parser);
     } else {
         IParserStateUtils.incrementAttributeCounter(state);
@@ -2720,17 +2703,17 @@ export function readBracketDisambiguation<S extends IParserState = IParserState>
 function testCsvContinuationDanglingCommaForBrace<S extends IParserState = IParserState>(
     state: S,
 ): ParseError.ExpectedCsvContinuationError | undefined {
-    return IParserStateUtils.testCsvContinuationDanglingComma(state, Language.TokenKind.RightBrace);
+    return IParserStateUtils.testCsvContinuationDanglingComma(state, Token.TokenKind.RightBrace);
 }
 
 function testCsvContinuationDanglingCommaForBracket<S extends IParserState = IParserState>(
     state: S,
 ): ParseError.ExpectedCsvContinuationError | undefined {
-    return IParserStateUtils.testCsvContinuationDanglingComma(state, Language.TokenKind.RightBracket);
+    return IParserStateUtils.testCsvContinuationDanglingComma(state, Token.TokenKind.RightBracket);
 }
 
 function testCsvContinuationDanglingCommaForParenthesis<S extends IParserState = IParserState>(
     state: S,
 ): ParseError.ExpectedCsvContinuationError | undefined {
-    return IParserStateUtils.testCsvContinuationDanglingComma(state, Language.TokenKind.RightParenthesis);
+    return IParserStateUtils.testCsvContinuationDanglingComma(state, Token.TokenKind.RightParenthesis);
 }

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -13,7 +13,7 @@ import {
     StringUtils,
     TypeScriptUtils,
 } from "../../common";
-import { Ast, AstUtils } from "../../language";
+import { Ast, Constant, ConstantUtils } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 import { BracketDisambiguation, IParser, ParenthesisDisambiguation } from "../IParser";
 import { IParserState, IParserStateUtils } from "../IParserState";
@@ -31,11 +31,11 @@ type TriedReadPrimitiveType = Result<
 
 interface WrappedRead<
     Kind extends Ast.TWrappedNodeKind,
-    Open extends Ast.WrapperConstantKind,
+    Open extends Constant.WrapperConstantKind,
     Content,
-    Close extends Ast.WrapperConstantKind
+    Close extends Constant.WrapperConstantKind
 > extends Ast.IWrapped<Kind, Open, Content, Close> {
-    readonly maybeOptionalConstant: Ast.IConstant<Ast.MiscConstantKind.QuestionMark> | undefined;
+    readonly maybeOptionalConstant: Ast.IConstant<Constant.MiscConstantKind.QuestionMark> | undefined;
 }
 
 const GeneralizedIdentifierTerminatorTokenKinds: ReadonlyArray<Language.TokenKind> = [
@@ -214,10 +214,10 @@ export function readSectionDocument<S extends IParserState = IParserState>(state
     IParserStateUtils.startContext(state, nodeKind);
 
     const maybeLiteralAttributes: Ast.RecordLiteral | undefined = maybeReadLiteralAttributes(state, parser);
-    const sectionConstant: Ast.IConstant<Ast.KeywordConstantKind.Section> = readTokenKindAsConstant(
+    const sectionConstant: Ast.IConstant<Constant.KeywordConstantKind.Section> = readTokenKindAsConstant(
         state,
         Language.TokenKind.KeywordSection,
-        Ast.KeywordConstantKind.Section,
+        Constant.KeywordConstantKind.Section,
     );
 
     let maybeName: Ast.Identifier | undefined;
@@ -227,10 +227,10 @@ export function readSectionDocument<S extends IParserState = IParserState>(state
         IParserStateUtils.incrementAttributeCounter(state);
     }
 
-    const semicolonConstant: Ast.IConstant<Ast.MiscConstantKind.Semicolon> = readTokenKindAsConstant(
+    const semicolonConstant: Ast.IConstant<Constant.MiscConstantKind.Semicolon> = readTokenKindAsConstant(
         state,
         Language.TokenKind.Semicolon,
-        Ast.MiscConstantKind.Semicolon,
+        Constant.MiscConstantKind.Semicolon,
     );
     const sectionMembers: Ast.IArrayWrapper<Ast.SectionMember> = parser.readSectionMembers(state, parser);
 
@@ -281,16 +281,18 @@ export function readSectionMember<S extends IParserState = IParserState>(
     IParserStateUtils.startContext(state, nodeKind);
 
     const maybeLiteralAttributes: Ast.RecordLiteral | undefined = maybeReadLiteralAttributes(state, parser);
-    const maybeSharedConstant: Ast.IConstant<Ast.KeywordConstantKind.Shared> | undefined = maybeReadTokenKindAsConstant(
+    const maybeSharedConstant:
+        | Ast.IConstant<Constant.KeywordConstantKind.Shared>
+        | undefined = maybeReadTokenKindAsConstant(
         state,
         Language.TokenKind.KeywordShared,
-        Ast.KeywordConstantKind.Shared,
+        Constant.KeywordConstantKind.Shared,
     );
     const namePairedExpression: Ast.IdentifierPairedExpression = parser.readIdentifierPairedExpression(state, parser);
-    const semicolonConstant: Ast.IConstant<Ast.MiscConstantKind.Semicolon> = readTokenKindAsConstant(
+    const semicolonConstant: Ast.IConstant<Constant.MiscConstantKind.Semicolon> = readTokenKindAsConstant(
         state,
         Language.TokenKind.Semicolon,
-        Ast.MiscConstantKind.Semicolon,
+        Constant.MiscConstantKind.Semicolon,
     );
 
     const astNode: Ast.SectionMember = {
@@ -324,7 +326,7 @@ export function readNullCoalescingExpression<S extends IParserState = IParserSta
         S,
         Ast.NodeKind.NullCoalescingExpression,
         Ast.TLogicalExpression,
-        Ast.MiscConstantKind.NullCoalescingOperator,
+        Constant.MiscConstantKind.NullCoalescingOperator,
         Ast.TLogicalExpression
     >(
         state,
@@ -332,7 +334,7 @@ export function readNullCoalescingExpression<S extends IParserState = IParserSta
         () => parser.readLogicalExpression(state, parser),
         (maybeCurrentTokenKind: Language.TokenKind | undefined) =>
             maybeCurrentTokenKind === Language.TokenKind.NullCoalescingOperator
-                ? Ast.MiscConstantKind.NullCoalescingOperator
+                ? Constant.MiscConstantKind.NullCoalescingOperator
                 : undefined,
         () => parser.readLogicalExpression(state, parser),
     );
@@ -397,13 +399,13 @@ export function readLogicalExpression<S extends IParserState = IParserState>(
         S,
         Ast.NodeKind.LogicalExpression,
         Ast.TLogicalExpression,
-        Ast.LogicalOperatorKind,
+        Constant.LogicalOperatorKind,
         Ast.TLogicalExpression
     >(
         state,
         Ast.NodeKind.LogicalExpression,
         () => parser.readIsExpression(state, parser),
-        maybeCurrentTokenKind => AstUtils.maybeLogicalOperatorKindFrom(maybeCurrentTokenKind),
+        maybeCurrentTokenKind => ConstantUtils.maybeLogicalOperatorKindFrom(maybeCurrentTokenKind),
         () => parser.readIsExpression(state, parser),
     );
 }
@@ -422,14 +424,14 @@ export function readIsExpression<S extends IParserState = IParserState>(
         S,
         Ast.NodeKind.IsExpression,
         Ast.TAsExpression,
-        Ast.KeywordConstantKind.Is,
+        Constant.KeywordConstantKind.Is,
         Ast.TNullablePrimitiveType
     >(
         state,
         Ast.NodeKind.IsExpression,
         () => parser.readAsExpression(state, parser),
         maybeCurrentTokenKind =>
-            maybeCurrentTokenKind === Language.TokenKind.KeywordIs ? Ast.KeywordConstantKind.Is : undefined,
+            maybeCurrentTokenKind === Language.TokenKind.KeywordIs ? Constant.KeywordConstantKind.Is : undefined,
         () => parser.readNullablePrimitiveType(state, parser),
     );
 }
@@ -441,11 +443,11 @@ export function readNullablePrimitiveType<S extends IParserState = IParserState>
 ): Ast.TNullablePrimitiveType {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    if (IParserStateUtils.isOnConstantKind(state, Ast.IdentifierConstantKind.Nullable)) {
+    if (IParserStateUtils.isOnConstantKind(state, Constant.IdentifierConstantKind.Nullable)) {
         return readPairedConstant(
             state,
             Ast.NodeKind.NullablePrimitiveType,
-            () => readConstantKind(state, Ast.IdentifierConstantKind.Nullable),
+            () => readConstantKind(state, Constant.IdentifierConstantKind.Nullable),
             () => parser.readPrimitiveType(state, parser),
         );
     } else {
@@ -467,14 +469,14 @@ export function readAsExpression<S extends IParserState = IParserState>(
         S,
         Ast.NodeKind.AsExpression,
         Ast.TEqualityExpression,
-        Ast.KeywordConstantKind.As,
+        Constant.KeywordConstantKind.As,
         Ast.TNullablePrimitiveType
     >(
         state,
         Ast.NodeKind.AsExpression,
         () => parser.readEqualityExpression(state, parser),
         maybeCurrentTokenKind =>
-            maybeCurrentTokenKind === Language.TokenKind.KeywordAs ? Ast.KeywordConstantKind.As : undefined,
+            maybeCurrentTokenKind === Language.TokenKind.KeywordAs ? Constant.KeywordConstantKind.As : undefined,
         () => parser.readNullablePrimitiveType(state, parser),
     );
 }
@@ -493,13 +495,13 @@ export function readEqualityExpression<S extends IParserState = IParserState>(
         S,
         Ast.NodeKind.EqualityExpression,
         Ast.TEqualityExpression,
-        Ast.EqualityOperatorKind,
+        Constant.EqualityOperatorKind,
         Ast.TEqualityExpression
     >(
         state,
         Ast.NodeKind.EqualityExpression,
         () => parser.readRelationalExpression(state, parser),
-        maybeCurrentTokenKind => AstUtils.maybeEqualityOperatorKindFrom(maybeCurrentTokenKind),
+        maybeCurrentTokenKind => ConstantUtils.maybeEqualityOperatorKindFrom(maybeCurrentTokenKind),
         () => parser.readRelationalExpression(state, parser),
     );
 }
@@ -518,13 +520,13 @@ export function readRelationalExpression<S extends IParserState = IParserState>(
         S,
         Ast.NodeKind.RelationalExpression,
         Ast.TArithmeticExpression,
-        Ast.RelationalOperatorKind,
+        Constant.RelationalOperatorKind,
         Ast.TArithmeticExpression
     >(
         state,
         Ast.NodeKind.RelationalExpression,
         () => parser.readArithmeticExpression(state, parser),
-        maybeCurrentTokenKind => AstUtils.maybeRelationalOperatorKindFrom(maybeCurrentTokenKind),
+        maybeCurrentTokenKind => ConstantUtils.maybeRelationalOperatorKindFrom(maybeCurrentTokenKind),
         () => parser.readArithmeticExpression(state, parser),
     );
 }
@@ -543,13 +545,13 @@ export function readArithmeticExpression<S extends IParserState = IParserState>(
         S,
         Ast.NodeKind.ArithmeticExpression,
         Ast.TMetadataExpression,
-        Ast.ArithmeticOperatorKind,
+        Constant.ArithmeticOperatorKind,
         Ast.TMetadataExpression
     >(
         state,
         Ast.NodeKind.ArithmeticExpression,
         () => parser.readMetadataExpression(state, parser),
-        maybeCurrentTokenKind => AstUtils.maybeArithmeticOperatorKindFrom(maybeCurrentTokenKind),
+        maybeCurrentTokenKind => ConstantUtils.maybeArithmeticOperatorKindFrom(maybeCurrentTokenKind),
         () => parser.readMetadataExpression(state, parser),
     );
 }
@@ -567,14 +569,16 @@ export function readMetadataExpression<S extends IParserState = IParserState>(
     IParserStateUtils.startContext(state, nodeKind);
 
     const left: Ast.TUnaryExpression = parser.readUnaryExpression(state, parser);
-    const maybeMetaConstant: Ast.IConstant<Ast.KeywordConstantKind.Meta> | undefined = maybeReadTokenKindAsConstant(
+    const maybeMetaConstant:
+        | Ast.IConstant<Constant.KeywordConstantKind.Meta>
+        | undefined = maybeReadTokenKindAsConstant(
         state,
         Language.TokenKind.KeywordMeta,
-        Ast.KeywordConstantKind.Meta,
+        Constant.KeywordConstantKind.Meta,
     );
 
     if (maybeMetaConstant !== undefined) {
-        const operatorConstant: Ast.IConstant<Ast.KeywordConstantKind.Meta> = maybeMetaConstant;
+        const operatorConstant: Ast.IConstant<Constant.KeywordConstantKind.Meta> = maybeMetaConstant;
         const right: Ast.TUnaryExpression = parser.readUnaryExpression(state, parser);
 
         const astNode: Ast.MetadataExpression = {
@@ -604,7 +608,7 @@ export function readUnaryExpression<S extends IParserState = IParserState>(
 ): Ast.TUnaryExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    let maybeOperator: Ast.UnaryOperatorKind | undefined = AstUtils.maybeUnaryOperatorKindFrom(
+    let maybeOperator: Constant.UnaryOperatorKind | undefined = ConstantUtils.maybeUnaryOperatorKindFrom(
         state.maybeCurrentTokenKind,
     );
     if (maybeOperator === undefined) {
@@ -617,14 +621,14 @@ export function readUnaryExpression<S extends IParserState = IParserState>(
     const arrayNodeKind: Ast.NodeKind.ArrayWrapper = Ast.NodeKind.ArrayWrapper;
     IParserStateUtils.startContext(state, arrayNodeKind);
 
-    const operatorConstants: Ast.IConstant<Ast.UnaryOperatorKind>[] = [];
+    const operatorConstants: Ast.IConstant<Constant.UnaryOperatorKind>[] = [];
     while (maybeOperator) {
         operatorConstants.push(
             readTokenKindAsConstant(state, state.maybeCurrentTokenKind as Language.TokenKind, maybeOperator),
         );
-        maybeOperator = AstUtils.maybeUnaryOperatorKindFrom(state.maybeCurrentTokenKind);
+        maybeOperator = ConstantUtils.maybeUnaryOperatorKindFrom(state.maybeCurrentTokenKind);
     }
-    const operators: Ast.IArrayWrapper<Ast.IConstant<Ast.UnaryOperatorKind>> = {
+    const operators: Ast.IArrayWrapper<Ast.IConstant<Constant.UnaryOperatorKind>> = {
         ...IParserStateUtils.assertContextNodeMetadata(state),
         kind: arrayNodeKind,
         isLeaf: false,
@@ -836,11 +840,11 @@ export function readLiteralExpression<S extends IParserState = IParserState>(
     }
 
     const maybeLiteralKind:
-        | Ast.LiteralKind.Numeric
-        | Ast.LiteralKind.Logical
-        | Ast.LiteralKind.Null
-        | Ast.LiteralKind.Text
-        | undefined = AstUtils.maybeLiteralKindFrom(state.maybeCurrentTokenKind);
+        | Constant.LiteralKind.Numeric
+        | Constant.LiteralKind.Logical
+        | Constant.LiteralKind.Null
+        | Constant.LiteralKind.Text
+        | undefined = ConstantUtils.maybeLiteralKindFrom(state.maybeCurrentTokenKind);
 
     Assert.isDefined(maybeLiteralKind, `couldn't convert TokenKind into LiteralKind`, {
         maybeCurrentTokenKind: state.maybeCurrentTokenKind,
@@ -870,11 +874,9 @@ export function readIdentifierExpression<S extends IParserState = IParserState>(
     const nodeKind: Ast.NodeKind.IdentifierExpression = Ast.NodeKind.IdentifierExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const maybeInclusiveConstant: Ast.IConstant<Ast.MiscConstantKind.AtSign> | undefined = maybeReadTokenKindAsConstant(
-        state,
-        Language.TokenKind.AtSign,
-        Ast.MiscConstantKind.AtSign,
-    );
+    const maybeInclusiveConstant:
+        | Ast.IConstant<Constant.MiscConstantKind.AtSign>
+        | undefined = maybeReadTokenKindAsConstant(state, Language.TokenKind.AtSign, Constant.MiscConstantKind.AtSign);
     const identifier: Ast.Identifier = parser.readIdentifier(state, parser);
 
     const astNode: Ast.IdentifierExpression = {
@@ -902,13 +904,17 @@ export function readParenthesizedExpression<S extends IParserState = IParserStat
         state,
         Ast.NodeKind.ParenthesizedExpression,
         () =>
-            readTokenKindAsConstant(state, Language.TokenKind.LeftParenthesis, Ast.WrapperConstantKind.LeftParenthesis),
+            readTokenKindAsConstant(
+                state,
+                Language.TokenKind.LeftParenthesis,
+                Constant.WrapperConstantKind.LeftParenthesis,
+            ),
         () => parser.readExpression(state, parser),
         () =>
             readTokenKindAsConstant(
                 state,
                 Language.TokenKind.RightParenthesis,
-                Ast.WrapperConstantKind.RightParenthesis,
+                Constant.WrapperConstantKind.RightParenthesis,
             ),
         false,
     );
@@ -926,10 +932,10 @@ export function readNotImplementedExpression<S extends IParserState = IParserSta
     const nodeKind: Ast.NodeKind.NotImplementedExpression = Ast.NodeKind.NotImplementedExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const ellipsisConstant: Ast.IConstant<Ast.MiscConstantKind.Ellipsis> = readTokenKindAsConstant(
+    const ellipsisConstant: Ast.IConstant<Constant.MiscConstantKind.Ellipsis> = readTokenKindAsConstant(
         state,
         Language.TokenKind.Ellipsis,
-        Ast.MiscConstantKind.Ellipsis,
+        Constant.MiscConstantKind.Ellipsis,
     );
 
     const astNode: Ast.NotImplementedExpression = {
@@ -960,7 +966,11 @@ export function readInvokeExpression<S extends IParserState = IParserState>(
         state,
         Ast.NodeKind.InvokeExpression,
         () =>
-            readTokenKindAsConstant(state, Language.TokenKind.LeftParenthesis, Ast.WrapperConstantKind.LeftParenthesis),
+            readTokenKindAsConstant(
+                state,
+                Language.TokenKind.LeftParenthesis,
+                Constant.WrapperConstantKind.LeftParenthesis,
+            ),
         () =>
             // The type inference in VSCode considers the lambda below a type error, but it compiles just fine.
             // I'm adding an explicit type to stop it from (incorrectly) saying it's an error.
@@ -974,7 +984,7 @@ export function readInvokeExpression<S extends IParserState = IParserState>(
             readTokenKindAsConstant(
                 state,
                 Language.TokenKind.RightParenthesis,
-                Ast.WrapperConstantKind.RightParenthesis,
+                Constant.WrapperConstantKind.RightParenthesis,
             ),
         false,
     );
@@ -994,7 +1004,7 @@ export function readListExpression<S extends IParserState = IParserState>(
     return readWrapped(
         state,
         Ast.NodeKind.ListExpression,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Ast.WrapperConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
         () =>
             readCsvArray<S, Ast.TListItem>(
                 state,
@@ -1002,7 +1012,7 @@ export function readListExpression<S extends IParserState = IParserState>(
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBrace,
             ),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Ast.WrapperConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
         false,
     );
 }
@@ -1014,10 +1024,10 @@ export function readListItem<S extends IParserState = IParserState>(state: S, pa
 
     const left: Ast.TExpression = parser.readExpression(state, parser);
     if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.DotDot)) {
-        const rangeConstant: Ast.IConstant<Ast.MiscConstantKind.DotDot> = readTokenKindAsConstant(
+        const rangeConstant: Ast.IConstant<Constant.MiscConstantKind.DotDot> = readTokenKindAsConstant(
             state,
             Language.TokenKind.DotDot,
-            Ast.MiscConstantKind.DotDot,
+            Constant.MiscConstantKind.DotDot,
         );
         const right: Ast.TExpression = parser.readExpression(state, parser);
         const astNode: Ast.RangeExpression = {
@@ -1051,7 +1061,7 @@ export function readRecordExpression<S extends IParserState = IParserState>(
     return readWrapped(
         state,
         Ast.NodeKind.RecordExpression,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Ast.WrapperConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
         () =>
             parser.readGeneralizedIdentifierPairedExpressions(
                 state,
@@ -1059,7 +1069,8 @@ export function readRecordExpression<S extends IParserState = IParserState>(
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Ast.WrapperConstantKind.RightBracket),
+        () =>
+            readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
         false,
     );
 }
@@ -1077,9 +1088,9 @@ export function readItemAccessExpression<S extends IParserState = IParserState>(
     return readWrapped(
         state,
         Ast.NodeKind.ItemAccessExpression,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Ast.WrapperConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
         () => parser.readExpression(state, parser),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Ast.WrapperConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
         true,
     );
 }
@@ -1105,7 +1116,7 @@ export function readFieldProjection<S extends IParserState = IParserState>(
     return readWrapped(
         state,
         Ast.NodeKind.FieldProjection,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Ast.WrapperConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
         () =>
             readCsvArray(
                 state,
@@ -1113,7 +1124,8 @@ export function readFieldProjection<S extends IParserState = IParserState>(
                 true,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Ast.WrapperConstantKind.RightBracket),
+        () =>
+            readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
         true,
     );
 }
@@ -1128,9 +1140,10 @@ export function readFieldSelector<S extends IParserState = IParserState>(
     return readWrapped(
         state,
         Ast.NodeKind.FieldSelector,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Ast.WrapperConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
         () => parser.readGeneralizedIdentifier(state, parser),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Ast.WrapperConstantKind.RightBracket),
+        () =>
+            readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
         allowOptional,
     );
 }
@@ -1155,10 +1168,10 @@ export function readFunctionExpression<S extends IParserState = IParserState>(
         state,
         parser,
     );
-    const fatArrowConstant: Ast.IConstant<Ast.MiscConstantKind.FatArrow> = readTokenKindAsConstant(
+    const fatArrowConstant: Ast.IConstant<Constant.MiscConstantKind.FatArrow> = readTokenKindAsConstant(
         state,
         Language.TokenKind.FatArrow,
-        Ast.MiscConstantKind.FatArrow,
+        Constant.MiscConstantKind.FatArrow,
     );
     const expression: Ast.TExpression = parser.readExpression(state, parser);
 
@@ -1194,7 +1207,7 @@ function maybeReadAsNullablePrimitiveType<S extends IParserState = IParserState>
         state,
         Ast.NodeKind.AsNullablePrimitiveType,
         () => IParserStateUtils.isOnTokenKind(state, Language.TokenKind.KeywordAs),
-        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordAs, Ast.KeywordConstantKind.As),
+        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordAs, Constant.KeywordConstantKind.As),
         () => parser.readNullablePrimitiveType(state, parser),
     );
 }
@@ -1205,7 +1218,7 @@ export function readAsType<S extends IParserState = IParserState>(state: S, pars
     return readPairedConstant(
         state,
         Ast.NodeKind.AsType,
-        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordAs, Ast.KeywordConstantKind.As),
+        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordAs, Constant.KeywordConstantKind.As),
         () => parser.readType(state, parser),
     );
 }
@@ -1223,7 +1236,7 @@ export function readEachExpression<S extends IParserState = IParserState>(
     return readPairedConstant(
         state,
         Ast.NodeKind.EachExpression,
-        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordEach, Ast.KeywordConstantKind.Each),
+        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordEach, Constant.KeywordConstantKind.Each),
         () => parser.readExpression(state, parser),
     );
 }
@@ -1240,10 +1253,10 @@ export function readLetExpression<S extends IParserState = IParserState>(
     const nodeKind: Ast.NodeKind.LetExpression = Ast.NodeKind.LetExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const letConstant: Ast.IConstant<Ast.KeywordConstantKind.Let> = readTokenKindAsConstant(
+    const letConstant: Ast.IConstant<Constant.KeywordConstantKind.Let> = readTokenKindAsConstant(
         state,
         Language.TokenKind.KeywordLet,
-        Ast.KeywordConstantKind.Let,
+        Constant.KeywordConstantKind.Let,
     );
     const identifierPairedExpression: Ast.ICsvArray<Ast.IdentifierPairedExpression> = parser.readIdentifierPairedExpressions(
         state,
@@ -1251,10 +1264,10 @@ export function readLetExpression<S extends IParserState = IParserState>(
         !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.KeywordIn),
         IParserStateUtils.testCsvContinuationLetExpression,
     );
-    const inConstant: Ast.IConstant<Ast.KeywordConstantKind.In> = readTokenKindAsConstant(
+    const inConstant: Ast.IConstant<Constant.KeywordConstantKind.In> = readTokenKindAsConstant(
         state,
         Language.TokenKind.KeywordIn,
-        Ast.KeywordConstantKind.In,
+        Constant.KeywordConstantKind.In,
     );
     const expression: Ast.TExpression = parser.readExpression(state, parser);
 
@@ -1283,24 +1296,24 @@ export function readIfExpression<S extends IParserState = IParserState>(
     const nodeKind: Ast.NodeKind.IfExpression = Ast.NodeKind.IfExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const ifConstant: Ast.IConstant<Ast.KeywordConstantKind.If> = readTokenKindAsConstant(
+    const ifConstant: Ast.IConstant<Constant.KeywordConstantKind.If> = readTokenKindAsConstant(
         state,
         Language.TokenKind.KeywordIf,
-        Ast.KeywordConstantKind.If,
+        Constant.KeywordConstantKind.If,
     );
     const condition: Ast.TExpression = parser.readExpression(state, parser);
 
-    const thenConstant: Ast.IConstant<Ast.KeywordConstantKind.Then> = readTokenKindAsConstant(
+    const thenConstant: Ast.IConstant<Constant.KeywordConstantKind.Then> = readTokenKindAsConstant(
         state,
         Language.TokenKind.KeywordThen,
-        Ast.KeywordConstantKind.Then,
+        Constant.KeywordConstantKind.Then,
     );
     const trueExpression: Ast.TExpression = parser.readExpression(state, parser);
 
-    const elseConstant: Ast.IConstant<Ast.KeywordConstantKind.Else> = readTokenKindAsConstant(
+    const elseConstant: Ast.IConstant<Constant.KeywordConstantKind.Else> = readTokenKindAsConstant(
         state,
         Language.TokenKind.KeywordElse,
-        Ast.KeywordConstantKind.Else,
+        Constant.KeywordConstantKind.Else,
     );
     const falseExpression: Ast.TExpression = parser.readExpression(state, parser);
 
@@ -1333,7 +1346,7 @@ export function readTypeExpression<S extends IParserState = IParserState>(
         return readPairedConstant(
             state,
             Ast.NodeKind.TypePrimaryType,
-            () => readTokenKindAsConstant(state, Language.TokenKind.KeywordType, Ast.KeywordConstantKind.Type),
+            () => readTokenKindAsConstant(state, Language.TokenKind.KeywordType, Constant.KeywordConstantKind.Type),
             () => parser.readPrimaryType(state, parser),
         );
     } else {
@@ -1390,9 +1403,9 @@ export function readTableType<S extends IParserState = IParserState>(state: S, p
     const nodeKind: Ast.NodeKind.TableType = Ast.NodeKind.TableType;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const tableConstant: Ast.IConstant<Ast.PrimitiveTypeConstantKind.Table> = readConstantKind(
+    const tableConstant: Ast.IConstant<Constant.PrimitiveTypeConstantKind.Table> = readConstantKind(
         state,
-        Ast.PrimitiveTypeConstantKind.Table,
+        Constant.PrimitiveTypeConstantKind.Table,
     );
     const maybeCurrentTokenKind: Language.TokenKind | undefined = state.maybeCurrentTokenKind;
     const isPrimaryExpressionExpected: boolean =
@@ -1428,10 +1441,10 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
     const nodeKind: Ast.NodeKind.FieldSpecificationList = Ast.NodeKind.FieldSpecificationList;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const leftBracketConstant: Ast.IConstant<Ast.WrapperConstantKind.LeftBracket> = readTokenKindAsConstant(
+    const leftBracketConstant: Ast.IConstant<Constant.WrapperConstantKind.LeftBracket> = readTokenKindAsConstant(
         state,
         Language.TokenKind.LeftBracket,
-        Ast.WrapperConstantKind.LeftBracket,
+        Constant.WrapperConstantKind.LeftBracket,
     );
     const fields: Ast.ICsv<Ast.FieldSpecification>[] = [];
     let continueReadingValues: boolean = true;
@@ -1465,8 +1478,8 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
             IParserStateUtils.startContext(state, fieldSpecificationNodeKind);
 
             const maybeOptionalConstant:
-                | Ast.IConstant<Ast.IdentifierConstantKind.Optional>
-                | undefined = maybeReadConstantKind(state, Ast.IdentifierConstantKind.Optional);
+                | Ast.IConstant<Constant.IdentifierConstantKind.Optional>
+                | undefined = maybeReadConstantKind(state, Constant.IdentifierConstantKind.Optional);
 
             const name: Ast.GeneralizedIdentifier = parser.readGeneralizedIdentifier(state, parser);
 
@@ -1486,8 +1499,12 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
             IParserStateUtils.endContext(state, field);
 
             const maybeCommaConstant:
-                | Ast.IConstant<Ast.MiscConstantKind.Comma>
-                | undefined = maybeReadTokenKindAsConstant(state, Language.TokenKind.Comma, Ast.MiscConstantKind.Comma);
+                | Ast.IConstant<Constant.MiscConstantKind.Comma>
+                | undefined = maybeReadTokenKindAsConstant(
+                state,
+                Language.TokenKind.Comma,
+                Constant.MiscConstantKind.Comma,
+            );
             continueReadingValues = maybeCommaConstant !== undefined;
 
             const csv: Ast.ICsv<Ast.FieldSpecification> = {
@@ -1512,19 +1529,19 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
     };
     IParserStateUtils.endContext(state, fieldArray);
 
-    let maybeOpenRecordMarkerConstant: Ast.IConstant<Ast.MiscConstantKind.Ellipsis> | undefined = undefined;
+    let maybeOpenRecordMarkerConstant: Ast.IConstant<Constant.MiscConstantKind.Ellipsis> | undefined = undefined;
     if (isOnOpenRecordMarker) {
         maybeOpenRecordMarkerConstant = readTokenKindAsConstant(
             state,
             Language.TokenKind.Ellipsis,
-            Ast.MiscConstantKind.Ellipsis,
+            Constant.MiscConstantKind.Ellipsis,
         );
     }
 
-    const rightBracketConstant: Ast.IConstant<Ast.WrapperConstantKind.RightBracket> = readTokenKindAsConstant(
+    const rightBracketConstant: Ast.IConstant<Constant.WrapperConstantKind.RightBracket> = readTokenKindAsConstant(
         state,
         Language.TokenKind.RightBracket,
-        Ast.WrapperConstantKind.RightBracket,
+        Constant.WrapperConstantKind.RightBracket,
     );
 
     const astNode: Ast.FieldSpecificationList = {
@@ -1548,10 +1565,10 @@ function maybeReadFieldTypeSpecification<S extends IParserState = IParserState>(
     const nodeKind: Ast.NodeKind.FieldTypeSpecification = Ast.NodeKind.FieldTypeSpecification;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const maybeEqualConstant: Ast.IConstant<Ast.MiscConstantKind.Equal> | undefined = maybeReadTokenKindAsConstant(
+    const maybeEqualConstant: Ast.IConstant<Constant.MiscConstantKind.Equal> | undefined = maybeReadTokenKindAsConstant(
         state,
         Language.TokenKind.Equal,
-        Ast.MiscConstantKind.Equal,
+        Constant.MiscConstantKind.Equal,
     );
     if (maybeEqualConstant) {
         const fieldType: Ast.TType = parser.readType(state, parser);
@@ -1590,9 +1607,9 @@ export function readListType<S extends IParserState = IParserState>(state: S, pa
     return readWrapped(
         state,
         Ast.NodeKind.ListType,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Ast.WrapperConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
         () => parser.readType(state, parser),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Ast.WrapperConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
         false,
     );
 }
@@ -1605,9 +1622,9 @@ export function readFunctionType<S extends IParserState = IParserState>(
     const nodeKind: Ast.NodeKind.FunctionType = Ast.NodeKind.FunctionType;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const functionConstant: Ast.IConstant<Ast.PrimitiveTypeConstantKind.Function> = readConstantKind(
+    const functionConstant: Ast.IConstant<Constant.PrimitiveTypeConstantKind.Function> = readConstantKind(
         state,
-        Ast.PrimitiveTypeConstantKind.Function,
+        Constant.PrimitiveTypeConstantKind.Function,
     );
     const parameters: Ast.IParameterList<Ast.AsType> = parser.readParameterSpecificationList(state, parser);
     const functionReturnType: Ast.AsType = parser.readAsType(state, parser);
@@ -1626,13 +1643,13 @@ export function readFunctionType<S extends IParserState = IParserState>(
 
 function tryReadPrimaryType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): TriedReadPrimaryType {
     const isTableTypeNext: boolean =
-        IParserStateUtils.isOnConstantKind(state, Ast.PrimitiveTypeConstantKind.Table) &&
+        IParserStateUtils.isOnConstantKind(state, Constant.PrimitiveTypeConstantKind.Table) &&
         (IParserStateUtils.isNextTokenKind(state, Language.TokenKind.LeftBracket) ||
             IParserStateUtils.isNextTokenKind(state, Language.TokenKind.LeftParenthesis) ||
             IParserStateUtils.isNextTokenKind(state, Language.TokenKind.AtSign) ||
             IParserStateUtils.isNextTokenKind(state, Language.TokenKind.Identifier));
     const isFunctionTypeNext: boolean =
-        IParserStateUtils.isOnConstantKind(state, Ast.PrimitiveTypeConstantKind.Function) &&
+        IParserStateUtils.isOnConstantKind(state, Constant.PrimitiveTypeConstantKind.Function) &&
         IParserStateUtils.isNextTokenKind(state, Language.TokenKind.LeftParenthesis);
 
     if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.LeftBracket)) {
@@ -1643,7 +1660,7 @@ function tryReadPrimaryType<S extends IParserState = IParserState>(state: S, par
         return ResultUtils.okFactory(parser.readTableType(state, parser));
     } else if (isFunctionTypeNext) {
         return ResultUtils.okFactory(parser.readFunctionType(state, parser));
-    } else if (IParserStateUtils.isOnConstantKind(state, Ast.IdentifierConstantKind.Nullable)) {
+    } else if (IParserStateUtils.isOnConstantKind(state, Constant.IdentifierConstantKind.Nullable)) {
         return ResultUtils.okFactory(parser.readNullableType(state, parser));
     } else {
         const stateBackup: IParserStateUtils.FastStateBackup = IParserStateUtils.fastStateBackup(state);
@@ -1674,7 +1691,7 @@ export function readNullableType<S extends IParserState = IParserState>(
     return readPairedConstant(
         state,
         Ast.NodeKind.NullableType,
-        () => readConstantKind(state, Ast.IdentifierConstantKind.Nullable),
+        () => readConstantKind(state, Constant.IdentifierConstantKind.Nullable),
         () => parser.readType(state, parser),
     );
 }
@@ -1692,7 +1709,7 @@ export function readErrorRaisingExpression<S extends IParserState = IParserState
     return readPairedConstant(
         state,
         Ast.NodeKind.ErrorRaisingExpression,
-        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordError, Ast.KeywordConstantKind.Error),
+        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordError, Constant.KeywordConstantKind.Error),
         () => parser.readExpression(state, parser),
     );
 }
@@ -1709,10 +1726,10 @@ export function readErrorHandlingExpression<S extends IParserState = IParserStat
     const nodeKind: Ast.NodeKind.ErrorHandlingExpression = Ast.NodeKind.ErrorHandlingExpression;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const tryConstant: Ast.IConstant<Ast.KeywordConstantKind.Try> = readTokenKindAsConstant(
+    const tryConstant: Ast.IConstant<Constant.KeywordConstantKind.Try> = readTokenKindAsConstant(
         state,
         Language.TokenKind.KeywordTry,
-        Ast.KeywordConstantKind.Try,
+        Constant.KeywordConstantKind.Try,
     );
     const protectedExpression: Ast.TExpression = parser.readExpression(state, parser);
 
@@ -1721,7 +1738,8 @@ export function readErrorHandlingExpression<S extends IParserState = IParserStat
         state,
         otherwiseExpressionNodeKind,
         () => IParserStateUtils.isOnTokenKind(state, Language.TokenKind.KeywordOtherwise),
-        () => readTokenKindAsConstant(state, Language.TokenKind.KeywordOtherwise, Ast.KeywordConstantKind.Otherwise),
+        () =>
+            readTokenKindAsConstant(state, Language.TokenKind.KeywordOtherwise, Constant.KeywordConstantKind.Otherwise),
         () => parser.readExpression(state, parser),
     );
 
@@ -1750,13 +1768,13 @@ export function readRecordLiteral<S extends IParserState = IParserState>(
     const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.RightBracket);
     const wrappedRead: Ast.IWrapped<
         Ast.NodeKind.RecordLiteral,
-        Ast.WrapperConstantKind.LeftBracket,
+        Constant.WrapperConstantKind.LeftBracket,
         Ast.ICsvArray<Ast.GeneralizedIdentifierPairedAnyLiteral>,
-        Ast.WrapperConstantKind.RightBracket
+        Constant.WrapperConstantKind.RightBracket
     > = readWrapped(
         state,
         Ast.NodeKind.RecordLiteral,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Ast.WrapperConstantKind.LeftBracket),
+        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBracket, Constant.WrapperConstantKind.LeftBracket),
         () =>
             parser.readFieldNamePairedAnyLiterals(
                 state,
@@ -1764,11 +1782,12 @@ export function readRecordLiteral<S extends IParserState = IParserState>(
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBracket,
             ),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Ast.WrapperConstantKind.RightBracket),
+        () =>
+            readTokenKindAsConstant(state, Language.TokenKind.RightBracket, Constant.WrapperConstantKind.RightBracket),
         false,
     );
     return {
-        literalKind: Ast.LiteralKind.Record,
+        literalKind: Constant.LiteralKind.Record,
         ...wrappedRead,
     };
 }
@@ -1806,13 +1825,13 @@ export function readListLiteral<S extends IParserState = IParserState>(state: S,
     const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Language.TokenKind.RightBrace);
     const wrappedRead: Ast.IWrapped<
         Ast.NodeKind.ListLiteral,
-        Ast.WrapperConstantKind.LeftBrace,
+        Constant.WrapperConstantKind.LeftBrace,
         Ast.ICsvArray<Ast.TAnyLiteral>,
-        Ast.WrapperConstantKind.RightBrace
+        Constant.WrapperConstantKind.RightBrace
     > = readWrapped(
         state,
         Ast.NodeKind.ListLiteral,
-        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Ast.WrapperConstantKind.LeftBrace),
+        () => readTokenKindAsConstant(state, Language.TokenKind.LeftBrace, Constant.WrapperConstantKind.LeftBrace),
         () =>
             readCsvArray<S, Ast.TAnyLiteral>(
                 state,
@@ -1820,11 +1839,11 @@ export function readListLiteral<S extends IParserState = IParserState>(state: S,
                 continueReadingValues,
                 testCsvContinuationDanglingCommaForBrace,
             ),
-        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Ast.WrapperConstantKind.RightBrace),
+        () => readTokenKindAsConstant(state, Language.TokenKind.RightBrace, Constant.WrapperConstantKind.RightBrace),
         false,
     );
     return {
-        literalKind: Ast.LiteralKind.List,
+        literalKind: Constant.LiteralKind.List,
         ...wrappedRead,
     };
 }
@@ -1877,27 +1896,27 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
         return ResultUtils.errFactory(error);
     }
 
-    let primitiveType: Ast.IConstant<Ast.PrimitiveTypeConstantKind>;
+    let primitiveType: Ast.IConstant<Constant.PrimitiveTypeConstantKind>;
     if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.Identifier)) {
         const currentTokenData: string = state.lexerSnapshot.tokens[state.tokenIndex].data;
         switch (currentTokenData) {
-            case Ast.PrimitiveTypeConstantKind.Action:
-            case Ast.PrimitiveTypeConstantKind.Any:
-            case Ast.PrimitiveTypeConstantKind.AnyNonNull:
-            case Ast.PrimitiveTypeConstantKind.Binary:
-            case Ast.PrimitiveTypeConstantKind.Date:
-            case Ast.PrimitiveTypeConstantKind.DateTime:
-            case Ast.PrimitiveTypeConstantKind.DateTimeZone:
-            case Ast.PrimitiveTypeConstantKind.Duration:
-            case Ast.PrimitiveTypeConstantKind.Function:
-            case Ast.PrimitiveTypeConstantKind.List:
-            case Ast.PrimitiveTypeConstantKind.Logical:
-            case Ast.PrimitiveTypeConstantKind.None:
-            case Ast.PrimitiveTypeConstantKind.Number:
-            case Ast.PrimitiveTypeConstantKind.Record:
-            case Ast.PrimitiveTypeConstantKind.Table:
-            case Ast.PrimitiveTypeConstantKind.Text:
-            case Ast.PrimitiveTypeConstantKind.Time:
+            case Constant.PrimitiveTypeConstantKind.Action:
+            case Constant.PrimitiveTypeConstantKind.Any:
+            case Constant.PrimitiveTypeConstantKind.AnyNonNull:
+            case Constant.PrimitiveTypeConstantKind.Binary:
+            case Constant.PrimitiveTypeConstantKind.Date:
+            case Constant.PrimitiveTypeConstantKind.DateTime:
+            case Constant.PrimitiveTypeConstantKind.DateTimeZone:
+            case Constant.PrimitiveTypeConstantKind.Duration:
+            case Constant.PrimitiveTypeConstantKind.Function:
+            case Constant.PrimitiveTypeConstantKind.List:
+            case Constant.PrimitiveTypeConstantKind.Logical:
+            case Constant.PrimitiveTypeConstantKind.None:
+            case Constant.PrimitiveTypeConstantKind.Number:
+            case Constant.PrimitiveTypeConstantKind.Record:
+            case Constant.PrimitiveTypeConstantKind.Table:
+            case Constant.PrimitiveTypeConstantKind.Text:
+            case Constant.PrimitiveTypeConstantKind.Time:
                 primitiveType = readConstantKind(state, currentTokenData);
                 break;
 
@@ -1916,13 +1935,13 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
         primitiveType = readTokenKindAsConstant(
             state,
             Language.TokenKind.KeywordType,
-            Ast.PrimitiveTypeConstantKind.Type,
+            Constant.PrimitiveTypeConstantKind.Type,
         );
     } else if (IParserStateUtils.isOnTokenKind(state, Language.TokenKind.NullLiteral)) {
         primitiveType = readTokenKindAsConstant(
             state,
             Language.TokenKind.NullLiteral,
-            Ast.PrimitiveTypeConstantKind.Null,
+            Constant.PrimitiveTypeConstantKind.Null,
         );
     } else {
         const details: {} = { tokenKind: state.maybeCurrentTokenKind };
@@ -2145,37 +2164,37 @@ function recursiveReadBinOpExpression<
     S extends IParserState,
     Kind extends Ast.TBinOpExpressionNodeKind,
     Left,
-    Operator extends Ast.TBinOpExpressionOperator,
+    Op extends Constant.TBinOpExpressionOperator,
     Right
 >(
     state: S,
     nodeKind: Kind,
     leftReader: () => Left,
-    maybeOperatorFrom: (tokenKind: Language.TokenKind | undefined) => Operator | undefined,
+    maybeOperatorFrom: (tokenKind: Language.TokenKind | undefined) => Op | undefined,
     rightReader: () => Right,
-): Left | Ast.IBinOpExpression<Kind, Left, Operator, Right> {
+): Left | Ast.IBinOpExpression<Kind, Left, Op, Right> {
     IParserStateUtils.startContext(state, nodeKind);
     const left: Left = leftReader();
 
     // If no operator, return Left
-    const maybeOperator: Operator | undefined = maybeOperatorFrom(state.maybeCurrentTokenKind);
+    const maybeOperator: Op | undefined = maybeOperatorFrom(state.maybeCurrentTokenKind);
     if (maybeOperator === undefined) {
         IParserStateUtils.deleteContext(state, undefined);
         return left;
     }
-    const operatorConstant: Ast.TConstant & Ast.IConstant<Operator> = readTokenKindAsConstant(
+    const operatorConstant: Ast.TConstant & Ast.IConstant<Op> = readTokenKindAsConstant(
         state,
         state.maybeCurrentTokenKind!,
         maybeOperator,
     );
-    const right: Right | Ast.IBinOpExpression<Kind, Right, Operator, Right> = recursiveReadBinOpExpressionHelper<
+    const right: Right | Ast.IBinOpExpression<Kind, Right, Op, Right> = recursiveReadBinOpExpressionHelper<
         S,
         Kind,
-        Operator,
+        Op,
         Right
     >(state, nodeKind, maybeOperatorFrom, rightReader);
 
-    const astNode: Ast.IBinOpExpression<Kind, Left, Operator, Right> = {
+    const astNode: Ast.IBinOpExpression<Kind, Left, Op, Right> = {
         ...IParserStateUtils.assertContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
@@ -2194,7 +2213,7 @@ function recursiveReadBinOpExpression<
 function recursiveReadBinOpExpressionHelper<
     S extends IParserState,
     Kind extends Ast.TBinOpExpressionNodeKind,
-    OperatorKind extends Ast.TBinOpExpressionOperator,
+    OperatorKind extends Constant.TBinOpExpressionOperator,
     Right
 >(
     state: S,
@@ -2256,10 +2275,12 @@ function readCsvArray<S extends IParserState, T extends Ast.TCsvType>(
         }
 
         const node: T = valueReader();
-        const maybeCommaConstant: Ast.IConstant<Ast.MiscConstantKind.Comma> | undefined = maybeReadTokenKindAsConstant(
+        const maybeCommaConstant:
+            | Ast.IConstant<Constant.MiscConstantKind.Comma>
+            | undefined = maybeReadTokenKindAsConstant(
             state,
             Language.TokenKind.Comma,
-            Ast.MiscConstantKind.Comma,
+            Constant.MiscConstantKind.Comma,
         );
 
         const element: Ast.TCsv & Ast.ICsv<T> = {
@@ -2294,10 +2315,10 @@ function readKeyValuePair<S extends IParserState, Kind extends Ast.TKeyValuePair
     IParserStateUtils.startContext(state, nodeKind);
 
     const key: Key = keyReader();
-    const equalConstant: Ast.IConstant<Ast.MiscConstantKind.Equal> = readTokenKindAsConstant(
+    const equalConstant: Ast.IConstant<Constant.MiscConstantKind.Equal> = readTokenKindAsConstant(
         state,
         Language.TokenKind.Equal,
-        Ast.MiscConstantKind.Equal,
+        Constant.MiscConstantKind.Equal,
     );
     const value: Value = valueReader();
 
@@ -2316,7 +2337,7 @@ function readKeyValuePair<S extends IParserState, Kind extends Ast.TKeyValuePair
 function readPairedConstant<
     S extends IParserState,
     Kind extends Ast.TPairedConstantNodeKind,
-    ConstantKind extends Ast.TConstantKind,
+    ConstantKind extends Constant.TConstantKind,
     Paired
 >(
     state: S,
@@ -2345,7 +2366,7 @@ function readPairedConstant<
 function maybeReadPairedConstant<
     S extends IParserState,
     Kind extends Ast.TPairedConstantNodeKind,
-    ConstantKind extends Ast.TConstantKind,
+    ConstantKind extends Constant.TConstantKind,
     Paired
 >(
     state: S,
@@ -2370,10 +2391,10 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
     const nodeKind: Ast.NodeKind.ParameterList = Ast.NodeKind.ParameterList;
     IParserStateUtils.startContext(state, nodeKind);
 
-    const leftParenthesisConstant: Ast.IConstant<Ast.WrapperConstantKind.LeftParenthesis> = readTokenKindAsConstant(
+    const leftParenthesisConstant: Ast.IConstant<Constant.WrapperConstantKind.LeftParenthesis> = readTokenKindAsConstant(
         state,
         Language.TokenKind.LeftParenthesis,
-        Ast.WrapperConstantKind.LeftParenthesis,
+        Constant.WrapperConstantKind.LeftParenthesis,
     );
     let continueReadingValues: boolean = !IParserStateUtils.isOnTokenKind(state, Language.TokenKind.RightParenthesis);
     let reachedOptionalParameter: boolean = false;
@@ -2392,8 +2413,8 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
         }
 
         const maybeOptionalConstant:
-            | Ast.IConstant<Ast.IdentifierConstantKind.Optional>
-            | undefined = maybeReadConstantKind(state, Ast.IdentifierConstantKind.Optional);
+            | Ast.IConstant<Constant.IdentifierConstantKind.Optional>
+            | undefined = maybeReadConstantKind(state, Constant.IdentifierConstantKind.Optional);
 
         if (reachedOptionalParameter && !maybeOptionalConstant) {
             const token: Language.Token = IParserStateUtils.assertTokenAt(state, state.tokenIndex);
@@ -2419,10 +2440,12 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
         };
         IParserStateUtils.endContext(state, parameter);
 
-        const maybeCommaConstant: Ast.IConstant<Ast.MiscConstantKind.Comma> | undefined = maybeReadTokenKindAsConstant(
+        const maybeCommaConstant:
+            | Ast.IConstant<Constant.MiscConstantKind.Comma>
+            | undefined = maybeReadTokenKindAsConstant(
             state,
             Language.TokenKind.Comma,
-            Ast.MiscConstantKind.Comma,
+            Constant.MiscConstantKind.Comma,
         );
         continueReadingValues = maybeCommaConstant !== undefined;
 
@@ -2446,10 +2469,10 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
     };
     IParserStateUtils.endContext(state, parameterArray);
 
-    const rightParenthesisConstant: Ast.IConstant<Ast.WrapperConstantKind.RightParenthesis> = readTokenKindAsConstant(
+    const rightParenthesisConstant: Ast.IConstant<Constant.WrapperConstantKind.RightParenthesis> = readTokenKindAsConstant(
         state,
         Language.TokenKind.RightParenthesis,
-        Ast.WrapperConstantKind.RightParenthesis,
+        Constant.WrapperConstantKind.RightParenthesis,
     );
 
     const astNode: Ast.IParameterList<T> = {
@@ -2467,9 +2490,9 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
 function readWrapped<
     S extends IParserState,
     Kind extends Ast.TWrappedNodeKind,
-    Open extends Ast.WrapperConstantKind,
+    Open extends Constant.WrapperConstantKind,
     Content,
-    Close extends Ast.WrapperConstantKind
+    Close extends Constant.WrapperConstantKind
 >(
     state: S,
     nodeKind: Kind,
@@ -2484,12 +2507,12 @@ function readWrapped<
     const content: Content = contentReader();
     const closeWrapperConstant: Ast.IConstant<Close> = closeConstantReader();
 
-    let maybeOptionalConstant: Ast.IConstant<Ast.MiscConstantKind.QuestionMark> | undefined;
+    let maybeOptionalConstant: Ast.IConstant<Constant.MiscConstantKind.QuestionMark> | undefined;
     if (allowOptionalConstant) {
         maybeOptionalConstant = maybeReadTokenKindAsConstant(
             state,
             Language.TokenKind.QuestionMark,
-            Ast.MiscConstantKind.QuestionMark,
+            Constant.MiscConstantKind.QuestionMark,
         );
     }
 
@@ -2532,7 +2555,7 @@ export function readToken<S extends IParserState = IParserState>(state: S): stri
     return data;
 }
 
-export function readTokenKindAsConstant<S extends IParserState, ConstantKind extends Ast.TConstantKind>(
+export function readTokenKindAsConstant<S extends IParserState, ConstantKind extends Constant.TConstantKind>(
     state: S,
     tokenKind: Language.TokenKind,
     constantKind: ConstantKind,
@@ -2562,7 +2585,7 @@ export function readTokenKindAsConstant<S extends IParserState, ConstantKind ext
     return astNode;
 }
 
-export function maybeReadTokenKindAsConstant<S extends IParserState, ConstantKind extends Ast.TConstantKind>(
+export function maybeReadTokenKindAsConstant<S extends IParserState, ConstantKind extends Constant.TConstantKind>(
     state: S,
     tokenKind: Language.TokenKind,
     constantKind: ConstantKind,
@@ -2606,7 +2629,7 @@ function readTokenKind(state: IParserState, tokenKind: Language.TokenKind): stri
     return readToken(state);
 }
 
-function readConstantKind<S extends IParserState, ConstantKind extends Ast.TConstantKind>(
+function readConstantKind<S extends IParserState, ConstantKind extends Constant.TConstantKind>(
     state: S,
     constantKind: ConstantKind,
 ): Ast.TConstant & Ast.IConstant<ConstantKind> {
@@ -2619,7 +2642,7 @@ function readConstantKind<S extends IParserState, ConstantKind extends Ast.TCons
     return maybeConstant;
 }
 
-function maybeReadConstantKind<S extends IParserState, ConstantKind extends Ast.TConstantKind>(
+function maybeReadConstantKind<S extends IParserState, ConstantKind extends Constant.TConstantKind>(
     state: S,
     constantKind: ConstantKind,
 ): (Ast.TConstant & Ast.IConstant<ConstantKind>) | undefined {

--- a/src/test/libraryTest/inspection/autocomplete.ts
+++ b/src/test/libraryTest/inspection/autocomplete.ts
@@ -3,11 +3,11 @@
 
 import { expect } from "chai";
 import "mocha";
-import { Inspection, Language } from "../../..";
+import { Inspection } from "../../..";
 import { Assert } from "../../../common";
 import { AutocompleteOption, Position, StartOfDocumentKeywords, TriedAutocomplete } from "../../../inspection";
 import { ActiveNode, ActiveNodeUtils } from "../../../inspection/activeNode";
-import { Ast } from "../../../language";
+import { Ast, Constant, Keyword } from "../../../language";
 import { IParserState, IParserStateUtils, NodeIdMap, ParseContext, ParseError, ParseOk } from "../../../parser";
 import { CommonSettings, DefaultSettings, LexSettings, ParseSettings } from "../../../settings";
 import { TestAssertUtils } from "../../testUtils";
@@ -80,8 +80,8 @@ describe(`Inspection - Autocomplete`, () => {
     it("|", () => {
         const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`|`);
         const expected: ReadonlyArray<AutocompleteOption> = [
-            ...Language.ExpressionKeywords,
-            Language.KeywordKind.Section,
+            ...Keyword.ExpressionKeywordKinds,
+            Keyword.KeywordKind.Section,
         ];
         const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(DefaultSettings, text, position);
         expect(actual).to.have.members(expected);
@@ -101,7 +101,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it("x a|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`x a|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.And, Language.KeywordKind.As];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.And, Keyword.KeywordKind.As];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -112,7 +112,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it("e|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`e|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Each, Language.KeywordKind.Error];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Each, Keyword.KeywordKind.Error];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -125,7 +125,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if x then x e|`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Else];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Else];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -136,7 +136,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it("i|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`i|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.If];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.If];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -147,7 +147,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it("l|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`l|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Let];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Let];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -169,7 +169,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it("x m|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`x m|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Meta];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Meta];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -180,7 +180,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it("n|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`n|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Not];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Not];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -191,7 +191,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it("true o|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`true o|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Or];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Or];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -204,10 +204,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true o|`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [
-                Language.KeywordKind.Or,
-                Language.KeywordKind.Otherwise,
-            ];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Or, Keyword.KeywordKind.Otherwise];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -233,7 +230,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true ot|`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Otherwise];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Otherwise];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -246,7 +243,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true oth|`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Otherwise];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Otherwise];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -257,7 +254,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it("s|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`s|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Section];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Section];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -268,7 +265,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it("[] s|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`[] s|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Section];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Section];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -281,7 +278,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section; s|`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Shared];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Shared];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -307,7 +304,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section; [] s|`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Shared];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Shared];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -320,7 +317,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if true t|`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Then];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -332,9 +329,9 @@ describe(`Inspection - Autocomplete`, () => {
         it("t|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`t|`);
             const expected: ReadonlyArray<AutocompleteOption> = [
-                Language.KeywordKind.True,
-                Language.KeywordKind.Try,
-                Language.KeywordKind.Type,
+                Keyword.KeywordKind.True,
+                Keyword.KeywordKind.Try,
+                Keyword.KeywordKind.Type,
             ];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
                 DefaultSettings,
@@ -348,7 +345,7 @@ describe(`Inspection - Autocomplete`, () => {
     describe(`${Ast.NodeKind.ErrorHandlingExpression}`, () => {
         it(`try |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`try |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -359,7 +356,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`try true|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`try true|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.True];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.True];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -373,12 +370,12 @@ describe(`Inspection - Autocomplete`, () => {
                 `try true |`,
             );
             const expected: ReadonlyArray<AutocompleteOption> = [
-                Language.KeywordKind.And,
-                Language.KeywordKind.As,
-                Language.KeywordKind.Is,
-                Language.KeywordKind.Meta,
-                Language.KeywordKind.Or,
-                Language.KeywordKind.Otherwise,
+                Keyword.KeywordKind.And,
+                Keyword.KeywordKind.As,
+                Keyword.KeywordKind.Is,
+                Keyword.KeywordKind.Meta,
+                Keyword.KeywordKind.Or,
+                Keyword.KeywordKind.Otherwise,
             ];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
                 DefaultSettings,
@@ -392,7 +389,7 @@ describe(`Inspection - Autocomplete`, () => {
     describe(`${Ast.NodeKind.AsExpression}`, () => {
         it(`foo as |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo as |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.Ast.PrimitiveTypeConstantKinds;
+            const expected: ReadonlyArray<AutocompleteOption> = Constant.PrimitiveTypeConstantKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -405,7 +402,7 @@ describe(`Inspection - Autocomplete`, () => {
     describe(`${Ast.NodeKind.ErrorRaisingExpression}`, () => {
         it(`if |error`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if |error`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -427,7 +424,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`error |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`error |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -442,7 +439,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let x = (_ |) => a in x`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.As];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.As];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -455,7 +452,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let x = (_ a|) => a in`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.As];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.As];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -479,7 +476,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(` if |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -501,7 +498,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`if |if`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if |if`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -512,7 +509,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`if i|f`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if i|f`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.If];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.If];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -523,7 +520,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`if if | `, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if if |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -534,7 +531,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`if 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if 1 |`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Then];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -545,7 +542,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`if 1 t|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if 1 t|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Then];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -558,7 +555,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if 1 then |`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -584,7 +581,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if 1 then 1 e|`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Else];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Else];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -610,7 +607,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if 1 th|en 1 else`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Then];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Then];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -623,7 +620,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if 1 then 1 else |`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -636,7 +633,7 @@ describe(`Inspection - Autocomplete`, () => {
     describe(`${Ast.NodeKind.InvokeExpression}`, () => {
         it(`foo(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo(|`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -669,7 +666,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`foo(a,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo(a,|`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -682,7 +679,7 @@ describe(`Inspection - Autocomplete`, () => {
     describe(`${Ast.NodeKind.ListExpression}`, () => {
         it(`{|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{|`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -715,7 +712,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`{1,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{1,|`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -726,7 +723,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`{1,|2`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{1,|2`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -737,7 +734,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`{1,|2,`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{1,|2,`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -748,7 +745,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`{1..|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{1..|`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -776,7 +773,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true otherwise |false`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -789,7 +786,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true oth|`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Otherwise];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Otherwise];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -802,7 +799,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true otherwise |`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -815,7 +812,7 @@ describe(`Inspection - Autocomplete`, () => {
     describe(`${Ast.NodeKind.ParenthesizedExpression}`, () => {
         it(`+(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+(|`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -839,7 +836,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`+[a=|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=|`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -883,7 +880,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`+[a=|1]`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=| 1]`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -938,7 +935,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`+[a=|1,b=`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=|1,b=`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -977,7 +974,7 @@ describe(`Inspection - Autocomplete`, () => {
     describe(`AutocompleteExpression`, () => {
         it(`error |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`error |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -988,7 +985,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`let x = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`let x = |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -999,7 +996,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`() => |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`() => |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1010,7 +1007,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`if |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1023,7 +1020,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if true then |`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1036,7 +1033,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if true then true else |`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1047,7 +1044,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`foo(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo(|`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1060,7 +1057,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let x = 1 in |`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1071,7 +1068,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`+{|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+{|`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1084,7 +1081,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true otherwise |`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1095,7 +1092,7 @@ describe(`Inspection - Autocomplete`, () => {
 
         it(`+(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+(|`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1110,7 +1107,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section; [] |`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Shared];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Shared];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1136,7 +1133,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section; x = |`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1149,7 +1146,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section foo; a = () => true; b = "string"; c = 1; d = |;`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1162,7 +1159,7 @@ describe(`Inspection - Autocomplete`, () => {
     describe(`${Ast.NodeKind.LetExpression}`, () => {
         it(`let a = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`let a = |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1189,12 +1186,12 @@ describe(`Inspection - Autocomplete`, () => {
                 `let a = 1 |`,
             );
             const expected: ReadonlyArray<AutocompleteOption> = [
-                Language.KeywordKind.And,
-                Language.KeywordKind.As,
-                Language.KeywordKind.In,
-                Language.KeywordKind.Is,
-                Language.KeywordKind.Meta,
-                Language.KeywordKind.Or,
+                Keyword.KeywordKind.And,
+                Keyword.KeywordKind.As,
+                Keyword.KeywordKind.In,
+                Keyword.KeywordKind.Is,
+                Keyword.KeywordKind.Meta,
+                Keyword.KeywordKind.Or,
             ];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
@@ -1208,7 +1205,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let a = 1 o|`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Or];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Or];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1221,7 +1218,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let a = 1 m|`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Meta];
+            const expected: ReadonlyArray<AutocompleteOption> = [Keyword.KeywordKind.Meta];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1247,7 +1244,7 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let a = let b = |`,
             );
-            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,
@@ -1261,12 +1258,12 @@ describe(`Inspection - Autocomplete`, () => {
                 `let a = let b = 1 |`,
             );
             const expected: ReadonlyArray<AutocompleteOption> = [
-                Language.KeywordKind.And,
-                Language.KeywordKind.As,
-                Language.KeywordKind.In,
-                Language.KeywordKind.Is,
-                Language.KeywordKind.Meta,
-                Language.KeywordKind.Or,
+                Keyword.KeywordKind.And,
+                Keyword.KeywordKind.As,
+                Keyword.KeywordKind.In,
+                Keyword.KeywordKind.Is,
+                Keyword.KeywordKind.Meta,
+                Keyword.KeywordKind.Or,
             ];
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,

--- a/src/test/libraryTest/inspection/autocomplete.ts
+++ b/src/test/libraryTest/inspection/autocomplete.ts
@@ -7,7 +7,7 @@ import { Inspection } from "../../..";
 import { Assert } from "../../../common";
 import { AutocompleteOption, Position, StartOfDocumentKeywords, TriedAutocomplete } from "../../../inspection";
 import { ActiveNode, ActiveNodeUtils } from "../../../inspection/activeNode";
-import { Ast, Constant, Keyword } from "../../../language";
+import { Ast, Keyword } from "../../../language";
 import { IParserState, IParserStateUtils, NodeIdMap, ParseContext, ParseError, ParseOk } from "../../../parser";
 import { CommonSettings, DefaultSettings, LexSettings, ParseSettings } from "../../../settings";
 import { TestAssertUtils } from "../../testUtils";
@@ -386,30 +386,6 @@ describe(`Inspection - Autocomplete`, () => {
         });
     });
 
-    describe(`${Ast.NodeKind.AsExpression}`, () => {
-        it(`foo as|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo as|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [];
-            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
-                DefaultSettings,
-                text,
-                position,
-            );
-            expect(actual).to.have.members(expected);
-        });
-
-        it(`foo as |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo as |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Constant.PrimitiveTypeConstantKinds;
-            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
-                DefaultSettings,
-                text,
-                position,
-            );
-            expect(actual).to.have.members(expected);
-        });
-    });
-
     describe(`${Ast.NodeKind.ErrorRaisingExpression}`, () => {
         it(`if |error`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if |error`);
@@ -678,30 +654,6 @@ describe(`Inspection - Autocomplete`, () => {
         it(`foo(a,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo(a,|`);
             const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
-            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
-                DefaultSettings,
-                text,
-                position,
-            );
-            expect(actual).to.have.members(expected);
-        });
-    });
-
-    describe(`${Ast.NodeKind.IsExpression}`, () => {
-        it(`foo is|`, () => {
-            const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo is|`);
-            const expected: ReadonlyArray<AutocompleteOption> = [];
-            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
-                DefaultSettings,
-                text,
-                position,
-            );
-            expect(actual).to.have.members(expected);
-        });
-
-        it(`foo is |`, () => {
-            const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo is |`);
-            const expected: ReadonlyArray<AutocompleteOption> = Constant.PrimitiveTypeConstantKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,

--- a/src/test/libraryTest/inspection/autocomplete.ts
+++ b/src/test/libraryTest/inspection/autocomplete.ts
@@ -5,7 +5,7 @@ import { expect } from "chai";
 import "mocha";
 import { Inspection, Language } from "../../..";
 import { Assert } from "../../../common";
-import { Position, StartOfDocumentKeywords, TriedAutocomplete } from "../../../inspection";
+import { AutocompleteOption, Position, StartOfDocumentKeywords, TriedAutocomplete } from "../../../inspection";
 import { ActiveNode, ActiveNodeUtils } from "../../../inspection/activeNode";
 import { Ast } from "../../../language";
 import { IParserState, IParserStateUtils, NodeIdMap, ParseContext, ParseError, ParseOk } from "../../../parser";
@@ -18,7 +18,7 @@ function assertAutocompleteOk<S extends IParserState>(
     leafNodeIds: ReadonlyArray<number>,
     position: Position,
     maybeParseError: ParseError.ParseError<S> | undefined,
-): ReadonlyArray<Language.KeywordKind> {
+): ReadonlyArray<AutocompleteOption> {
     const maybeActiveNode: ActiveNode | undefined = ActiveNodeUtils.maybeActiveNode(
         nodeIdMapCollection,
         leafNodeIds,
@@ -43,7 +43,7 @@ function assertParseOkAutocompleteOk(
     settings: LexSettings & ParseSettings<IParserState>,
     text: string,
     position: Position,
-): ReadonlyArray<Language.KeywordKind> {
+): ReadonlyArray<AutocompleteOption> {
     const parseOk: ParseOk = TestAssertUtils.assertParseOk(settings, text, IParserStateUtils.stateFactory);
     const contextState: ParseContext.State = parseOk.state.contextState;
     return assertAutocompleteOk(
@@ -59,7 +59,7 @@ function assertParseErrAutocompleteOk(
     settings: LexSettings & ParseSettings<IParserState>,
     text: string,
     position: Position,
-): ReadonlyArray<Language.KeywordKind> {
+): ReadonlyArray<AutocompleteOption> {
     const parseError: ParseError.ParseError = TestAssertUtils.assertParseErr(
         settings,
         text,
@@ -79,187 +79,300 @@ function assertParseErrAutocompleteOk(
 describe(`Inspection - Autocomplete`, () => {
     it("|", () => {
         const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`|`);
-        const expected: ReadonlyArray<Language.KeywordKind> = [
+        const expected: ReadonlyArray<AutocompleteOption> = [
             ...Language.ExpressionKeywords,
             Language.KeywordKind.Section,
         ];
-        expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+        const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(DefaultSettings, text, position);
+        expect(actual).to.have.members(expected);
     });
 
     describe("partial keyword", () => {
         it("a|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`a|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("x a|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`x a|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.And, Language.KeywordKind.As];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.And, Language.KeywordKind.As];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("e|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`e|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [
-                Language.KeywordKind.Each,
-                Language.KeywordKind.Error,
-            ];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Each, Language.KeywordKind.Error];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("if x then x e|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if x then x e|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Else];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Else];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("i|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`i|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.If];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.If];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("l|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`l|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Let];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Let];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("m|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`m|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("x m|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`x m|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Meta];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Meta];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("n|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`n|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Not];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Not];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("true o|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`true o|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Or];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Or];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("try true o|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true o|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [
+            const expected: ReadonlyArray<AutocompleteOption> = [
                 Language.KeywordKind.Or,
                 Language.KeywordKind.Otherwise,
             ];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("try true o |", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true o |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("try true ot|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true ot|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Otherwise];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Otherwise];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("try true oth|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true oth|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Otherwise];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Otherwise];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("s|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`s|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Section];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Section];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("[] s|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`[] s|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Section];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Section];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("section; s|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section; s|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Shared];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Shared];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("section; shared x|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section; shared x|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("section; [] s|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section; [] s|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Shared];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Shared];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("if true t|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if true t|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Then];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Then];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it("t|", () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`t|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [
+            const expected: ReadonlyArray<AutocompleteOption> = [
                 Language.KeywordKind.True,
                 Language.KeywordKind.Try,
                 Language.KeywordKind.Type,
             ];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
     describe(`${Ast.NodeKind.ErrorHandlingExpression}`, () => {
         it(`try |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`try |`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`try true|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`try true|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.True];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.True];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`try true |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [
+            const expected: ReadonlyArray<AutocompleteOption> = [
                 Language.KeywordKind.And,
                 Language.KeywordKind.As,
                 Language.KeywordKind.Is,
@@ -267,27 +380,60 @@ describe(`Inspection - Autocomplete`, () => {
                 Language.KeywordKind.Or,
                 Language.KeywordKind.Otherwise,
             ];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
+        });
+    });
+
+    describe(`${Ast.NodeKind.AsExpression}`, () => {
+        it(`foo as |`, () => {
+            const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo as |`);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.Ast.PrimitiveTypeConstantKinds;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
     describe(`${Ast.NodeKind.ErrorRaisingExpression}`, () => {
         it(`if |error`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if |error`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if error|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if error|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`error |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`error |`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
@@ -296,184 +442,319 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let x = (_ |) => a in x`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.As];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.As];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`let x = (_ a|) => a in`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let x = (_ a|) => a in`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.As];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.As];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
     describe(`${Ast.NodeKind.IfExpression}`, () => {
         it(`if|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(` if |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if |`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if 1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if 1|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if |if`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if |if`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if i|f`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if i|f`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.If];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.If];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if if | `, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if if |`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if 1 |`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Then];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Then];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if 1 t|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if 1 t|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Then];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Then];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if 1 then |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if 1 then |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if 1 then 1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if 1 then 1|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if 1 then 1 e|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if 1 then 1 e|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Else];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Else];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if 1 then 1 else|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if 1 then 1 else|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if 1 th|en 1 else`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if 1 th|en 1 else`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Then];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Then];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if 1 then 1 else |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if 1 then 1 else |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
     describe(`${Ast.NodeKind.InvokeExpression}`, () => {
         it(`foo(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo(|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`foo(a|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo(a|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`foo(a|,`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo(a|,`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`foo(a,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo(a,|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
     describe(`${Ast.NodeKind.ListExpression}`, () => {
         it(`{|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`{1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{1|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`{1|,`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{1|,`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`{1,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{1,|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`{1,|2`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{1,|2`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`{1,|2,`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{1,|2,`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`{1..|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`{1..|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
@@ -482,200 +763,345 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true otherwise| false`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`try true otherwise |false`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true otherwise |false`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`try true oth|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true oth|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Otherwise];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Otherwise];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`try true otherwise |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true otherwise |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
     describe(`${Ast.NodeKind.ParenthesizedExpression}`, () => {
         it(`+(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+(|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
     describe(`${Ast.NodeKind.RecordExpression}`, () => {
         it(`+[|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a=|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a=1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=1|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a|=1`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a|=1`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a=1|]`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=1|]`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a=|1]`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=| 1]`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseOkAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseOkAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a=1|,`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=1|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a=1,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=1,|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a=1|,b`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=1|,b`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a=1|,b=`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=1|,b=`);
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a=|1,b=`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+[a=|1,b=`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a=1,b=2|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `+[a=1,b=2|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+[a=1,b=2 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `+[a=1,b=2 |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
     describe(`AutocompleteExpression`, () => {
         it(`error |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`error |`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`let x = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`let x = |`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`() => |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`() => |`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`if |`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if true then |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if true then |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`if true then true else |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `if true then true else |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`foo(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo(|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`let x = 1 in |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let x = 1 in |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+{|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+{|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`try true otherwise |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `try true otherwise |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`+(|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`+(|`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
@@ -684,55 +1110,85 @@ describe(`Inspection - Autocomplete`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section; [] |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Shared];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Shared];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`section; [] x |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section; [] x |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`section; x = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section; x = |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`section foo; a = () => true; b = "string"; c = 1; d = |;`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `section foo; a = () => true; b = "string"; c = 1; d = |;`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 
     describe(`${Ast.NodeKind.LetExpression}`, () => {
         it(`let a = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`let a = |`);
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`let a = 1|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let a = 1|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`let a = 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let a = 1 |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [
+            const expected: ReadonlyArray<AutocompleteOption> = [
                 Language.KeywordKind.And,
                 Language.KeywordKind.As,
                 Language.KeywordKind.In,
@@ -740,46 +1196,71 @@ describe(`Inspection - Autocomplete`, () => {
                 Language.KeywordKind.Meta,
                 Language.KeywordKind.Or,
             ];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`let a = 1 o|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let a = 1 o|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Or];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Or];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`let a = 1 m|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let a = 1 m|`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [Language.KeywordKind.Meta];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [Language.KeywordKind.Meta];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`let a = 1, |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let a = 1, |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`let a = let b = |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let a = let b = |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = Language.ExpressionKeywords;
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = Language.ExpressionKeywords;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`let a = let b = 1 |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let a = let b = 1 |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [
+            const expected: ReadonlyArray<AutocompleteOption> = [
                 Language.KeywordKind.And,
                 Language.KeywordKind.As,
                 Language.KeywordKind.In,
@@ -787,15 +1268,25 @@ describe(`Inspection - Autocomplete`, () => {
                 Language.KeywordKind.Meta,
                 Language.KeywordKind.Or,
             ];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
 
         it(`let a = let b = 1, |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(
                 `let a = let b = 1, |`,
             );
-            const expected: ReadonlyArray<Language.KeywordKind> = [];
-            expect(assertParseErrAutocompleteOk(DefaultSettings, text, position)).to.have.members(expected);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
         });
     });
 });

--- a/src/test/libraryTest/inspection/autocomplete.ts
+++ b/src/test/libraryTest/inspection/autocomplete.ts
@@ -387,6 +387,17 @@ describe(`Inspection - Autocomplete`, () => {
     });
 
     describe(`${Ast.NodeKind.AsExpression}`, () => {
+        it(`foo as|`, () => {
+            const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo as|`);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
+        });
+
         it(`foo as |`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo as |`);
             const expected: ReadonlyArray<AutocompleteOption> = Constant.PrimitiveTypeConstantKinds;
@@ -667,6 +678,30 @@ describe(`Inspection - Autocomplete`, () => {
         it(`foo(a,|`, () => {
             const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo(a,|`);
             const expected: ReadonlyArray<AutocompleteOption> = Keyword.ExpressionKeywordKinds;
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
+        });
+    });
+
+    describe(`${Ast.NodeKind.IsExpression}`, () => {
+        it(`foo is|`, () => {
+            const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo is|`);
+            const expected: ReadonlyArray<AutocompleteOption> = [];
+            const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
+                DefaultSettings,
+                text,
+                position,
+            );
+            expect(actual).to.have.members(expected);
+        });
+
+        it(`foo is |`, () => {
+            const [text, position]: [string, Inspection.Position] = TestAssertUtils.assertTextWithPosition(`foo is |`);
+            const expected: ReadonlyArray<AutocompleteOption> = Constant.PrimitiveTypeConstantKinds;
             const actual: ReadonlyArray<AutocompleteOption> = assertParseErrAutocompleteOk(
                 DefaultSettings,
                 text,

--- a/src/test/libraryTest/inspection/scope.ts
+++ b/src/test/libraryTest/inspection/scope.ts
@@ -7,7 +7,7 @@ import { Inspection } from "../../..";
 import { Assert } from "../../../common";
 import { Position, ScopeItemByKey, ScopeItemKind } from "../../../inspection";
 import { ActiveNode, ActiveNodeUtils } from "../../../inspection/activeNode";
-import { Ast } from "../../../language";
+import { Ast, Constant } from "../../../language";
 import { IParserState, IParserStateUtils, NodeIdMap, ParseContext, ParseError, ParseOk } from "../../../parser";
 import { CommonSettings, DefaultSettings, LexSettings, ParseSettings } from "../../../settings";
 import { TestAssertUtils } from "../../testUtils";
@@ -43,7 +43,7 @@ interface AbridgedParameterScopeItem extends IAbridgedNodeScopeItem {
     readonly nameNodeId: number;
     readonly isNullable: boolean;
     readonly isOptional: boolean;
-    readonly maybeType: Ast.PrimitiveTypeConstantKind | undefined;
+    readonly maybeType: Constant.PrimitiveTypeConstantKind | undefined;
 }
 
 interface AbridgedSectionMemberScopeItem extends IAbridgedNodeScopeItem {
@@ -1308,7 +1308,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     nameNodeId: 11,
                     isNullable: false,
                     isOptional: false,
-                    maybeType: Ast.PrimitiveTypeConstantKind.Number,
+                    maybeType: Constant.PrimitiveTypeConstantKind.Number,
                 },
                 {
                     identifier: "c",
@@ -1317,7 +1317,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     nameNodeId: 19,
                     isNullable: true,
                     isOptional: false,
-                    maybeType: Ast.PrimitiveTypeConstantKind.Function,
+                    maybeType: Constant.PrimitiveTypeConstantKind.Function,
                 },
                 {
                     identifier: "d",
@@ -1335,7 +1335,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                     nameNodeId: 35,
                     isNullable: false,
                     isOptional: true,
-                    maybeType: Ast.PrimitiveTypeConstantKind.Table,
+                    maybeType: Constant.PrimitiveTypeConstantKind.Table,
                 },
             ];
             const actual: ReadonlyArray<TAbridgedNodeScopeItem> = abridgedParametersFactory(

--- a/src/test/libraryTest/lexer/common.ts
+++ b/src/test/libraryTest/lexer/common.ts
@@ -2,30 +2,30 @@
 // Licensed under the MIT license.
 
 import { expect } from "chai";
-import { Language } from "../../..";
 import { Assert } from "../../../common";
+import { Comment, Token } from "../../../language";
 import { Lexer, LexerSnapshot, TriedLexerSnapshot } from "../../../lexer";
 import { DefaultSettings } from "../../../settings";
 
-export type AbridgedComments = ReadonlyArray<[Language.CommentKind, string]>;
+export type AbridgedComments = ReadonlyArray<[Comment.CommentKind, string]>;
 
-export type AbridgedTokens = ReadonlyArray<[Language.TokenKind, string]>;
+export type AbridgedTokens = ReadonlyArray<[Token.TokenKind, string]>;
 
 export interface AbridgedSnapshot {
     readonly tokens: AbridgedTokens;
     readonly comments: AbridgedComments;
 }
 
-export type AbridgedLineTokens = ReadonlyArray<[Language.LineTokenKind, string]>;
+export type AbridgedLineTokens = ReadonlyArray<[Token.LineTokenKind, string]>;
 
 export function assertAbridgedSnapshotMatch(text: string, expected: AbridgedSnapshot, wrapped: boolean): LexerSnapshot {
     if (wrapped) {
         const wrappedText: string = `wrapperOpen\n${text}\nwrapperClose`;
         const wrappedExpected: AbridgedSnapshot = {
             tokens: [
-                [Language.TokenKind.Identifier, "wrapperOpen"],
+                [Token.TokenKind.Identifier, "wrapperOpen"],
                 ...expected.tokens,
-                [Language.TokenKind.Identifier, "wrapperClose"],
+                [Token.TokenKind.Identifier, "wrapperClose"],
             ],
             comments: expected.comments,
         };
@@ -48,16 +48,16 @@ export function assertLineTokenMatch(text: string, expected: AbridgedLineTokens,
     if (wrapped) {
         const wrappedText: string = `wrapperOpen\n${text}\nwrapperClose`;
         const wrappedExpected: AbridgedLineTokens = [
-            [Language.LineTokenKind.Identifier, "wrapperOpen"],
+            [Token.LineTokenKind.Identifier, "wrapperOpen"],
             ...expected,
-            [Language.LineTokenKind.Identifier, "wrapperClose"],
+            [Token.LineTokenKind.Identifier, "wrapperClose"],
         ];
         assertLineTokenMatch(wrappedText, wrappedExpected, false);
     }
 
     const state: Lexer.State = assertLexOk(text);
 
-    const tmp: [Language.LineTokenKind, string][] = [];
+    const tmp: [Token.LineTokenKind, string][] = [];
     for (const line of state.lines) {
         for (const token of line.tokens) {
             tmp.push([token.kind, token.data]);

--- a/src/test/libraryTest/lexer/multilineTokens.ts
+++ b/src/test/libraryTest/lexer/multilineTokens.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import "mocha";
-import { Language } from "../../..";
+import { Comment, Token } from "../../../language";
 import {
     AbridgedComments,
     AbridgedLineTokens,
@@ -21,21 +21,21 @@ describe(`Lexer`, () => {
         describe(`MultilineComment`, () => {
             it(`/**/`, () => {
                 const text: string = `/**/`;
-                const expected: AbridgedLineTokens = [[Language.LineTokenKind.MultilineComment, `/**/`]];
+                const expected: AbridgedLineTokens = [[Token.LineTokenKind.MultilineComment, `/**/`]];
                 assertLineTokenMatch(text, expected, true);
             });
 
             it(`/*/*/`, () => {
                 const text: string = `/*/*/`;
-                const expected: AbridgedLineTokens = [[Language.LineTokenKind.MultilineComment, `/*/*/`]];
+                const expected: AbridgedLineTokens = [[Token.LineTokenKind.MultilineComment, `/*/*/`]];
                 assertLineTokenMatch(text, expected, true);
             });
 
             it(`/*\\n*/`, () => {
                 const text: string = `/*${LINE_TERMINATOR}*/`;
                 const expected: AbridgedLineTokens = [
-                    [Language.LineTokenKind.MultilineCommentStart, `/*`],
-                    [Language.LineTokenKind.MultilineCommentEnd, `*/`],
+                    [Token.LineTokenKind.MultilineCommentStart, `/*`],
+                    [Token.LineTokenKind.MultilineCommentEnd, `*/`],
                 ];
                 assertLineTokenMatch(text, expected, true);
             });
@@ -43,9 +43,9 @@ describe(`Lexer`, () => {
             it(`/*\\nfoobar\\n*/`, () => {
                 const text: string = `/*${LINE_TERMINATOR}foobar${LINE_TERMINATOR}*/`;
                 const expected: AbridgedLineTokens = [
-                    [Language.LineTokenKind.MultilineCommentStart, `/*`],
-                    [Language.LineTokenKind.MultilineCommentContent, `foobar`],
-                    [Language.LineTokenKind.MultilineCommentEnd, `*/`],
+                    [Token.LineTokenKind.MultilineCommentStart, `/*`],
+                    [Token.LineTokenKind.MultilineCommentContent, `foobar`],
+                    [Token.LineTokenKind.MultilineCommentEnd, `*/`],
                 ];
                 assertLineTokenMatch(text, expected, true);
             });
@@ -53,9 +53,9 @@ describe(`Lexer`, () => {
             it(`/*\\n\nfoobar\\n\\n*/`, () => {
                 const text: string = `/*${LINE_TERMINATOR}${LINE_TERMINATOR}foobar${LINE_TERMINATOR}${LINE_TERMINATOR}*/`;
                 const expected: AbridgedLineTokens = [
-                    [Language.LineTokenKind.MultilineCommentStart, `/*`],
-                    [Language.LineTokenKind.MultilineCommentContent, `foobar`],
-                    [Language.LineTokenKind.MultilineCommentEnd, `*/`],
+                    [Token.LineTokenKind.MultilineCommentStart, `/*`],
+                    [Token.LineTokenKind.MultilineCommentContent, `foobar`],
+                    [Token.LineTokenKind.MultilineCommentEnd, `*/`],
                 ];
                 assertLineTokenMatch(text, expected, true);
             });
@@ -64,15 +64,15 @@ describe(`Lexer`, () => {
         describe(`TextLiteral`, () => {
             it(`""`, () => {
                 const text: string = `""`;
-                const expected: AbridgedLineTokens = [[Language.LineTokenKind.TextLiteral, `""`]];
+                const expected: AbridgedLineTokens = [[Token.LineTokenKind.TextLiteral, `""`]];
                 assertLineTokenMatch(text, expected, true);
             });
 
             it(`"\\n"`, () => {
                 const text: string = `"${LINE_TERMINATOR}"`;
                 const expected: AbridgedLineTokens = [
-                    [Language.LineTokenKind.TextLiteralStart, `"`],
-                    [Language.LineTokenKind.TextLiteralEnd, `"`],
+                    [Token.LineTokenKind.TextLiteralStart, `"`],
+                    [Token.LineTokenKind.TextLiteralEnd, `"`],
                 ];
                 assertLineTokenMatch(text, expected, true);
             });
@@ -80,9 +80,9 @@ describe(`Lexer`, () => {
             it(`"\\nfoobar\\n"`, () => {
                 const text: string = `"${LINE_TERMINATOR}foobar${LINE_TERMINATOR}"`;
                 const expected: AbridgedLineTokens = [
-                    [Language.LineTokenKind.TextLiteralStart, `"`],
-                    [Language.LineTokenKind.TextLiteralContent, `foobar`],
-                    [Language.LineTokenKind.TextLiteralEnd, `"`],
+                    [Token.LineTokenKind.TextLiteralStart, `"`],
+                    [Token.LineTokenKind.TextLiteralContent, `foobar`],
+                    [Token.LineTokenKind.TextLiteralEnd, `"`],
                 ];
                 assertLineTokenMatch(text, expected, true);
             });
@@ -91,15 +91,15 @@ describe(`Lexer`, () => {
         describe(`QuotedIdentifer`, () => {
             it(`""`, () => {
                 const text: string = `#""`;
-                const expected: AbridgedLineTokens = [[Language.LineTokenKind.Identifier, `#""`]];
+                const expected: AbridgedLineTokens = [[Token.LineTokenKind.Identifier, `#""`]];
                 assertLineTokenMatch(text, expected, true);
             });
 
             it(`#"\\n"`, () => {
                 const text: string = `#"${LINE_TERMINATOR}"`;
                 const expected: AbridgedLineTokens = [
-                    [Language.LineTokenKind.QuotedIdentifierStart, `#"`],
-                    [Language.LineTokenKind.QuotedIdentifierEnd, `"`],
+                    [Token.LineTokenKind.QuotedIdentifierStart, `#"`],
+                    [Token.LineTokenKind.QuotedIdentifierEnd, `"`],
                 ];
                 assertLineTokenMatch(text, expected, true);
             });
@@ -107,9 +107,9 @@ describe(`Lexer`, () => {
             it(`#"\\nfoobar\\n"`, () => {
                 const text: string = `#"${LINE_TERMINATOR}foobar${LINE_TERMINATOR}"`;
                 const expected: AbridgedLineTokens = [
-                    [Language.LineTokenKind.QuotedIdentifierStart, `#"`],
-                    [Language.LineTokenKind.QuotedIdentifierContent, `foobar`],
-                    [Language.LineTokenKind.QuotedIdentifierEnd, `"`],
+                    [Token.LineTokenKind.QuotedIdentifierStart, `#"`],
+                    [Token.LineTokenKind.QuotedIdentifierContent, `foobar`],
+                    [Token.LineTokenKind.QuotedIdentifierEnd, `"`],
                 ];
                 assertLineTokenMatch(text, expected, true);
             });
@@ -120,26 +120,26 @@ describe(`Lexer`, () => {
         describe(`MultilineComment`, () => {
             it(`/**/`, () => {
                 const text: string = `/**/`;
-                const expected: AbridgedComments = [[Language.CommentKind.Multiline, `/**/`]];
+                const expected: AbridgedComments = [[Comment.CommentKind.Multiline, `/**/`]];
                 assertSnapshotAbridgedComments(text, expected, true);
             });
 
             it(`/* */`, () => {
                 const text: string = `/* */`;
-                const expected: AbridgedComments = [[Language.CommentKind.Multiline, `/* */`]];
+                const expected: AbridgedComments = [[Comment.CommentKind.Multiline, `/* */`]];
                 assertSnapshotAbridgedComments(text, expected, true);
             });
 
             it(`/* X */`, () => {
                 const text: string = `/* X */`;
-                const expected: AbridgedComments = [[Language.CommentKind.Multiline, `/* X */`]];
+                const expected: AbridgedComments = [[Comment.CommentKind.Multiline, `/* X */`]];
                 assertSnapshotAbridgedComments(text, expected, true);
             });
 
             it(`/*X\\nX\\nX*/`, () => {
                 const text: string = `/*X${LINE_TERMINATOR}X${LINE_TERMINATOR}X*/`;
                 const expected: AbridgedComments = [
-                    [Language.CommentKind.Multiline, `/*X${LINE_TERMINATOR}X${LINE_TERMINATOR}X*/`],
+                    [Comment.CommentKind.Multiline, `/*X${LINE_TERMINATOR}X${LINE_TERMINATOR}X*/`],
                 ];
                 assertSnapshotAbridgedComments(text, expected, true);
             });
@@ -147,8 +147,8 @@ describe(`Lexer`, () => {
             it(`abc /*X\\nX\\nX*/`, () => {
                 const text: string = `abc /*X${LINE_TERMINATOR}X${LINE_TERMINATOR}X*/`;
                 const expected: AbridgedSnapshot = {
-                    comments: [[Language.CommentKind.Multiline, `/*X${LINE_TERMINATOR}X${LINE_TERMINATOR}X*/`]],
-                    tokens: [[Language.TokenKind.Identifier, `abc`]],
+                    comments: [[Comment.CommentKind.Multiline, `/*X${LINE_TERMINATOR}X${LINE_TERMINATOR}X*/`]],
+                    tokens: [[Token.TokenKind.Identifier, `abc`]],
                 };
                 assertAbridgedSnapshotMatch(text, expected, true);
             });
@@ -156,8 +156,8 @@ describe(`Lexer`, () => {
             it(`/*X\\nX\\nX*/ abc`, () => {
                 const text: string = `/*X${LINE_TERMINATOR}X${LINE_TERMINATOR}X*/ abc`;
                 const expected: AbridgedSnapshot = {
-                    tokens: [[Language.TokenKind.Identifier, `abc`]],
-                    comments: [[Language.CommentKind.Multiline, `/*X${LINE_TERMINATOR}X${LINE_TERMINATOR}X*/`]],
+                    tokens: [[Token.TokenKind.Identifier, `abc`]],
+                    comments: [[Comment.CommentKind.Multiline, `/*X${LINE_TERMINATOR}X${LINE_TERMINATOR}X*/`]],
                 };
                 assertAbridgedSnapshotMatch(text, expected, true);
             });
@@ -166,14 +166,14 @@ describe(`Lexer`, () => {
         describe(`TextLiteral`, () => {
             it(`"X"`, () => {
                 const text: string = `"X"`;
-                const expected: AbridgedTokens = [[Language.TokenKind.TextLiteral, `"X"`]];
+                const expected: AbridgedTokens = [[Token.TokenKind.TextLiteral, `"X"`]];
                 assertSnapshotAbridgedTokens(text, expected, true);
             });
 
             it(`"X\\nX\\nX"`, () => {
                 const text: string = `"X${LINE_TERMINATOR}X${LINE_TERMINATOR}X"`;
                 const expected: AbridgedTokens = [
-                    [Language.TokenKind.TextLiteral, `"X${LINE_TERMINATOR}X${LINE_TERMINATOR}X"`],
+                    [Token.TokenKind.TextLiteral, `"X${LINE_TERMINATOR}X${LINE_TERMINATOR}X"`],
                 ];
                 assertSnapshotAbridgedTokens(text, expected, true);
             });
@@ -181,8 +181,8 @@ describe(`Lexer`, () => {
             it(`abc "X\\nX\\nX"`, () => {
                 const text: string = `abc "X${LINE_TERMINATOR}X${LINE_TERMINATOR}X"`;
                 const expected: AbridgedTokens = [
-                    [Language.TokenKind.Identifier, `abc`],
-                    [Language.TokenKind.TextLiteral, `"X${LINE_TERMINATOR}X${LINE_TERMINATOR}X"`],
+                    [Token.TokenKind.Identifier, `abc`],
+                    [Token.TokenKind.TextLiteral, `"X${LINE_TERMINATOR}X${LINE_TERMINATOR}X"`],
                 ];
                 assertSnapshotAbridgedTokens(text, expected, true);
             });
@@ -190,8 +190,8 @@ describe(`Lexer`, () => {
             it(`"X\\nX\\nX" abc`, () => {
                 const text: string = `"X${LINE_TERMINATOR}X${LINE_TERMINATOR}X" abc`;
                 const expected: AbridgedTokens = [
-                    [Language.TokenKind.TextLiteral, `"X${LINE_TERMINATOR}X${LINE_TERMINATOR}X"`],
-                    [Language.TokenKind.Identifier, `abc`],
+                    [Token.TokenKind.TextLiteral, `"X${LINE_TERMINATOR}X${LINE_TERMINATOR}X"`],
+                    [Token.TokenKind.Identifier, `abc`],
                 ];
                 assertSnapshotAbridgedTokens(text, expected, true);
             });

--- a/src/test/libraryTest/lexer/simple.ts
+++ b/src/test/libraryTest/lexer/simple.ts
@@ -3,7 +3,7 @@
 
 import { expect } from "chai";
 import "mocha";
-import { Language } from "../../..";
+import { Keyword, Token } from "../../../language";
 import { assertSnapshotAbridgedTokens } from "./common";
 
 describe(`Lexer.Simple.TokenKinds`, () => {
@@ -11,9 +11,9 @@ describe(`Lexer.Simple.TokenKinds`, () => {
         const text: string = `
 0x1
 0X1`;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [
-            [Language.TokenKind.HexLiteral, `0x1`],
-            [Language.TokenKind.HexLiteral, `0X1`],
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [
+            [Token.TokenKind.HexLiteral, `0x1`],
+            [Token.TokenKind.HexLiteral, `0X1`],
         ];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
@@ -51,46 +51,46 @@ type
 #shared
 #table
 #time`;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [
-            [Language.TokenKind.KeywordAnd, `and`],
-            [Language.TokenKind.KeywordAs, `as`],
-            [Language.TokenKind.KeywordEach, `each`],
-            [Language.TokenKind.KeywordElse, `else`],
-            [Language.TokenKind.KeywordError, `error`],
-            [Language.TokenKind.KeywordFalse, `false`],
-            [Language.TokenKind.KeywordIf, `if`],
-            [Language.TokenKind.KeywordIn, `in`],
-            [Language.TokenKind.KeywordIs, `is`],
-            [Language.TokenKind.KeywordLet, `let`],
-            [Language.TokenKind.KeywordMeta, `meta`],
-            [Language.TokenKind.KeywordNot, `not`],
-            [Language.TokenKind.KeywordOtherwise, `otherwise`],
-            [Language.TokenKind.KeywordOr, `or`],
-            [Language.TokenKind.KeywordSection, `section`],
-            [Language.TokenKind.KeywordShared, `shared`],
-            [Language.TokenKind.KeywordThen, `then`],
-            [Language.TokenKind.KeywordTrue, `true`],
-            [Language.TokenKind.KeywordTry, `try`],
-            [Language.TokenKind.KeywordType, `type`],
-            [Language.TokenKind.KeywordHashBinary, `#binary`],
-            [Language.TokenKind.KeywordHashDate, `#date`],
-            [Language.TokenKind.KeywordHashDateTime, `#datetime`],
-            [Language.TokenKind.KeywordHashDateTimeZone, `#datetimezone`],
-            [Language.TokenKind.KeywordHashDuration, `#duration`],
-            [Language.TokenKind.KeywordHashInfinity, `#infinity`],
-            [Language.TokenKind.KeywordHashNan, `#nan`],
-            [Language.TokenKind.KeywordHashSections, `#sections`],
-            [Language.TokenKind.KeywordHashShared, `#shared`],
-            [Language.TokenKind.KeywordHashTable, `#table`],
-            [Language.TokenKind.KeywordHashTime, `#time`],
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [
+            [Token.TokenKind.KeywordAnd, `and`],
+            [Token.TokenKind.KeywordAs, `as`],
+            [Token.TokenKind.KeywordEach, `each`],
+            [Token.TokenKind.KeywordElse, `else`],
+            [Token.TokenKind.KeywordError, `error`],
+            [Token.TokenKind.KeywordFalse, `false`],
+            [Token.TokenKind.KeywordIf, `if`],
+            [Token.TokenKind.KeywordIn, `in`],
+            [Token.TokenKind.KeywordIs, `is`],
+            [Token.TokenKind.KeywordLet, `let`],
+            [Token.TokenKind.KeywordMeta, `meta`],
+            [Token.TokenKind.KeywordNot, `not`],
+            [Token.TokenKind.KeywordOtherwise, `otherwise`],
+            [Token.TokenKind.KeywordOr, `or`],
+            [Token.TokenKind.KeywordSection, `section`],
+            [Token.TokenKind.KeywordShared, `shared`],
+            [Token.TokenKind.KeywordThen, `then`],
+            [Token.TokenKind.KeywordTrue, `true`],
+            [Token.TokenKind.KeywordTry, `try`],
+            [Token.TokenKind.KeywordType, `type`],
+            [Token.TokenKind.KeywordHashBinary, `#binary`],
+            [Token.TokenKind.KeywordHashDate, `#date`],
+            [Token.TokenKind.KeywordHashDateTime, `#datetime`],
+            [Token.TokenKind.KeywordHashDateTimeZone, `#datetimezone`],
+            [Token.TokenKind.KeywordHashDuration, `#duration`],
+            [Token.TokenKind.KeywordHashInfinity, `#infinity`],
+            [Token.TokenKind.KeywordHashNan, `#nan`],
+            [Token.TokenKind.KeywordHashSections, `#sections`],
+            [Token.TokenKind.KeywordHashShared, `#shared`],
+            [Token.TokenKind.KeywordHashTable, `#table`],
+            [Token.TokenKind.KeywordHashTime, `#time`],
         ];
-        expect(expected.length).to.equal(Language.Keyword.KeywordKinds.length);
+        expect(expected.length).to.equal(Keyword.KeywordKinds.length);
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 
     it(`NullLiteral`, () => {
         const text: string = `null`;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [[Language.TokenKind.NullLiteral, `null`]];
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [[Token.TokenKind.NullLiteral, `null`]];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 
@@ -108,19 +108,19 @@ type
 0.1e1
 0.1e-1
 0.1e+1`;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [
-            [Language.TokenKind.NumericLiteral, `1`],
-            [Language.TokenKind.NumericLiteral, `1e1`],
-            [Language.TokenKind.NumericLiteral, `1e-1`],
-            [Language.TokenKind.NumericLiteral, `1e+1`],
-            [Language.TokenKind.NumericLiteral, `.1`],
-            [Language.TokenKind.NumericLiteral, `.1e1`],
-            [Language.TokenKind.NumericLiteral, `.1e-1`],
-            [Language.TokenKind.NumericLiteral, `.1e+1`],
-            [Language.TokenKind.NumericLiteral, `0.1`],
-            [Language.TokenKind.NumericLiteral, `0.1e1`],
-            [Language.TokenKind.NumericLiteral, `0.1e-1`],
-            [Language.TokenKind.NumericLiteral, `0.1e+1`],
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [
+            [Token.TokenKind.NumericLiteral, `1`],
+            [Token.TokenKind.NumericLiteral, `1e1`],
+            [Token.TokenKind.NumericLiteral, `1e-1`],
+            [Token.TokenKind.NumericLiteral, `1e+1`],
+            [Token.TokenKind.NumericLiteral, `.1`],
+            [Token.TokenKind.NumericLiteral, `.1e1`],
+            [Token.TokenKind.NumericLiteral, `.1e-1`],
+            [Token.TokenKind.NumericLiteral, `.1e+1`],
+            [Token.TokenKind.NumericLiteral, `0.1`],
+            [Token.TokenKind.NumericLiteral, `0.1e1`],
+            [Token.TokenKind.NumericLiteral, `0.1e-1`],
+            [Token.TokenKind.NumericLiteral, `0.1e+1`],
         ];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
@@ -152,32 +152,32 @@ type
 =>
 ..
 ...`;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [
-            [Language.TokenKind.Comma, `,`],
-            [Language.TokenKind.Semicolon, `;`],
-            [Language.TokenKind.Equal, `=`],
-            [Language.TokenKind.LessThan, `<`],
-            [Language.TokenKind.LessThanEqualTo, `<=`],
-            [Language.TokenKind.GreaterThan, `>`],
-            [Language.TokenKind.GreaterThanEqualTo, `>=`],
-            [Language.TokenKind.NotEqual, `<>`],
-            [Language.TokenKind.Plus, `+`],
-            [Language.TokenKind.Minus, `-`],
-            [Language.TokenKind.Asterisk, `*`],
-            [Language.TokenKind.Division, `/`],
-            [Language.TokenKind.Ampersand, `&`],
-            [Language.TokenKind.LeftParenthesis, `(`],
-            [Language.TokenKind.RightParenthesis, `)`],
-            [Language.TokenKind.LeftBracket, `[`],
-            [Language.TokenKind.RightBracket, `]`],
-            [Language.TokenKind.LeftBrace, `{`],
-            [Language.TokenKind.RightBrace, `}`],
-            [Language.TokenKind.AtSign, `@`],
-            [Language.TokenKind.QuestionMark, `?`],
-            [Language.TokenKind.NullCoalescingOperator, `??`],
-            [Language.TokenKind.FatArrow, `=>`],
-            [Language.TokenKind.DotDot, `..`],
-            [Language.TokenKind.Ellipsis, `...`],
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [
+            [Token.TokenKind.Comma, `,`],
+            [Token.TokenKind.Semicolon, `;`],
+            [Token.TokenKind.Equal, `=`],
+            [Token.TokenKind.LessThan, `<`],
+            [Token.TokenKind.LessThanEqualTo, `<=`],
+            [Token.TokenKind.GreaterThan, `>`],
+            [Token.TokenKind.GreaterThanEqualTo, `>=`],
+            [Token.TokenKind.NotEqual, `<>`],
+            [Token.TokenKind.Plus, `+`],
+            [Token.TokenKind.Minus, `-`],
+            [Token.TokenKind.Asterisk, `*`],
+            [Token.TokenKind.Division, `/`],
+            [Token.TokenKind.Ampersand, `&`],
+            [Token.TokenKind.LeftParenthesis, `(`],
+            [Token.TokenKind.RightParenthesis, `)`],
+            [Token.TokenKind.LeftBracket, `[`],
+            [Token.TokenKind.RightBracket, `]`],
+            [Token.TokenKind.LeftBrace, `{`],
+            [Token.TokenKind.RightBrace, `}`],
+            [Token.TokenKind.AtSign, `@`],
+            [Token.TokenKind.QuestionMark, `?`],
+            [Token.TokenKind.NullCoalescingOperator, `??`],
+            [Token.TokenKind.FatArrow, `=>`],
+            [Token.TokenKind.DotDot, `..`],
+            [Token.TokenKind.Ellipsis, `...`],
         ];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
@@ -187,9 +187,9 @@ type
 ""
 """"
 `;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [
-            [Language.TokenKind.TextLiteral, `""`],
-            [Language.TokenKind.TextLiteral, `""""`],
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [
+            [Token.TokenKind.TextLiteral, `""`],
+            [Token.TokenKind.TextLiteral, `""""`],
         ];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
@@ -198,61 +198,61 @@ type
 describe(`Lexer.Simple.Whitespace`, () => {
     it(`only whitespace`, () => {
         const text: string = `  `;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [];
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 
     it(`spaces`, () => {
         const text: string = ` a b `;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [
-            [Language.TokenKind.Identifier, `a`],
-            [Language.TokenKind.Identifier, `b`],
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [
+            [Token.TokenKind.Identifier, `a`],
+            [Token.TokenKind.Identifier, `b`],
         ];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 
     it(`tabs`, () => {
         const text: string = `\ta\tb\t`;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [
-            [Language.TokenKind.Identifier, `a`],
-            [Language.TokenKind.Identifier, `b`],
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [
+            [Token.TokenKind.Identifier, `a`],
+            [Token.TokenKind.Identifier, `b`],
         ];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 
     it(`trailing \\n`, () => {
         const text: string = `a\n`;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [[Language.TokenKind.Identifier, `a`]];
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [[Token.TokenKind.Identifier, `a`]];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 
     it(`trailing \\r\\n`, () => {
         const text: string = `a\r\n`;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [[Language.TokenKind.Identifier, `a`]];
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [[Token.TokenKind.Identifier, `a`]];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 
     it(`trailing space`, () => {
         const text: string = `a `;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [[Language.TokenKind.Identifier, `a`]];
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [[Token.TokenKind.Identifier, `a`]];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 
     it(`leading \\n`, () => {
         const text: string = `\na`;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [[Language.TokenKind.Identifier, `a`]];
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [[Token.TokenKind.Identifier, `a`]];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 
     it(`leading \\r\\n`, () => {
         const text: string = `\r\na`;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [[Language.TokenKind.Identifier, `a`]];
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [[Token.TokenKind.Identifier, `a`]];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 
     it(`leading space`, () => {
         const text: string = ` a`;
-        const expected: ReadonlyArray<[Language.TokenKind, string]> = [[Language.TokenKind.Identifier, `a`]];
+        const expected: ReadonlyArray<[Token.TokenKind, string]> = [[Token.TokenKind.Identifier, `a`]];
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 });

--- a/src/test/libraryTest/lexer/simple.ts
+++ b/src/test/libraryTest/lexer/simple.ts
@@ -84,7 +84,7 @@ type
             [Language.TokenKind.KeywordHashTable, `#table`],
             [Language.TokenKind.KeywordHashTime, `#time`],
         ];
-        expect(expected.length).to.equal(Language.Keywords.length);
+        expect(expected.length).to.equal(Language.Keyword.KeywordKinds.length);
         assertSnapshotAbridgedTokens(text, expected, true);
     });
 

--- a/src/test/libraryTest/parser/simple.ts
+++ b/src/test/libraryTest/parser/simple.ts
@@ -5,7 +5,7 @@ import { expect } from "chai";
 import "mocha";
 import { Task } from "../../..";
 import { Assert, Traverse } from "../../../common";
-import { Ast } from "../../../language";
+import { Ast, Constant } from "../../../language";
 import { DefaultTemplates } from "../../../localization";
 import { IParser, IParserState, IParserStateUtils } from "../../../parser";
 import { RecursiveDescentParser } from "../../../parser/parsers";
@@ -138,7 +138,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperatorKind.And);
+            expect(operatorNode.constantKind).to.equal(Constant.ArithmeticOperatorKind.And);
         });
 
         it(`1 * 2`, () => {
@@ -152,7 +152,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperatorKind.Multiplication);
+            expect(operatorNode.constantKind).to.equal(Constant.ArithmeticOperatorKind.Multiplication);
         });
 
         it(`1 / 2`, () => {
@@ -166,7 +166,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperatorKind.Division);
+            expect(operatorNode.constantKind).to.equal(Constant.ArithmeticOperatorKind.Division);
         });
 
         it(`1 + 2`, () => {
@@ -180,7 +180,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperatorKind.Addition);
+            expect(operatorNode.constantKind).to.equal(Constant.ArithmeticOperatorKind.Addition);
         });
 
         it(`1 - 2`, () => {
@@ -194,7 +194,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.ArithmeticOperatorKind.Subtraction);
+            expect(operatorNode.constantKind).to.equal(Constant.ArithmeticOperatorKind.Subtraction);
         });
 
         it(`1 + 2 + 3 + 4`, () => {
@@ -281,7 +281,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.EqualityOperatorKind.EqualTo);
+            expect(operatorNode.constantKind).to.equal(Constant.EqualityOperatorKind.EqualTo);
         });
 
         it(`1 <> 2`, () => {
@@ -295,7 +295,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.EqualityOperatorKind.NotEqualTo);
+            expect(operatorNode.constantKind).to.equal(Constant.EqualityOperatorKind.NotEqualTo);
         });
     });
 
@@ -1434,7 +1434,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperatorKind.GreaterThan);
+            expect(operatorNode.constantKind).to.equal(Constant.RelationalOperatorKind.GreaterThan);
         });
 
         it(`1 >= 2`, () => {
@@ -1448,7 +1448,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperatorKind.GreaterThanEqualTo);
+            expect(operatorNode.constantKind).to.equal(Constant.RelationalOperatorKind.GreaterThanEqualTo);
         });
 
         it(`1 < 2`, () => {
@@ -1462,7 +1462,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperatorKind.LessThan);
+            expect(operatorNode.constantKind).to.equal(Constant.RelationalOperatorKind.LessThan);
         });
 
         it(`1 <= 2`, () => {
@@ -1476,7 +1476,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.RelationalOperatorKind.LessThanEqualTo);
+            expect(operatorNode.constantKind).to.equal(Constant.RelationalOperatorKind.LessThanEqualTo);
         });
     });
 
@@ -1668,7 +1668,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperatorKind.Negative);
+            expect(operatorNode.constantKind).to.equal(Constant.UnaryOperatorKind.Negative);
         });
 
         it(`not 1`, () => {
@@ -1682,7 +1682,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperatorKind.Not);
+            expect(operatorNode.constantKind).to.equal(Constant.UnaryOperatorKind.Not);
         });
 
         it(`+1`, () => {
@@ -1696,7 +1696,7 @@ describe("Parser.AbridgedNode", () => {
             assertAbridgeNodes(text, expected);
 
             const operatorNode: Ast.TConstant = assertNthNodeOfKind<Ast.TConstant>(text, Ast.NodeKind.Constant, 1);
-            expect(operatorNode.constantKind).to.equal(Ast.UnaryOperatorKind.Positive);
+            expect(operatorNode.constantKind).to.equal(Constant.UnaryOperatorKind.Positive);
         });
     });
 });

--- a/src/test/libraryTest/tokenizer/common.ts
+++ b/src/test/libraryTest/tokenizer/common.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import { Language } from "../../..";
+import { Assert } from "../../../common";
 import { Lexer } from "../../../lexer";
 import { DefaultTemplates } from "../../../localization";
-import { Assert } from "../../../common";
 
 export class Tokenizer implements TokensProvider {
     constructor(private readonly lineTerminator: string) {}

--- a/src/test/libraryTest/tokenizer/common.ts
+++ b/src/test/libraryTest/tokenizer/common.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Language } from "../../..";
 import { Assert } from "../../../common";
+import { Token } from "../../../language";
 import { Lexer } from "../../../lexer";
 import { DefaultTemplates } from "../../../localization";
 
@@ -10,7 +10,7 @@ export class Tokenizer implements TokensProvider {
     constructor(private readonly lineTerminator: string) {}
 
     // tslint:disable-next-line: function-name
-    public static ITokenFrom(lineToken: Language.LineToken): IToken {
+    public static ITokenFrom(lineToken: Token.LineToken): IToken {
         // UNSAFE MARKER
         //
         // Purpose of code block:

--- a/src/test/resourceTest/benchmarkParser.ts
+++ b/src/test/resourceTest/benchmarkParser.ts
@@ -4,8 +4,7 @@
 // tslint:disable-next-line: no-require-imports
 import performanceNow = require("performance-now");
 
-import { Language } from "../..";
-import { Ast } from "../../language";
+import { Ast, Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 import { IParser } from "../../parser/IParser";
 import { IParserState, IParserStateUtils } from "../../parser/IParserState";
@@ -319,7 +318,7 @@ function functionEntry<S extends IParserState, T>(
     state: BenchmarkState,
     fn: (state: S, parser: IParser<S>) => T,
 ): number {
-    const tokenPosition: Language.TokenPosition = state.maybeCurrentToken!.positionStart;
+    const tokenPosition: Token.TokenPosition = state.maybeCurrentToken!.positionStart;
     const id: number = state.functionTimestampCounter;
     state.functionTimestampCounter += 1;
 
@@ -342,7 +341,7 @@ function functionEntry<S extends IParserState, T>(
 }
 
 function functionExit(state: BenchmarkState, id: number): void {
-    const tokenPosition: Language.TokenPosition = state.maybeCurrentToken!.positionStart;
+    const tokenPosition: Token.TokenPosition = state.maybeCurrentToken!.positionStart;
     const fnTimestamp: FunctionTimestamp = state.functionTimestamps.get(id)!;
     const finish: number = performanceNow();
     const duration: number = finish - fnTimestamp.timeStart;


### PR DESCRIPTION
There was an inconsistency with how Language was exporting things. If you wanted the Token interface it was `Language.IToken`, but if you wanted the IfExpression it was `Language.Ast.IfExpression`. The other weird thing was if you wanted something like an operator constant it was under `Language.Ast.ArithmeticOperatorKind` even though it's not an Ast member.

It's now standardized that Language only exports other namespaces:
![image](https://user-images.githubusercontent.com/17787492/91889976-941b4300-ec43-11ea-996f-f7ce31977db2.png)