### PR TITLE
Move parser state backup/restore into IParser API

### DIFF
--- a/src/parser/IParser/IParser.ts
+++ b/src/parser/IParser/IParser.ts
@@ -38,7 +38,7 @@ export interface IParser<
     C extends IParserStateCheckpoint = IParserStateCheckpoint
 > {
     readonly createCheckpoint: (state: S) => C;
-    readonly restoreCheckpoint: (state: S, checkpoint: C) => void;
+    readonly restoreFromCheckpoint: (state: S, checkpoint: C) => void;
 
     // 12.1.6 Identifiers
     readonly readIdentifier: (state: S, parser: IParser<S>) => Ast.Identifier;

--- a/src/parser/IParser/IParser.ts
+++ b/src/parser/IParser/IParser.ts
@@ -18,6 +18,12 @@ export const enum BracketDisambiguation {
     Record = "Record",
 }
 
+export interface IParserStateCheckpoint {
+    readonly tokenIndex: number;
+    readonly contextStateIdCounter: number;
+    readonly maybeContextNodeId: number | undefined;
+}
+
 export interface ParseOk<S extends IParserState = IParserState> {
     readonly root: Ast.TNode;
     readonly state: S;
@@ -27,7 +33,13 @@ export interface ParserOptions<S extends IParserState = IParserState> {
     readonly maybeEntryPoint: ((state: S, parser: IParser<S>) => Ast.TNode) | undefined;
 }
 
-export interface IParser<S extends IParserState = IParserState> {
+export interface IParser<
+    S extends IParserState = IParserState,
+    C extends IParserStateCheckpoint = IParserStateCheckpoint
+> {
+    readonly createCheckpoint: (state: S) => C;
+    readonly restoreCheckpoint: (state: S, checkpoint: C) => void;
+
     // 12.1.6 Identifiers
     readonly readIdentifier: (state: S, parser: IParser<S>) => Ast.Identifier;
     readonly readGeneralizedIdentifier: (state: S, parser: IParser<S>) => Ast.GeneralizedIdentifier;

--- a/src/parser/IParser/IParserUtils.ts
+++ b/src/parser/IParser/IParserUtils.ts
@@ -6,8 +6,10 @@ import { CommonError, ResultUtils } from "../../common";
 import { Ast } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 import { ParseSettings } from "../../settings";
+import { ParseContext, ParseContextUtils } from "../context";
 import { IParserState, IParserStateUtils } from "../IParserState";
-import { IParser, TriedParse } from "./IParser";
+import { NodeIdMap, NodeIdMapUtils } from "../nodeIdMap";
+import { IParser, IParserStateCheckpoint, TriedParse } from "./IParser";
 
 export function tryParse<S extends IParserState = IParserState>(
     parseSettings: ParseSettings<S>,
@@ -91,6 +93,64 @@ export function tryParseDocument<S extends IParserState = IParserState>(
 
             return ResultUtils.errFactory(ensureParseError(betterParsedState, betterParsedError, parseSettings.locale));
         }
+    }
+}
+
+// Due to performance reasons the backup no longer can include a naive deep copy of the context state.
+// Instead it's assumed that a backup is made immediately before a try/catch read block.
+// This means the state begins in a parsing context and the backup will either be immediately consumed or dropped.
+// Therefore we only care about the delta between before and after the try/catch block.
+// Thanks to the invariants above and the fact the ids for nodes are an auto-incrementing integer
+// we can easily just drop all delete all context nodes past the id of when the backup was created.
+export function stateCheckpointFactory(state: IParserState): IParserStateCheckpoint {
+    return {
+        tokenIndex: state.tokenIndex,
+        contextStateIdCounter: state.contextState.idCounter,
+        maybeContextNodeId: state.maybeCurrentContextNode?.id,
+    };
+}
+
+// See stateCheckpointFactory above for more information.
+export function restoreStateCheckpoint(state: IParserState, checkpoint: IParserStateCheckpoint): void {
+    state.tokenIndex = checkpoint.tokenIndex;
+    state.maybeCurrentToken = state.lexerSnapshot.tokens[state.tokenIndex];
+    state.maybeCurrentTokenKind = state.maybeCurrentToken?.kind;
+
+    const contextState: ParseContext.State = state.contextState;
+    const nodeIdMapCollection: NodeIdMap.Collection = state.contextState.nodeIdMapCollection;
+    const backupIdCounter: number = checkpoint.contextStateIdCounter;
+    contextState.idCounter = backupIdCounter;
+
+    const newContextNodeIds: number[] = [];
+    const newAstNodeIds: number[] = [];
+    for (const nodeId of nodeIdMapCollection.astNodeById.keys()) {
+        if (nodeId > backupIdCounter) {
+            newAstNodeIds.push(nodeId);
+        }
+    }
+    for (const nodeId of nodeIdMapCollection.contextNodeById.keys()) {
+        if (nodeId > backupIdCounter) {
+            newContextNodeIds.push(nodeId);
+        }
+    }
+
+    const sortByNumber: (left: number, right: number) => number = (left: number, right: number) => left - right;
+    for (const nodeId of newAstNodeIds.sort(sortByNumber).reverse()) {
+        const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(nodeId);
+        const parentWillBeDeleted: boolean = maybeParentId !== undefined && maybeParentId >= backupIdCounter;
+        ParseContextUtils.deleteAst(state.contextState, nodeId, parentWillBeDeleted);
+    }
+    for (const nodeId of newContextNodeIds.sort(sortByNumber).reverse()) {
+        ParseContextUtils.deleteContext(state.contextState, nodeId);
+    }
+
+    if (checkpoint.maybeContextNodeId) {
+        state.maybeCurrentContextNode = NodeIdMapUtils.assertGetContext(
+            state.contextState.nodeIdMapCollection.contextNodeById,
+            checkpoint.maybeContextNodeId,
+        );
+    } else {
+        state.maybeCurrentContextNode = undefined;
     }
 }
 

--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -8,16 +8,6 @@ import { LexerSnapshot } from "../../lexer";
 import { SequenceKind } from "../error";
 import { IParserState } from "./IParserState";
 
-export interface FastStateBackup {
-    readonly tokenIndex: number;
-    readonly contextStateIdCounter: number;
-    readonly maybeContextNodeId: number | undefined;
-}
-
-// ---------------------------
-// ---------- State ----------
-// ---------------------------
-
 // If you have a custom parser + parser state, then you'll have to create your own factory function.
 // See `benchmark.ts` for an example.
 export function stateFactory(

--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { NodeIdMap, ParseContext, ParseContextUtils, ParseError } from "..";
+import { ParseContext, ParseContextUtils, ParseError } from "..";
 import { Assert, CommonError, ICancellationToken } from "../../common";
 import { Ast, Constant, Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 import { SequenceKind } from "../error";
-import { NodeIdMapUtils } from "../nodeIdMap";
 import { IParserState } from "./IParserState";
 
 export interface FastStateBackup {
@@ -39,73 +38,6 @@ export function stateFactory(
         contextState: ParseContextUtils.stateFactory(),
         maybeCurrentContextNode: undefined,
     };
-}
-
-export function applyState(originalState: IParserState, otherState: IParserState): void {
-    originalState.tokenIndex = otherState.tokenIndex;
-    originalState.maybeCurrentToken = otherState.maybeCurrentToken;
-    originalState.maybeCurrentTokenKind = otherState.maybeCurrentTokenKind;
-
-    originalState.contextState = otherState.contextState;
-    originalState.maybeCurrentContextNode = otherState.maybeCurrentContextNode;
-}
-
-// Due to performance reasons the backup no longer can include a naive deep copy of the context state.
-// Instead it's assumed that a backup is made immediately before a try/catch read block.
-// This means the state begins in a parsing context and the backup will either be immediately consumed or dropped.
-// Therefore we only care about the delta between before and after the try/catch block.
-// Thanks to the invariants above and the fact the ids for nodes are an auto-incrementing integer
-// we can easily just drop all delete all context nodes past the id of when the backup was created.
-export function fastStateBackup(state: IParserState): FastStateBackup {
-    return {
-        tokenIndex: state.tokenIndex,
-        contextStateIdCounter: state.contextState.idCounter,
-        maybeContextNodeId: state.maybeCurrentContextNode?.id,
-    };
-}
-
-// See state.fastSnapshot for more information.
-export function applyFastStateBackup(state: IParserState, backup: FastStateBackup): void {
-    state.tokenIndex = backup.tokenIndex;
-    state.maybeCurrentToken = state.lexerSnapshot.tokens[state.tokenIndex];
-    state.maybeCurrentTokenKind = state.maybeCurrentToken?.kind;
-
-    const contextState: ParseContext.State = state.contextState;
-    const nodeIdMapCollection: NodeIdMap.Collection = state.contextState.nodeIdMapCollection;
-    const backupIdCounter: number = backup.contextStateIdCounter;
-    contextState.idCounter = backupIdCounter;
-
-    const newContextNodeIds: number[] = [];
-    const newAstNodeIds: number[] = [];
-    for (const nodeId of nodeIdMapCollection.astNodeById.keys()) {
-        if (nodeId > backupIdCounter) {
-            newAstNodeIds.push(nodeId);
-        }
-    }
-    for (const nodeId of nodeIdMapCollection.contextNodeById.keys()) {
-        if (nodeId > backupIdCounter) {
-            newContextNodeIds.push(nodeId);
-        }
-    }
-
-    const sortByNumber: (left: number, right: number) => number = (left: number, right: number) => left - right;
-    for (const nodeId of newAstNodeIds.sort(sortByNumber).reverse()) {
-        const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(nodeId);
-        const parentWillBeDeleted: boolean = maybeParentId !== undefined && maybeParentId >= backupIdCounter;
-        ParseContextUtils.deleteAst(state.contextState, nodeId, parentWillBeDeleted);
-    }
-    for (const nodeId of newContextNodeIds.sort(sortByNumber).reverse()) {
-        ParseContextUtils.deleteContext(state.contextState, nodeId);
-    }
-
-    if (backup.maybeContextNodeId) {
-        state.maybeCurrentContextNode = NodeIdMapUtils.assertGetContext(
-            state.contextState.nodeIdMapCollection.contextNodeById,
-            backup.maybeContextNodeId,
-        );
-    } else {
-        state.maybeCurrentContextNode = undefined;
-    }
 }
 
 export function startContext(state: IParserState, nodeKind: Ast.NodeKind): void {

--- a/src/parser/parsers/combinatorialParser.ts
+++ b/src/parser/parsers/combinatorialParser.ts
@@ -5,7 +5,7 @@ import { NaiveParseSteps } from ".";
 import { NodeIdMap, ParseContextUtils } from "..";
 import { ArrayUtils, Assert, TypeScriptUtils } from "../../common";
 import { Ast, AstUtils, Constant, ConstantUtils, Token } from "../../language";
-import { BracketDisambiguation, IParser } from "../IParser";
+import { BracketDisambiguation, IParser, IParserStateCheckpoint, IParserUtils } from "../IParser";
 import { IParserState, IParserStateUtils } from "../IParserState";
 
 // If the Naive parser were to parse the expression '1' it would need to recurse down a dozen or so constructs,
@@ -23,6 +23,9 @@ import { IParserState, IParserStateUtils } from "../IParserState";
 // readUnaryExpression uses limited look ahead to eliminate several function calls on the call stack.
 export const CombinatorialParser: IParser<IParserState> = {
     ...NaiveParseSteps,
+    createCheckpoint: (state: IParserState) => IParserUtils.stateCheckpointFactory(state),
+    restoreCheckpoint: (state: IParserState, checkpoint: IParserStateCheckpoint) =>
+        IParserUtils.restoreStateCheckpoint(state, checkpoint),
 
     // 12.2.3.2 Logical expressions
     readLogicalExpression: (state: IParserState, parser: IParser<IParserState>) =>

--- a/src/parser/parsers/combinatorialParser.ts
+++ b/src/parser/parsers/combinatorialParser.ts
@@ -24,7 +24,7 @@ import { IParserState, IParserStateUtils } from "../IParserState";
 export const CombinatorialParser: IParser<IParserState> = {
     ...NaiveParseSteps,
     createCheckpoint: (state: IParserState) => IParserUtils.stateCheckpointFactory(state),
-    restoreCheckpoint: (state: IParserState, checkpoint: IParserStateCheckpoint) =>
+    restoreFromCheckpoint: (state: IParserState, checkpoint: IParserStateCheckpoint) =>
         IParserUtils.restoreStateCheckpoint(state, checkpoint),
 
     // 12.2.3.2 Logical expressions

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -190,7 +190,7 @@ export function readDocument<S extends IParserState = IParserState>(state: S, pa
             let triedError: Error;
             if (expressionCheckpoint.tokenIndex > /* sectionErrorState */ state.tokenIndex) {
                 triedError = expressionError;
-                parser.restoreCheckpoint(state, expressionCheckpoint);
+                parser.restoreFromCheckpoint(state, expressionCheckpoint);
                 state.contextState = expressionErrorContextState;
             } else {
                 triedError = sectionError;
@@ -1657,7 +1657,7 @@ function tryReadPrimaryType<S extends IParserState = IParserState>(state: S, par
         const triedReadPrimitiveType: TriedReadPrimaryType = tryReadPrimitiveType(state, parser);
 
         if (ResultUtils.isErr(triedReadPrimitiveType)) {
-            parser.restoreCheckpoint(state, checkpoint);
+            parser.restoreFromCheckpoint(state, checkpoint);
         }
         return triedReadPrimitiveType;
     }
@@ -1912,7 +1912,7 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
 
             default:
                 const token: Token.Token = IParserStateUtils.assertGetTokenAt(state, state.tokenIndex);
-                parser.restoreCheckpoint(state, checkpoint);
+                parser.restoreFromCheckpoint(state, checkpoint);
                 return ResultUtils.errFactory(
                     new ParseError.InvalidPrimitiveTypeError(
                         state.locale,
@@ -1929,7 +1929,7 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
         readToken(state);
     } else {
         const details: {} = { tokenKind: state.maybeCurrentTokenKind };
-        parser.restoreCheckpoint(state, checkpoint);
+        parser.restoreFromCheckpoint(state, checkpoint);
         return ResultUtils.errFactory(
             new CommonError.InvariantError(`unknown currentTokenKind, not found in [${expectedTokenKinds}]`, details),
         );
@@ -1980,7 +1980,7 @@ export function disambiguateParenthesis<S extends IParserState = IParserState>(
                 try {
                     parser.readNullablePrimitiveType(state, parser);
                 } catch {
-                    parser.restoreCheckpoint(state, checkpoint);
+                    parser.restoreFromCheckpoint(state, checkpoint);
                     if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.FatArrow)) {
                         return ResultUtils.okFactory(ParenthesisDisambiguation.FunctionExpression);
                     } else {
@@ -1995,7 +1995,7 @@ export function disambiguateParenthesis<S extends IParserState = IParserState>(
                     disambiguation = ParenthesisDisambiguation.ParenthesizedExpression;
                 }
 
-                parser.restoreCheckpoint(state, checkpoint);
+                parser.restoreFromCheckpoint(state, checkpoint);
                 return ResultUtils.okFactory(disambiguation);
             } else {
                 if (IParserStateUtils.isTokenKind(state, Token.TokenKind.FatArrow, offsetTokenIndex + 1)) {

--- a/src/parser/parsers/recursiveDescentParser.ts
+++ b/src/parser/parsers/recursiveDescentParser.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import { NaiveParseSteps } from ".";
-import { IParser } from "../IParser";
+import { IParser, IParserStateCheckpoint, IParserUtils } from "../IParser";
 import { IParserState } from "../IParserState";
 
-export let RecursiveDescentParser: IParser<IParserState> = { ...NaiveParseSteps };
+export let RecursiveDescentParser: IParser<IParserState> = {
+    ...NaiveParseSteps,
+    createCheckpoint: (state: IParserState) => IParserUtils.stateCheckpointFactory(state),
+    restoreCheckpoint: (state: IParserState, checkpoint: IParserStateCheckpoint) =>
+        IParserUtils.restoreStateCheckpoint(state, checkpoint),
+};

--- a/src/parser/parsers/recursiveDescentParser.ts
+++ b/src/parser/parsers/recursiveDescentParser.ts
@@ -8,6 +8,6 @@ import { IParserState } from "../IParserState";
 export let RecursiveDescentParser: IParser<IParserState> = {
     ...NaiveParseSteps,
     createCheckpoint: (state: IParserState) => IParserUtils.stateCheckpointFactory(state),
-    restoreCheckpoint: (state: IParserState, checkpoint: IParserStateCheckpoint) =>
+    restoreFromCheckpoint: (state: IParserState, checkpoint: IParserStateCheckpoint) =>
         IParserUtils.restoreStateCheckpoint(state, checkpoint),
 };

--- a/src/test/resourceTest/benchmarkParser.ts
+++ b/src/test/resourceTest/benchmarkParser.ts
@@ -32,7 +32,7 @@ export interface FunctionTimestamp {
 
 export const BenchmarkParser: IParser<BenchmarkState> = {
     createCheckpoint: (state: IParserState) => IParserUtils.stateCheckpointFactory(state),
-    restoreCheckpoint: (state: IParserState, checkpoint: IParserStateCheckpoint) =>
+    restoreFromCheckpoint: (state: IParserState, checkpoint: IParserStateCheckpoint) =>
         IParserUtils.restoreStateCheckpoint(state, checkpoint),
 
     // 12.1.6 Identifiers

--- a/src/test/resourceTest/benchmarkParser.ts
+++ b/src/test/resourceTest/benchmarkParser.ts
@@ -6,7 +6,7 @@ import performanceNow = require("performance-now");
 
 import { Ast, Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
-import { IParser } from "../../parser/IParser";
+import { IParser, IParserStateCheckpoint, IParserUtils } from "../../parser/IParser";
 import { IParserState, IParserStateUtils } from "../../parser/IParserState";
 import { ParseSettings } from "../../settings";
 
@@ -31,6 +31,10 @@ export interface FunctionTimestamp {
 }
 
 export const BenchmarkParser: IParser<BenchmarkState> = {
+    createCheckpoint: (state: IParserState) => IParserUtils.stateCheckpointFactory(state),
+    restoreCheckpoint: (state: IParserState, checkpoint: IParserStateCheckpoint) =>
+        IParserUtils.restoreStateCheckpoint(state, checkpoint),
+
     // 12.1.6 Identifiers
     readIdentifier: (state: BenchmarkState, parser: IParser<BenchmarkState>) =>
         traceFunction(state, parser, state.baseParser.readIdentifier),


### PR DESCRIPTION
The parser code has for some time allowed for an arbitrary object to be its state object. The problem was the internals sometimes assumed state was IParserState, not something that extends IParserState. The state backup/restore was one of those sections. This elevates the state save/loads to the parser level.