### PR TITLE
Add `Kind` suffix to LanguageConstant

### DIFF
--- a/src/language/ast/ast.ts
+++ b/src/language/ast/ast.ts
@@ -264,7 +264,7 @@ export type TIsExpression = IsExpression | TAsExpression;
 export type TNullablePrimitiveType = NullablePrimitiveType | PrimitiveType;
 
 export interface NullablePrimitiveType
-    extends IPairedConstant<NodeKind.NullablePrimitiveType, Constant.LanguageConstant.Nullable, PrimitiveType> {}
+    extends IPairedConstant<NodeKind.NullablePrimitiveType, Constant.LanguageConstantKind.Nullable, PrimitiveType> {}
 
 export interface IsNullablePrimitiveType
     extends IPairedConstant<
@@ -515,7 +515,7 @@ export interface FunctionType extends INode {
 export interface ListType extends IBraceWrapped<NodeKind.ListType, TType> {}
 
 export interface NullableType
-    extends IPairedConstant<NodeKind.NullableType, Constant.LanguageConstant.Nullable, TType> {}
+    extends IPairedConstant<NodeKind.NullableType, Constant.LanguageConstantKind.Nullable, TType> {}
 
 export interface RecordType extends INode {
     readonly kind: NodeKind.RecordType;
@@ -766,7 +766,7 @@ export interface IParameterList<T extends TParameterType>
 export interface IParameter<T extends TParameterType> extends INode {
     readonly kind: NodeKind.Parameter;
     readonly isLeaf: false;
-    readonly maybeOptionalConstant: IConstant<Constant.LanguageConstant.Optional> | undefined;
+    readonly maybeOptionalConstant: IConstant<Constant.LanguageConstantKind.Optional> | undefined;
     readonly name: Identifier;
     readonly maybeParameterType: T;
 }
@@ -817,7 +817,7 @@ export interface NullCoalescingExpression
 export interface FieldSpecification extends INode {
     readonly kind: NodeKind.FieldSpecification;
     readonly isLeaf: false;
-    readonly maybeOptionalConstant: IConstant<Constant.LanguageConstant.Optional> | undefined;
+    readonly maybeOptionalConstant: IConstant<Constant.LanguageConstantKind.Optional> | undefined;
     readonly name: GeneralizedIdentifier;
     readonly maybeFieldTypeSpecification: FieldTypeSpecification | undefined;
 }

--- a/src/language/constant/constant.ts
+++ b/src/language/constant/constant.ts
@@ -5,7 +5,7 @@ export type TConstantKind =
     | ArithmeticOperatorKind
     | EqualityOperatorKind
     | KeywordConstantKind
-    | LanguageConstant
+    | LanguageConstantKind
     | LogicalOperatorKind
     | MiscConstantKind
     | PrimitiveTypeConstantKind
@@ -27,7 +27,7 @@ export type TBinOpExpressionOperator =
 // ---------- const enums ----------
 // ---------------------------------
 
-export const enum LanguageConstant {
+export const enum LanguageConstantKind {
     Nullable = "nullable",
     Optional = "optional",
 }

--- a/src/language/constant/constantUtils.ts
+++ b/src/language/constant/constantUtils.ts
@@ -181,8 +181,8 @@ export function isPrimitiveTypeConstantKind(
     maybePrimitiveTypeConstantKind: string,
 ): maybePrimitiveTypeConstantKind is Constant.PrimitiveTypeConstantKind {
     switch (maybePrimitiveTypeConstantKind) {
-        case Constant.LanguageConstant.Nullable:
-        case Constant.LanguageConstant.Optional:
+        case Constant.LanguageConstantKind.Nullable:
+        case Constant.LanguageConstantKind.Optional:
         case Constant.PrimitiveTypeConstantKind.Any:
         case Constant.PrimitiveTypeConstantKind.AnyNonNull:
         case Constant.PrimitiveTypeConstantKind.Binary:

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -442,11 +442,11 @@ export function readNullablePrimitiveType<S extends IParserState = IParserState>
 ): Ast.TNullablePrimitiveType {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    if (IParserStateUtils.isOnConstantKind(state, Constant.LanguageConstant.Nullable)) {
+    if (IParserStateUtils.isOnConstantKind(state, Constant.LanguageConstantKind.Nullable)) {
         return readPairedConstant(
             state,
             Ast.NodeKind.NullablePrimitiveType,
-            () => readConstantKind(state, Constant.LanguageConstant.Nullable),
+            () => readConstantKind(state, Constant.LanguageConstantKind.Nullable),
             () => parser.readPrimitiveType(state, parser),
         );
     } else {
@@ -1468,8 +1468,8 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
             IParserStateUtils.startContext(state, fieldSpecificationNodeKind);
 
             const maybeOptionalConstant:
-                | Ast.IConstant<Constant.LanguageConstant.Optional>
-                | undefined = maybeReadConstantKind(state, Constant.LanguageConstant.Optional);
+                | Ast.IConstant<Constant.LanguageConstantKind.Optional>
+                | undefined = maybeReadConstantKind(state, Constant.LanguageConstantKind.Optional);
 
             const name: Ast.GeneralizedIdentifier = parser.readGeneralizedIdentifier(state, parser);
 
@@ -1650,7 +1650,7 @@ function tryReadPrimaryType<S extends IParserState = IParserState>(state: S, par
         return ResultUtils.okFactory(parser.readTableType(state, parser));
     } else if (isFunctionTypeNext) {
         return ResultUtils.okFactory(parser.readFunctionType(state, parser));
-    } else if (IParserStateUtils.isOnConstantKind(state, Constant.LanguageConstant.Nullable)) {
+    } else if (IParserStateUtils.isOnConstantKind(state, Constant.LanguageConstantKind.Nullable)) {
         return ResultUtils.okFactory(parser.readNullableType(state, parser));
     } else {
         const stateBackup: IParserStateUtils.FastStateBackup = IParserStateUtils.fastStateBackup(state);
@@ -1681,7 +1681,7 @@ export function readNullableType<S extends IParserState = IParserState>(
     return readPairedConstant(
         state,
         Ast.NodeKind.NullableType,
-        () => readConstantKind(state, Constant.LanguageConstant.Nullable),
+        () => readConstantKind(state, Constant.LanguageConstantKind.Nullable),
         () => parser.readType(state, parser),
     );
 }
@@ -2393,8 +2393,8 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
         }
 
         const maybeOptionalConstant:
-            | Ast.IConstant<Constant.LanguageConstant.Optional>
-            | undefined = maybeReadConstantKind(state, Constant.LanguageConstant.Optional);
+            | Ast.IConstant<Constant.LanguageConstantKind.Optional>
+            | undefined = maybeReadConstantKind(state, Constant.LanguageConstantKind.Optional);
 
         if (reachedOptionalParameter && !maybeOptionalConstant) {
             const token: Token.Token = IParserStateUtils.assertGetTokenAt(state, state.tokenIndex);


### PR DESCRIPTION
It's probably needless boilerplate, but it continues the existing naming conventions.