### PR TITLE
Standardize locale over ILocalizationTemplates

### DIFF
--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Assert } from ".";
-import { Localization, Templates } from "../localization";
+import { Localization, LocalizationUtils, Templates } from "../localization";
 import { ICancellationToken } from "./cancellationToken/ICancellationToken";
 
 export type TInnerCommonError = CancellationError | InvariantError | UnknownError;
@@ -29,8 +29,8 @@ export class InvariantError extends Error {
 }
 
 export class UnknownError extends Error {
-    constructor(templates: Templates.ILocalizationTemplates, readonly innerError: any) {
-        super(Localization.error_common_unknown(templates, innerError));
+    constructor(locale: string, readonly innerError: any) {
+        super(Localization.error_common_unknown(LocalizationUtils.getLocalizationTemplates(locale), innerError));
         Object.setPrototypeOf(this, UnknownError.prototype);
     }
 }
@@ -48,12 +48,12 @@ export function isTInnerCommonError(x: any): x is TInnerCommonError {
     return x instanceof CancellationError || x instanceof InvariantError || x instanceof UnknownError;
 }
 
-export function ensureCommonError(templates: Templates.ILocalizationTemplates, err: Error): CommonError {
+export function ensureCommonError(locale: string, err: Error): CommonError {
     if (err instanceof CommonError) {
         return err;
     } else if (isTInnerCommonError(err)) {
         return new CommonError(err);
     } else {
-        return new CommonError(new UnknownError(templates, err));
+        return new CommonError(new UnknownError(locale, err));
     }
 }

--- a/src/common/result/resultUtils.ts
+++ b/src/common/result/resultUtils.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { CommonError } from "..";
-import { Templates } from "../../localization";
 import { Err, Ok, Result, ResultKind } from "./result";
 
 export function okFactory<T>(value: T): Ok<T> {
@@ -27,13 +26,10 @@ export function isErr<T, E>(result: Result<T, E>): result is Err<E> {
     return result.kind === ResultKind.Err;
 }
 
-export function ensureResult<T>(
-    templates: Templates.ILocalizationTemplates,
-    callbackFn: () => T,
-): Result<T, CommonError.CommonError> {
+export function ensureResult<T>(locale: string, callbackFn: () => T): Result<T, CommonError.CommonError> {
     try {
         return okFactory(callbackFn());
     } catch (err) {
-        return errFactory(CommonError.ensureCommonError(templates, err));
+        return errFactory(CommonError.ensureCommonError(locale, err));
     }
 }

--- a/src/common/traversal.ts
+++ b/src/common/traversal.ts
@@ -3,7 +3,6 @@
 
 import { Assert, CommonError, Result } from ".";
 import { Ast } from "../language";
-import { Templates } from "../localization";
 import { NodeIdMap, NodeIdMapUtils, ParseContext, TXorNode, XorNodeKind, XorNodeUtils } from "../parser";
 import { ResultUtils } from "./result";
 
@@ -39,7 +38,7 @@ export const enum VisitNodeStrategy {
 }
 
 export interface IState<T> {
-    readonly localizationTemplates: Templates.ILocalizationTemplates;
+    readonly locale: string;
     result: T;
 }
 
@@ -94,7 +93,7 @@ export function tryTraverse<State extends IState<ResultType>, ResultType, Node, 
     expandNodesFn: TExpandNodesFn<State, ResultType, Node, NodesById>,
     maybeEarlyExitFn: TEarlyExitFn<State, ResultType, Node> | undefined,
 ): TriedTraverse<ResultType> {
-    return ResultUtils.ensureResult(state.localizationTemplates, () => {
+    return ResultUtils.ensureResult(state.locale, () => {
         traverseRecursion<State, ResultType, Node, NodesById>(
             state,
             nodesById,

--- a/src/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -4,7 +4,6 @@
 import { Assert, CommonError, ResultUtils } from "../../common";
 import { Ast, Token, Type } from "../../language";
 import { LexerSnapshot } from "../../lexer";
-import { LocalizationUtils } from "../../localization";
 import {
     IParser,
     IParserState,
@@ -40,7 +39,7 @@ export function tryAutocompleteFieldAccess<S extends IParserState = IParserState
         return ResultUtils.okFactory(undefined);
     }
 
-    return ResultUtils.ensureResult(LocalizationUtils.getLocalizationTemplates(parseSettings.locale), () => {
+    return ResultUtils.ensureResult(parseSettings.locale, () => {
         return autocompleteFieldAccess(parseSettings, parserState, maybeActiveNode, typeCache, maybeParseError);
     });
 }

--- a/src/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
+++ b/src/inspection/autocomplete/autocompleteKeyword/autocompleteKeyword.ts
@@ -3,7 +3,6 @@
 
 import { ArrayUtils, ResultUtils } from "../../../common";
 import { Ast, Keyword, Token } from "../../../language";
-import { LocalizationUtils } from "../../../localization";
 import { NodeIdMap, TXorNode, XorNodeKind, XorNodeUtils } from "../../../parser";
 import { CommonSettings } from "../../../settings";
 import { ActiveNode, ActiveNodeLeafKind, ActiveNodeUtils, TMaybeActiveNode } from "../../activeNode";
@@ -29,7 +28,7 @@ export function tryAutocompleteKeyword(
         return ResultUtils.okFactory([...ExpressionAutocomplete, Keyword.KeywordKind.Section]);
     }
 
-    return ResultUtils.ensureResult(LocalizationUtils.getLocalizationTemplates(settings.locale), () => {
+    return ResultUtils.ensureResult(settings.locale, () => {
         return autocompleteKeyword(nodeIdMapCollection, leafNodeIds, maybeActiveNode, maybeTrailingToken);
     });
 }

--- a/src/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -3,6 +3,7 @@
 
 import { Assert, CommonError, ResultUtils } from "../../common";
 import { Ast, Constant } from "../../language";
+import { LocalizationUtils } from "../../localization";
 import {
     AncestryUtils,
     IParserState,
@@ -23,7 +24,7 @@ export function tryAutocompleteLanguageConstant<S extends IParserState = IParser
     maybeActiveNode: TMaybeActiveNode,
     maybeParseError: ParseError.ParseError | undefined,
 ): TriedAutocompleteLanguageConstant {
-    return ResultUtils.ensureResult(parserState.localizationTemplates, () => {
+    return ResultUtils.ensureResult(LocalizationUtils.getLocalizationTemplates(parseSettings.locale), () => {
         return autocompleteLanguageConstant(parseSettings, parserState, maybeActiveNode, maybeParseError);
     });
 }

--- a/src/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -3,7 +3,6 @@
 
 import { Assert, CommonError, ResultUtils } from "../../common";
 import { Ast, Constant } from "../../language";
-import { LocalizationUtils } from "../../localization";
 import {
     AncestryUtils,
     IParserState,
@@ -24,7 +23,7 @@ export function tryAutocompleteLanguageConstant<S extends IParserState = IParser
     maybeActiveNode: TMaybeActiveNode,
     maybeParseError: ParseError.ParseError | undefined,
 ): TriedAutocompleteLanguageConstant {
-    return ResultUtils.ensureResult(LocalizationUtils.getLocalizationTemplates(parseSettings.locale), () => {
+    return ResultUtils.ensureResult(parseSettings.locale, () => {
         return autocompleteLanguageConstant(parseSettings, parserState, maybeActiveNode, maybeParseError);
     });
 }

--- a/src/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -3,7 +3,6 @@
 
 import { ResultUtils } from "../../common";
 import { Ast, Constant } from "../../language";
-import { LocalizationUtils } from "../../localization";
 import { AncestryUtils, TXorNode, XorNodeKind } from "../../parser";
 import { CommonSettings } from "../../settings";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../activeNode";
@@ -19,7 +18,7 @@ export function tryAutocompletePrimitiveType(
         return ResultUtils.okFactory([]);
     }
 
-    return ResultUtils.ensureResult(LocalizationUtils.getLocalizationTemplates(settings.locale), () => {
+    return ResultUtils.ensureResult(settings.locale, () => {
         return autocompletePrimitiveType(maybeActiveNode, maybeTrailingToken);
     });
 }

--- a/src/inspection/invokeExpression.ts
+++ b/src/inspection/invokeExpression.ts
@@ -3,7 +3,6 @@
 
 import { Assert, CommonError, Result, ResultUtils } from "../common";
 import { Ast } from "../language";
-import { LocalizationUtils } from "../localization";
 import {
     AncestryUtils,
     NodeIdMap,
@@ -39,7 +38,7 @@ export function tryInvokeExpression(
         return ResultUtils.okFactory(undefined);
     }
 
-    return ResultUtils.ensureResult(LocalizationUtils.getLocalizationTemplates(settings.locale), () =>
+    return ResultUtils.ensureResult(settings.locale, () =>
         inspectInvokeExpression(nodeIdMapCollection, maybeActiveNode),
     );
 }

--- a/src/inspection/scope/scope.ts
+++ b/src/inspection/scope/scope.ts
@@ -4,7 +4,6 @@
 import { Inspection } from "../..";
 import { Assert, CommonError, Result, ResultUtils } from "../../common";
 import { Ast, Type, TypeInspector, TypeUtils } from "../../language";
-import { LocalizationUtils } from "../../localization";
 import {
     AncestryUtils,
     NodeIdMap,
@@ -47,7 +46,7 @@ export function tryScope(
     // If a map is given, then it's mutated and returned. Else create and return a new instance.
     maybeScopeById: ScopeById | undefined,
 ): TriedScope {
-    return ResultUtils.ensureResult(LocalizationUtils.getLocalizationTemplates(settings.locale), () =>
+    return ResultUtils.ensureResult(settings.locale, () =>
         inspectScope(settings, nodeIdMapCollection, leafNodeIds, ancestry, maybeScopeById),
     );
 }
@@ -61,7 +60,7 @@ export function tryNodeScope(
     // If a map is given, then it's mutated and returned. Else create and return a new instance.
     maybeScopeById: ScopeById | undefined,
 ): TriedNodeScope {
-    return ResultUtils.ensureResult(LocalizationUtils.getLocalizationTemplates(settings.locale), () => {
+    return ResultUtils.ensureResult(settings.locale, () => {
         const ancestry: ReadonlyArray<TXorNode> = AncestryUtils.assertGetAncestry(nodeIdMapCollection, nodeId);
         if (ancestry.length === 0) {
             return new Map();

--- a/src/inspection/type/task.ts
+++ b/src/inspection/type/task.ts
@@ -3,7 +3,6 @@
 
 import { Assert, CommonError, Result, ResultUtils } from "../../common";
 import { Type } from "../../language";
-import { LocalizationUtils } from "../../localization";
 import { NodeIdMap, NodeIdMapUtils } from "../../parser";
 import { CommonSettings } from "../../settings";
 import { NodeScope } from "../scope";
@@ -31,9 +30,7 @@ export function tryScopeType(
         scopeById: maybeTypeCache?.scopeById ?? new Map(),
     };
 
-    return ResultUtils.ensureResult(LocalizationUtils.getLocalizationTemplates(settings.locale), () =>
-        inspectScopeType(state, nodeId),
-    );
+    return ResultUtils.ensureResult(settings.locale, () => inspectScopeType(state, nodeId));
 }
 
 export function tryType(
@@ -52,7 +49,7 @@ export function tryType(
         scopeById: maybeTypeCache?.typeById ?? new Map(),
     };
 
-    return ResultUtils.ensureResult(LocalizationUtils.getLocalizationTemplates(settings.locale), () =>
+    return ResultUtils.ensureResult(settings.locale, () =>
         inspectXor(state, NodeIdMapUtils.assertGetXor(nodeIdMapCollection, nodeId)),
     );
 }

--- a/src/language/type/expectedType.ts
+++ b/src/language/type/expectedType.ts
@@ -5,7 +5,6 @@ import { Type } from ".";
 import { Assert, CommonError, Result, ResultUtils } from "../../common";
 import { ActiveNode, ActiveNodeLeafKind, ActiveNodeUtils, TMaybeActiveNode } from "../../inspection/activeNode";
 import { Ast } from "../../language";
-import { LocalizationUtils } from "../../localization";
 import { TXorNode, XorNodeKind } from "../../parser";
 import { CommonSettings } from "../../settings";
 
@@ -16,9 +15,7 @@ export function tryExpectedType(settings: CommonSettings, maybeActiveNode: TMayb
         return ResultUtils.okFactory(undefined);
     }
 
-    return ResultUtils.ensureResult(LocalizationUtils.getLocalizationTemplates(settings.locale), () =>
-        maybeExpectedType(maybeActiveNode),
-    );
+    return ResultUtils.ensureResult(settings.locale, () => maybeExpectedType(maybeActiveNode));
 }
 
 // Traverse up the ancestry and find what type is expected as the nth child of a node's kind.

--- a/src/lexer/error.ts
+++ b/src/lexer/error.ts
@@ -3,7 +3,7 @@
 
 import { Lexer } from "..";
 import { CommonError, StringUtils } from "../common";
-import { Localization, Templates } from "../localization";
+import { Localization, LocalizationUtils } from "../localization";
 
 export type TLexError = CommonError.CommonError | LexError;
 
@@ -56,76 +56,74 @@ export class LexError extends Error {
 
 export class BadLineNumberError extends Error {
     constructor(
-        templates: Templates.ILocalizationTemplates,
+        locale: string,
         readonly kind: BadLineNumberKind,
         readonly lineNumber: number,
         readonly numLines: number,
     ) {
-        super(Localization.error_lex_badLineNumber(templates, kind));
+        super(Localization.error_lex_badLineNumber(LocalizationUtils.getLocalizationTemplates(locale), kind));
         Object.setPrototypeOf(this, BadLineNumberError.prototype);
     }
 }
 
 export class BadRangeError extends Error {
-    constructor(templates: Templates.ILocalizationTemplates, readonly range: Lexer.Range, readonly kind: BadRangeKind) {
-        super(Localization.error_lex_badRange(templates, kind));
+    constructor(locale: string, readonly range: Lexer.Range, readonly kind: BadRangeKind) {
+        super(Localization.error_lex_badRange(LocalizationUtils.getLocalizationTemplates(locale), kind));
         Object.setPrototypeOf(this, BadRangeError.prototype);
     }
 }
 
 export class BadStateError extends Error {
-    constructor(templates: Templates.ILocalizationTemplates, readonly innerError: TLexError) {
-        super(Localization.error_lex_badState(templates));
+    constructor(locale: string, readonly innerError: TLexError) {
+        super(Localization.error_lex_badState(LocalizationUtils.getLocalizationTemplates(locale)));
         Object.setPrototypeOf(this, BadStateError.prototype);
     }
 }
 
 export class ErrorLineMapError extends Error {
-    constructor(templates: Templates.ILocalizationTemplates, readonly errorLineMap: Lexer.ErrorLineMap) {
-        super(Localization.error_lex_lineMap(templates, errorLineMap));
+    constructor(locale: string, readonly errorLineMap: Lexer.ErrorLineMap) {
+        super(Localization.error_lex_lineMap(LocalizationUtils.getLocalizationTemplates(locale), errorLineMap));
         Object.setPrototypeOf(this, ErrorLineMapError.prototype);
     }
 }
 
 export class EndOfStreamError extends Error {
-    constructor(templates: Templates.ILocalizationTemplates) {
-        super(Localization.error_lex_endOfStream(templates));
+    constructor(locale: string) {
+        super(Localization.error_lex_endOfStream(LocalizationUtils.getLocalizationTemplates(locale)));
         Object.setPrototypeOf(this, EndOfStreamError.prototype);
     }
 }
 
 export class ExpectedError extends Error {
-    constructor(
-        templates: Templates.ILocalizationTemplates,
-        readonly graphemePosition: StringUtils.GraphemePosition,
-        readonly kind: ExpectedKind,
-    ) {
-        super(Localization.error_lex_expectedKind(templates, kind));
+    constructor(locale: string, readonly graphemePosition: StringUtils.GraphemePosition, readonly kind: ExpectedKind) {
+        super(Localization.error_lex_expectedKind(LocalizationUtils.getLocalizationTemplates(locale), kind));
         Object.setPrototypeOf(this, ExpectedError.prototype);
     }
 }
 
 export class UnexpectedEofError extends Error {
-    constructor(templates: Templates.ILocalizationTemplates, readonly graphemePosition: StringUtils.GraphemePosition) {
-        super(Localization.error_lex_endOfStreamPartwayRead(templates));
+    constructor(locale: string, readonly graphemePosition: StringUtils.GraphemePosition) {
+        super(Localization.error_lex_endOfStreamPartwayRead(LocalizationUtils.getLocalizationTemplates(locale)));
         Object.setPrototypeOf(this, UnexpectedEofError.prototype);
     }
 }
 
 export class UnexpectedReadError extends Error {
-    constructor(templates: Templates.ILocalizationTemplates, readonly graphemePosition: StringUtils.GraphemePosition) {
-        super(Localization.error_lex_unexpectedRead(templates));
+    constructor(locale: string, readonly graphemePosition: StringUtils.GraphemePosition) {
+        super(Localization.error_lex_unexpectedRead(LocalizationUtils.getLocalizationTemplates(locale)));
         Object.setPrototypeOf(this, UnexpectedReadError.prototype);
     }
 }
 
 export class UnterminatedMultilineTokenError extends Error {
     constructor(
-        templates: Templates.ILocalizationTemplates,
+        locale: string,
         readonly graphemePosition: StringUtils.GraphemePosition,
         readonly kind: UnterminatedMultilineTokenKind,
     ) {
-        super(Localization.error_lex_unterminatedMultilineToken(templates, kind));
+        super(
+            Localization.error_lex_unterminatedMultilineToken(LocalizationUtils.getLocalizationTemplates(locale), kind),
+        );
         Object.setPrototypeOf(this, UnterminatedMultilineTokenError.prototype);
     }
 }

--- a/src/lexer/lexerSnapshot.ts
+++ b/src/lexer/lexerSnapshot.ts
@@ -5,7 +5,6 @@ import { LexError } from ".";
 import { Lexer } from "..";
 import { CommonError, ICancellationToken, Result, ResultUtils, StringUtils } from "../common";
 import { Comment, Token } from "../language";
-import { Templates } from "../localization";
 
 // The lexer is a multiline aware lexer.
 // That in part means multiline tokens are split up into <begin>, <content>, and <end> components.
@@ -70,7 +69,7 @@ export function trySnapshot(state: Lexer.State): TriedLexerSnapshot {
         if (LexError.isTInnerLexError(e)) {
             error = new LexError.LexError(e);
         } else {
-            error = CommonError.ensureCommonError(state.localizationTemplates, e);
+            error = CommonError.ensureCommonError(state.locale, e);
         }
         return ResultUtils.errFactory(error);
     }
@@ -85,7 +84,6 @@ function snapshotFactory(state: Lexer.State): LexerSnapshot {
     const numFlatTokens: number = flatTokens.length;
     const text: string = flattenedLines.text;
     const maybeCancellationToken: ICancellationToken | undefined = state.maybeCancellationToken;
-    const localizationTemplates: Templates.ILocalizationTemplates = state.localizationTemplates;
 
     let flatIndex: number = 0;
     while (flatIndex < numFlatTokens) {
@@ -104,7 +102,7 @@ function snapshotFactory(state: Lexer.State): LexerSnapshot {
             case Token.LineTokenKind.MultilineCommentStart: {
                 const concatenatedTokenRead: ConcatenatedCommentRead = readMultilineComment(
                     maybeCancellationToken,
-                    localizationTemplates,
+                    state.locale,
                     flattenedLines,
                     flatToken,
                 );
@@ -116,7 +114,7 @@ function snapshotFactory(state: Lexer.State): LexerSnapshot {
             case Token.LineTokenKind.QuotedIdentifierStart: {
                 const concatenatedTokenRead: ConcatenatedTokenRead = readQuotedIdentifier(
                     maybeCancellationToken,
-                    localizationTemplates,
+                    state.locale,
                     flattenedLines,
                     flatToken,
                 );
@@ -128,7 +126,7 @@ function snapshotFactory(state: Lexer.State): LexerSnapshot {
             case Token.LineTokenKind.TextLiteralStart: {
                 const concatenatedTokenRead: ConcatenatedTokenRead = readTextLiteral(
                     maybeCancellationToken,
-                    localizationTemplates,
+                    state.locale,
                     flattenedLines,
                     flatToken,
                 );
@@ -183,7 +181,7 @@ function readSingleLineMultilineComment(flatToken: FlatLineToken): Comment.Multi
 
 function readMultilineComment(
     maybeCancellationToken: ICancellationToken | undefined,
-    localizationTemplates: Templates.ILocalizationTemplates,
+    locale: string,
     flattenedLines: FlattenedLines,
     tokenStart: FlatLineToken,
 ): ConcatenatedCommentRead {
@@ -196,7 +194,7 @@ function readMultilineComment(
     const maybeTokenEnd: FlatLineToken | undefined = collection.maybeTokenEnd;
     if (!maybeTokenEnd) {
         throw new LexError.UnterminatedMultilineTokenError(
-            localizationTemplates,
+            locale,
             LexerSnapshot.graphemePositionStartFrom(flattenedLines.text, flattenedLines.lineTerminators, tokenStart),
             LexError.UnterminatedMultilineTokenKind.MultilineComment,
         );
@@ -224,7 +222,7 @@ function readMultilineComment(
 
 function readQuotedIdentifier(
     maybeCancellationToken: ICancellationToken | undefined,
-    localizationTemplates: Templates.ILocalizationTemplates,
+    locale: string,
     flattenedLines: FlattenedLines,
     tokenStart: FlatLineToken,
 ): ConcatenatedTokenRead {
@@ -237,7 +235,7 @@ function readQuotedIdentifier(
     const maybeTokenEnd: FlatLineToken | undefined = collection.maybeTokenEnd;
     if (!maybeTokenEnd) {
         throw new LexError.UnterminatedMultilineTokenError(
-            localizationTemplates,
+            locale,
             LexerSnapshot.graphemePositionStartFrom(flattenedLines.text, flattenedLines.lineTerminators, tokenStart),
             LexError.UnterminatedMultilineTokenKind.QuotedIdentifier,
         );
@@ -264,7 +262,7 @@ function readQuotedIdentifier(
 
 function readTextLiteral(
     maybeCancellationToken: ICancellationToken | undefined,
-    localizationTemplates: Templates.ILocalizationTemplates,
+    locale: string,
     flattenedLines: FlattenedLines,
     tokenStart: FlatLineToken,
 ): ConcatenatedTokenRead {
@@ -277,7 +275,7 @@ function readTextLiteral(
     const maybeTokenEnd: FlatLineToken | undefined = collection.maybeTokenEnd;
     if (!maybeTokenEnd) {
         throw new LexError.UnterminatedMultilineTokenError(
-            localizationTemplates,
+            locale,
             LexerSnapshot.graphemePositionStartFrom(flattenedLines.text, flattenedLines.lineTerminators, tokenStart),
             LexError.UnterminatedMultilineTokenKind.Text,
         );

--- a/src/parser/IParser/IParserUtils.ts
+++ b/src/parser/IParser/IParserUtils.ts
@@ -5,7 +5,6 @@ import { ParseError } from "..";
 import { CommonError, ResultUtils } from "../../common";
 import { Ast } from "../../language";
 import { LexerSnapshot } from "../../lexer";
-import { LocalizationUtils } from "../../localization";
 import { ParseSettings } from "../../settings";
 import { IParserState, IParserStateUtils } from "../IParserState";
 import { IParser, TriedParse } from "./IParser";
@@ -103,6 +102,6 @@ function ensureParseError<S extends IParserState = IParserState>(
     if (ParseError.isTInnerParseError(error)) {
         return new ParseError.ParseError(error, state);
     } else {
-        return CommonError.ensureCommonError(LocalizationUtils.getLocalizationTemplates(locale), error);
+        return CommonError.ensureCommonError(locale, error);
     }
 }

--- a/src/parser/IParserState/IParserState.ts
+++ b/src/parser/IParserState/IParserState.ts
@@ -5,12 +5,11 @@ import { ParseContext } from "..";
 import { ICancellationToken } from "../../common";
 import { Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
-import { Templates } from "../../localization";
 
 export interface IParserState {
     readonly maybeCancellationToken: ICancellationToken | undefined;
     readonly lexerSnapshot: LexerSnapshot;
-    readonly localizationTemplates: Templates.ILocalizationTemplates;
+    readonly locale: string;
     tokenIndex: number;
     maybeCurrentToken: Token.Token | undefined;
     maybeCurrentTokenKind: Token.TokenKind | undefined;

--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -5,7 +5,6 @@ import { NodeIdMap, ParseContext, ParseContextUtils, ParseError } from "..";
 import { Assert, CommonError, ICancellationToken } from "../../common";
 import { Ast, Constant, Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
-import { LocalizationUtils } from "../../localization";
 import { SequenceKind } from "../error";
 import { NodeIdMapUtils } from "../nodeIdMap";
 import { IParserState } from "./IParserState";

--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -33,7 +33,7 @@ export function stateFactory(
     return {
         maybeCancellationToken,
         lexerSnapshot,
-        localizationTemplates: LocalizationUtils.getLocalizationTemplates(locale),
+        locale,
         tokenIndex,
         maybeCurrentToken,
         maybeCurrentTokenKind: maybeCurrentToken?.kind,
@@ -292,7 +292,7 @@ export function testCsvContinuationLetExpression(
 ): ParseError.ExpectedCsvContinuationError | undefined {
     if (state.maybeCurrentTokenKind === Token.TokenKind.KeywordIn) {
         return new ParseError.ExpectedCsvContinuationError(
-            state.localizationTemplates,
+            state.locale,
             ParseError.CsvContinuationKind.LetExpression,
             maybeCurrentTokenWithColumnNumber(state),
         );
@@ -307,7 +307,7 @@ export function testCsvContinuationDanglingComma(
 ): ParseError.ExpectedCsvContinuationError | undefined {
     if (state.maybeCurrentTokenKind === tokenKind) {
         return new ParseError.ExpectedCsvContinuationError(
-            state.localizationTemplates,
+            state.locale,
             ParseError.CsvContinuationKind.DanglingComma,
             maybeCurrentTokenWithColumnNumber(state),
         );
@@ -326,7 +326,7 @@ export function testIsOnTokenKind(
 ): ParseError.ExpectedTokenKindError | undefined {
     if (expectedTokenKind !== state.maybeCurrentTokenKind) {
         const maybeToken: ParseError.TokenWithColumnNumber | undefined = maybeCurrentTokenWithColumnNumber(state);
-        return new ParseError.ExpectedTokenKindError(state.localizationTemplates, expectedTokenKind, maybeToken);
+        return new ParseError.ExpectedTokenKindError(state.locale, expectedTokenKind, maybeToken);
     } else {
         return undefined;
     }
@@ -341,7 +341,7 @@ export function testIsOnAnyTokenKind(
 
     if (isError) {
         const maybeToken: ParseError.TokenWithColumnNumber | undefined = maybeCurrentTokenWithColumnNumber(state);
-        return new ParseError.ExpectedAnyTokenKindError(state.localizationTemplates, expectedAnyTokenKinds, maybeToken);
+        return new ParseError.ExpectedAnyTokenKindError(state.locale, expectedAnyTokenKinds, maybeToken);
     } else {
         return undefined;
     }
@@ -354,7 +354,7 @@ export function assertNoMoreTokens(state: IParserState): void {
 
     const token: Token.Token = assertGetTokenAt(state, state.tokenIndex);
     throw new ParseError.UnusedTokensRemainError(
-        state.localizationTemplates,
+        state.locale,
         token,
         state.lexerSnapshot.graphemePositionStartFrom(token),
     );
@@ -381,7 +381,7 @@ export function unterminatedParenthesesError(state: IParserState): ParseError.Un
 function unterminatedSequence(state: IParserState, sequenceKind: SequenceKind): ParseError.UnterminatedSequence {
     const token: Token.Token = assertGetTokenAt(state, state.tokenIndex);
     return new ParseError.UnterminatedSequence(
-        state.localizationTemplates,
+        state.locale,
         sequenceKind,
         token,
         state.lexerSnapshot.graphemePositionStartFrom(token),

--- a/src/parser/error.ts
+++ b/src/parser/error.ts
@@ -3,7 +3,7 @@
 
 import { Assert, CommonError, StringUtils } from "../common";
 import { Token } from "../language";
-import { Localization, Templates } from "../localization";
+import { Localization, LocalizationUtils } from "../localization";
 import { IParserState } from "./IParserState";
 
 export type TParseError<S extends IParserState = IParserState> = CommonError.CommonError | ParseError<S>;
@@ -37,88 +37,100 @@ export class ParseError<S extends IParserState = IParserState> extends Error {
 
 export class ExpectedCsvContinuationError extends Error {
     constructor(
-        templates: Templates.ILocalizationTemplates,
+        locale: string,
         readonly kind: CsvContinuationKind,
         readonly maybeFoundToken: TokenWithColumnNumber | undefined,
     ) {
-        super(Localization.error_parse_csvContinuation(templates, kind));
+        super(Localization.error_parse_csvContinuation(LocalizationUtils.getLocalizationTemplates(locale), kind));
         Object.setPrototypeOf(this, ExpectedCsvContinuationError.prototype);
     }
 }
 
 export class ExpectedAnyTokenKindError extends Error {
     constructor(
-        templates: Templates.ILocalizationTemplates,
+        locale: string,
         readonly expectedAnyTokenKinds: ReadonlyArray<Token.TokenKind>,
         readonly maybeFoundToken: TokenWithColumnNumber | undefined,
     ) {
-        super(Localization.error_parse_expectAnyTokenKind(templates, expectedAnyTokenKinds, maybeFoundToken));
+        super(
+            Localization.error_parse_expectAnyTokenKind(
+                LocalizationUtils.getLocalizationTemplates(locale),
+                expectedAnyTokenKinds,
+                maybeFoundToken,
+            ),
+        );
         Object.setPrototypeOf(this, ExpectedAnyTokenKindError.prototype);
     }
 }
 
 export class ExpectedTokenKindError extends Error {
     constructor(
-        templates: Templates.ILocalizationTemplates,
+        locale: string,
         readonly expectedTokenKind: Token.TokenKind,
         readonly maybeFoundToken: TokenWithColumnNumber | undefined,
     ) {
-        super(Localization.error_parse_expectTokenKind(templates, expectedTokenKind, maybeFoundToken));
+        super(
+            Localization.error_parse_expectTokenKind(
+                LocalizationUtils.getLocalizationTemplates(locale),
+                expectedTokenKind,
+                maybeFoundToken,
+            ),
+        );
         Object.setPrototypeOf(this, ExpectedTokenKindError.prototype);
     }
 }
 
 export class ExpectedGeneralizedIdentifierError extends Error {
-    constructor(
-        templates: Templates.ILocalizationTemplates,
-        readonly maybeFoundToken: TokenWithColumnNumber | undefined,
-    ) {
-        super(Localization.error_parse_expectGeneralizedIdentifier(templates, maybeFoundToken));
+    constructor(locale: string, readonly maybeFoundToken: TokenWithColumnNumber | undefined) {
+        super(
+            Localization.error_parse_expectGeneralizedIdentifier(
+                LocalizationUtils.getLocalizationTemplates(locale),
+                maybeFoundToken,
+            ),
+        );
         Object.setPrototypeOf(this, ExpectedGeneralizedIdentifierError.prototype);
     }
 }
 
 export class InvalidPrimitiveTypeError extends Error {
-    constructor(
-        templates: Templates.ILocalizationTemplates,
-        readonly token: Token.Token,
-        readonly positionStart: StringUtils.GraphemePosition,
-    ) {
-        super(Localization.error_parse_invalidPrimitiveType(templates, token));
+    constructor(locale: string, readonly token: Token.Token, readonly positionStart: StringUtils.GraphemePosition) {
+        super(Localization.error_parse_invalidPrimitiveType(LocalizationUtils.getLocalizationTemplates(locale), token));
         Object.setPrototypeOf(this, InvalidPrimitiveTypeError.prototype);
     }
 }
 
 export class RequiredParameterAfterOptionalParameterError extends Error {
     constructor(
-        templates: Templates.ILocalizationTemplates,
+        locale: string,
         readonly missingOptionalToken: Token.Token,
         readonly positionStart: StringUtils.GraphemePosition,
     ) {
-        super(Localization.error_parse_requiredParameterAfterOptional(templates));
+        super(
+            Localization.error_parse_requiredParameterAfterOptional(LocalizationUtils.getLocalizationTemplates(locale)),
+        );
         Object.setPrototypeOf(this, RequiredParameterAfterOptionalParameterError.prototype);
     }
 }
 
 export class UnterminatedSequence extends Error {
     constructor(
-        templates: Templates.ILocalizationTemplates,
+        locale: string,
         readonly kind: SequenceKind,
         readonly startToken: Token.Token,
         readonly positionStart: StringUtils.GraphemePosition,
     ) {
-        super(Localization.error_parse_unterminated_sequence(templates, kind));
+        super(Localization.error_parse_unterminated_sequence(LocalizationUtils.getLocalizationTemplates(locale), kind));
         Object.setPrototypeOf(this, UnterminatedSequence.prototype);
     }
 }
 
 export class UnusedTokensRemainError extends Error {
     constructor(
-        templates: Templates.ILocalizationTemplates,
+        locale: string,
         readonly firstUnusedToken: Token.Token,
         readonly positionStart: StringUtils.GraphemePosition,
     ) {
-        super(Localization.error_parse_unusedTokens(templates));
+        super(Localization.error_parse_unusedTokens(LocalizationUtils.getLocalizationTemplates(locale)));
         Object.setPrototypeOf(this, UnusedTokensRemainError.prototype);
     }
 }

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -86,7 +86,7 @@ export function readGeneralizedIdentifier<S extends IParserState = IParserState>
 
     if (tokenRangeStartIndex === tokenRangeEndIndex) {
         throw new ParseError.ExpectedGeneralizedIdentifierError(
-            state.localizationTemplates,
+            state.locale,
             IParserStateUtils.maybeTokenWithColumnNumber(state, state.tokenIndex + 1),
         );
     }
@@ -103,7 +103,7 @@ export function readGeneralizedIdentifier<S extends IParserState = IParserState>
         !StringUtils.isQuotedIdentifier(literal)
     ) {
         throw new ParseError.ExpectedGeneralizedIdentifierError(
-            state.localizationTemplates,
+            state.locale,
             IParserStateUtils.maybeTokenWithColumnNumber(state, state.tokenIndex + 1),
         );
     }
@@ -1915,7 +1915,7 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
                 IParserStateUtils.applyFastStateBackup(state, stateBackup);
                 return ResultUtils.errFactory(
                     new ParseError.InvalidPrimitiveTypeError(
-                        state.localizationTemplates,
+                        state.locale,
                         token,
                         state.lexerSnapshot.graphemePositionStartFrom(token),
                     ),
@@ -2399,7 +2399,7 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
         if (reachedOptionalParameter && !maybeOptionalConstant) {
             const token: Token.Token = IParserStateUtils.assertGetTokenAt(state, state.tokenIndex);
             throw new ParseError.RequiredParameterAfterOptionalParameterError(
-                state.localizationTemplates,
+                state.locale,
                 token,
                 state.lexerSnapshot.graphemePositionStartFrom(token),
             );

--- a/src/task.ts
+++ b/src/task.ts
@@ -7,7 +7,6 @@ import { Assert, CommonError, Result, ResultUtils } from "./common";
 import { ActiveNodeUtils, TMaybeActiveNode } from "./inspection/activeNode";
 import { Ast } from "./language";
 import { LexError, LexerSnapshot } from "./lexer";
-import { LocalizationUtils } from "./localization";
 import {
     IParserState,
     IParserUtils,
@@ -50,12 +49,7 @@ export function tryLex(settings: LexSettings, text: string): Lexer.TriedLexerSna
     if (maybeErrorLineMap) {
         const errorLineMap: Lexer.ErrorLineMap = maybeErrorLineMap;
         return ResultUtils.errFactory(
-            new LexError.LexError(
-                new LexError.ErrorLineMapError(
-                    LocalizationUtils.getLocalizationTemplates(settings.locale),
-                    errorLineMap,
-                ),
-            ),
+            new LexError.LexError(new LexError.ErrorLineMapError(settings.locale, errorLineMap)),
         );
     }
 

--- a/src/test/libraryTest/parser/simple.ts
+++ b/src/test/libraryTest/parser/simple.ts
@@ -6,7 +6,7 @@ import "mocha";
 import { Task } from "../../..";
 import { Assert, Traverse } from "../../../common";
 import { Ast, Constant } from "../../../language";
-import { Templates } from "../../../localization";
+import { DefaultLocale } from "../../../localization";
 import { RecursiveDescentParser } from "../../../parser/parsers";
 import { DefaultSettings, Settings } from "../../../settings";
 import { TestAssertUtils } from "../../testUtils";
@@ -24,7 +24,7 @@ interface NthNodeOfKindState extends Traverse.IState<Ast.TNode | undefined> {
 function collectAbridgeNodeFromAst(text: string): ReadonlyArray<AbridgedNode> {
     const lexParseOk: Task.LexParseOk = TestAssertUtils.assertGetLexParseOk(DefaultSettings, text);
     const state: CollectAbridgeNodeState = {
-        localizationTemplates: Templates.DefaultTemplates,
+        locale: DefaultLocale,
         result: [],
     };
 
@@ -48,7 +48,7 @@ function collectAbridgeNodeFromAst(text: string): ReadonlyArray<AbridgedNode> {
 function assertGetNthNodeOfKind<N extends Ast.TNode>(text: string, nodeKind: Ast.NodeKind, nthRequired: number): N {
     const lexParseOk: Task.LexParseOk = TestAssertUtils.assertGetLexParseOk(DefaultSettings, text);
     const state: NthNodeOfKindState = {
-        localizationTemplates: Templates.DefaultTemplates,
+        locale: DefaultLocale,
         result: undefined,
         nodeKind,
         nthCounter: 0,

--- a/src/test/libraryTest/tokenizer/common.ts
+++ b/src/test/libraryTest/tokenizer/common.ts
@@ -3,7 +3,7 @@
 
 import { Assert, Lexer } from "../../../";
 import { Token } from "../../../language";
-import { Templates } from "../../../localization";
+import { DefaultLocale } from "../../../localization";
 
 export class Tokenizer implements TokensProvider {
     constructor(private readonly lineTerminator: string) {}
@@ -29,7 +29,7 @@ export class Tokenizer implements TokensProvider {
     public getInitialState(): IState {
         const lexerState: Lexer.State = {
             lines: [],
-            localizationTemplates: Templates.DefaultTemplates,
+            locale: DefaultLocale,
             maybeCancellationToken: undefined,
         };
         return new TokenizerState(lexerState);


### PR DESCRIPTION
Previously the public APIs had a mix of passing around either `locale` or `ILocalizationTemplates`. This standardizes things so that only `locale` is passed around. Now the only files with references to ILocalizationTemplates is limited to: localization.ts, localizationUtils, and localizationTemplates.ts.