### PR TITLE
Better signature for parserStateFactory

### DIFF
--- a/src/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -474,12 +474,11 @@ function tryParseFieldAccess<T extends Ast.FieldProjection | Ast.FieldSelector, 
     parserState: S,
     parseFn: (state: S, parser: IParser<S>) => T,
 ): AdditionalParse {
-    const newState: S = parseSettings.parserStateFactory(
-        parserState.maybeCancellationToken,
-        parserState.lexerSnapshot,
-        parserState.tokenIndex,
-        parseSettings.locale,
-    );
+    const newState: S = parseSettings.parserStateFactory(parserState.lexerSnapshot, {
+        maybeCancellationToken: parserState.maybeCancellationToken,
+        locale: parseSettings.locale,
+        tokenIndex: parserState.tokenIndex,
+    });
 
     try {
         const ast: T = parseFn(newState, parseSettings.parser);

--- a/src/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -144,12 +144,11 @@ function parseFunctionExpression<S extends IParserState = IParserState>(
     parseSettings: ParseSettings<S>,
     parserState: S,
 ): AdditionalParse<S> {
-    const newState: S = parseSettings.parserStateFactory(
-        parseSettings.maybeCancellationToken,
-        parserState.lexerSnapshot,
-        parserState.tokenIndex,
-        parseSettings.locale,
-    );
+    const newState: S = parseSettings.parserStateFactory(parserState.lexerSnapshot, {
+        maybeCancellationToken: parserState.maybeCancellationToken,
+        locale: parseSettings.locale,
+        tokenIndex: parserState.tokenIndex,
+    });
 
     try {
         return {

--- a/src/parser/IParser/IParserUtils.ts
+++ b/src/parser/IParser/IParserUtils.ts
@@ -22,12 +22,9 @@ export function tryParse<S extends IParserState = IParserState>(
         return tryParseDocument<S>(parseSettings, lexerSnapshot) as TriedParse<S>;
     }
 
-    const parseState: S = parseSettings.parserStateFactory(
-        parseSettings.maybeCancellationToken,
-        lexerSnapshot,
-        0,
-        parseSettings.locale,
-    );
+    const parseState: S = parseSettings.parserStateFactory(lexerSnapshot, {
+        maybeCancellationToken: parseSettings.maybeCancellationToken,
+    });
     try {
         const root: Ast.TNode = maybeEntryPointFn(parseState, parseSettings.parser);
         IParserStateUtils.assertNoMoreTokens(parseState);
@@ -48,12 +45,10 @@ export function tryParseDocument<S extends IParserState = IParserState>(
 ): TriedParse {
     let root: Ast.TNode;
 
-    const expressionDocumentState: S = parseSettings.parserStateFactory(
-        parseSettings.maybeCancellationToken,
-        lexerSnapshot,
-        0,
-        parseSettings.locale,
-    );
+    const expressionDocumentState: S = parseSettings.parserStateFactory(lexerSnapshot, {
+        maybeCancellationToken: parseSettings.maybeCancellationToken,
+        locale: parseSettings.locale,
+    });
     try {
         root = parseSettings.parser.readExpression(expressionDocumentState, parseSettings.parser);
         IParserStateUtils.assertNoMoreTokens(expressionDocumentState);
@@ -64,12 +59,10 @@ export function tryParseDocument<S extends IParserState = IParserState>(
             state: expressionDocumentState,
         });
     } catch (expressionDocumentError) {
-        const sectionDocumentState: S = parseSettings.parserStateFactory(
-            parseSettings.maybeCancellationToken,
-            lexerSnapshot,
-            0,
-            parseSettings.locale,
-        );
+        const sectionDocumentState: S = parseSettings.parserStateFactory(lexerSnapshot, {
+            maybeCancellationToken: parseSettings.maybeCancellationToken,
+            locale: parseSettings.locale,
+        });
         try {
             root = parseSettings.parser.readSectionDocument(sectionDocumentState, parseSettings.parser);
             IParserStateUtils.assertNoMoreTokens(sectionDocumentState);

--- a/src/parser/IParser/IParserUtils.ts
+++ b/src/parser/IParser/IParserUtils.ts
@@ -24,6 +24,7 @@ export function tryParse<S extends IParserState = IParserState>(
 
     const parseState: S = parseSettings.parserStateFactory(lexerSnapshot, {
         maybeCancellationToken: parseSettings.maybeCancellationToken,
+        locale: parseSettings.locale,
     });
     try {
         const root: Ast.TNode = maybeEntryPointFn(parseState, parseSettings.parser);

--- a/src/parser/IParserState/IParserState.ts
+++ b/src/parser/IParserState/IParserState.ts
@@ -6,7 +6,7 @@ import { ICancellationToken } from "../../common";
 import { Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 
-export type TParserStateOverrides = Partial<
+export type TParserStateFactoryOverrides = Partial<
     Omit<IParserState, "lexerSnapshot" | "maybeCurrentToken" | "maybeCurrentTokenKind" | "maybeCurrentContextNode">
 >;
 

--- a/src/parser/IParserState/IParserState.ts
+++ b/src/parser/IParserState/IParserState.ts
@@ -6,9 +6,13 @@ import { ICancellationToken } from "../../common";
 import { Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 
+export type TParserStateOverrides = Partial<
+    Omit<IParserState, "lexerSnapshot" | "maybeCurrentToken" | "maybeCurrentTokenKind" | "maybeCurrentContextNode">
+>;
+
 export interface IParserState {
-    readonly maybeCancellationToken: ICancellationToken | undefined;
     readonly lexerSnapshot: LexerSnapshot;
+    readonly maybeCancellationToken: ICancellationToken | undefined;
     readonly locale: string;
     tokenIndex: number;
     maybeCurrentToken: Token.Token | undefined;

--- a/src/parser/IParserState/IParserStateUtils.ts
+++ b/src/parser/IParserState/IParserStateUtils.ts
@@ -7,20 +7,18 @@ import { Ast, Constant, Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 import { DefaultLocale } from "../../localization";
 import { SequenceKind } from "../error";
-import { IParserState } from "./IParserState";
+import { IParserState, TParserStateFactoryOverrides } from "./IParserState";
 
 // If you have a custom parser + parser state, then you'll have to create your own factory function.
 // See `benchmark.ts` for an example.
 export function stateFactory(
     lexerSnapshot: LexerSnapshot,
-    overrides:
-        | Partial<Omit<IParserState, "maybeCurrentToken" | "maybeCurrentTokenKind" | "maybeCurrentContextNode">>
-        | undefined,
+    maybeOverrides: TParserStateFactoryOverrides | undefined,
 ): IParserState {
-    const tokenIndex: number = overrides?.tokenIndex ?? 0;
+    const tokenIndex: number = maybeOverrides?.tokenIndex ?? 0;
     const maybeCurrentToken: Token.Token | undefined = lexerSnapshot.tokens[tokenIndex];
     const maybeCurrentTokenKind: Token.TokenKind | undefined = maybeCurrentToken?.kind;
-    const contextState: ParseContext.State = overrides?.contextState ?? ParseContextUtils.stateFactory();
+    const contextState: ParseContext.State = maybeOverrides?.contextState ?? ParseContextUtils.stateFactory();
 
     const maybeCurrentContextNodeId: number | undefined =
         contextState.nodeIdMapCollection.contextNodeById.size > 0
@@ -34,12 +32,12 @@ export function stateFactory(
 
     return {
         lexerSnapshot,
-        maybeCancellationToken: overrides?.maybeCancellationToken,
-        locale: overrides?.locale ?? DefaultLocale,
+        maybeCancellationToken: maybeOverrides?.maybeCancellationToken,
+        locale: maybeOverrides?.locale ?? DefaultLocale,
         tokenIndex,
         maybeCurrentToken,
         maybeCurrentTokenKind,
-        contextState: overrides?.contextState ?? ParseContextUtils.stateFactory(),
+        contextState: maybeOverrides?.contextState ?? ParseContextUtils.stateFactory(),
         maybeCurrentContextNode,
     };
 }

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -24,7 +24,7 @@ export interface LexSettings extends CommonSettings {}
 export interface ParseSettings<S extends IParserState = IParserState> extends CommonSettings {
     readonly parser: IParser<S>;
     readonly maybeParserOptions: ParserOptions<S> | undefined;
-    readonly parserStateFactory: (lexerSnapshot: LexerSnapshot, overrides: TParserStateOverrides | undefined) => S;
+    readonly parserStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParserStateOverrides | undefined) => S;
 }
 
 export type Settings<S extends IParserState = IParserState> = LexSettings & ParseSettings<S>;
@@ -34,6 +34,6 @@ export const DefaultSettings: Settings<IParserState> = {
     locale: DefaultLocale,
     parser: CombinatorialParser,
     maybeParserOptions: undefined,
-    parserStateFactory: (lexerSnapshot: LexerSnapshot, overrides: TParserStateOverrides | undefined) =>
-        IParserStateUtils.stateFactory(lexerSnapshot, overrides),
+    parserStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParserStateOverrides | undefined) =>
+        IParserStateUtils.stateFactory(lexerSnapshot, maybeOverrides),
 };

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -10,7 +10,7 @@ import {
     IParserState,
     IParserStateUtils,
     ParserOptions,
-    TParserStateOverrides,
+    TParserStateFactoryOverrides,
 } from "../parser";
 
 export interface CommonSettings {
@@ -24,7 +24,10 @@ export interface LexSettings extends CommonSettings {}
 export interface ParseSettings<S extends IParserState = IParserState> extends CommonSettings {
     readonly parser: IParser<S>;
     readonly maybeParserOptions: ParserOptions<S> | undefined;
-    readonly parserStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParserStateOverrides | undefined) => S;
+    readonly parserStateFactory: (
+        lexerSnapshot: LexerSnapshot,
+        maybeOverrides: TParserStateFactoryOverrides | undefined,
+    ) => S;
 }
 
 export type Settings<S extends IParserState = IParserState> = LexSettings & ParseSettings<S>;
@@ -34,6 +37,6 @@ export const DefaultSettings: Settings<IParserState> = {
     locale: DefaultLocale,
     parser: CombinatorialParser,
     maybeParserOptions: undefined,
-    parserStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParserStateOverrides | undefined) =>
+    parserStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParserStateFactoryOverrides | undefined) =>
         IParserStateUtils.stateFactory(lexerSnapshot, maybeOverrides),
 };

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -3,8 +3,15 @@
 
 import { ICancellationToken } from "../common";
 import { LexerSnapshot } from "../lexer";
-import { DefaultLocale, Locale } from "../localization";
-import { CombinatorialParser, IParser, IParserState, IParserStateUtils, ParserOptions } from "../parser";
+import { DefaultLocale } from "../localization";
+import {
+    CombinatorialParser,
+    IParser,
+    IParserState,
+    IParserStateUtils,
+    ParserOptions,
+    TParserStateOverrides,
+} from "../parser";
 
 export interface CommonSettings {
     readonly maybeCancellationToken: ICancellationToken | undefined;
@@ -17,12 +24,7 @@ export interface LexSettings extends CommonSettings {}
 export interface ParseSettings<S extends IParserState = IParserState> extends CommonSettings {
     readonly parser: IParser<S>;
     readonly maybeParserOptions: ParserOptions<S> | undefined;
-    readonly parserStateFactory: (
-        maybeCancellationToken: ICancellationToken | undefined,
-        lexerSnapshot: LexerSnapshot,
-        tokenIndex: number,
-        maybeLocale: string | undefined,
-    ) => S;
+    readonly parserStateFactory: (lexerSnapshot: LexerSnapshot, overrides: TParserStateOverrides | undefined) => S;
 }
 
 export type Settings<S extends IParserState = IParserState> = LexSettings & ParseSettings<S>;
@@ -32,10 +34,6 @@ export const DefaultSettings: Settings<IParserState> = {
     locale: DefaultLocale,
     parser: CombinatorialParser,
     maybeParserOptions: undefined,
-    parserStateFactory: (
-        maybeCancellationToken: ICancellationToken | undefined,
-        lexerSnapshot: LexerSnapshot,
-        tokenIndex: number,
-        maybeLocale: string | undefined,
-    ) => IParserStateUtils.stateFactory(maybeCancellationToken, lexerSnapshot, tokenIndex, maybeLocale ?? Locale.en_US),
+    parserStateFactory: (lexerSnapshot: LexerSnapshot, overrides: TParserStateOverrides | undefined) =>
+        IParserStateUtils.stateFactory(lexerSnapshot, overrides),
 };

--- a/src/test/resourceTest/benchmark.ts
+++ b/src/test/resourceTest/benchmark.ts
@@ -67,8 +67,8 @@ function benchmarkParseSettingsFactory(baseParser: IParser<IParserState>): Parse
     return {
         maybeCancellationToken: undefined,
         parser: BenchmarkParser,
-        parserStateFactory: (lexerSnapshot: LexerSnapshot, overrides: TParserStateOverrides | undefined) =>
-            benchmarkStateFactory(lexerSnapshot, overrides, baseParser),
+        parserStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParserStateOverrides | undefined) =>
+            benchmarkStateFactory(lexerSnapshot, maybeOverrides, baseParser),
         maybeParserOptions: undefined,
         locale: DefaultLocale,
     };

--- a/src/test/resourceTest/benchmark.ts
+++ b/src/test/resourceTest/benchmark.ts
@@ -52,11 +52,11 @@ writeReport(ResourceDirectory, allSummaries);
 
 function benchmarkStateFactory(
     lexerSnapshot: LexerSnapshot,
-    overrides: TParserStateOverrides | undefined,
+    maybeOverrides: TParserStateOverrides | undefined,
     baseParser: IParser<IParserState>,
 ): BenchmarkState {
     return {
-        ...IParserStateUtils.stateFactory(lexerSnapshot, overrides),
+        ...IParserStateUtils.stateFactory(lexerSnapshot, maybeOverrides),
         baseParser,
         functionTimestamps: new Map(),
         functionTimestampCounter: 0,

--- a/src/test/resourceTest/benchmark.ts
+++ b/src/test/resourceTest/benchmark.ts
@@ -6,10 +6,17 @@ import performanceNow = require("performance-now");
 
 import "mocha";
 import { Task } from "../..";
-import { ICancellationToken, ResultUtils } from "../../common";
+import { ResultUtils } from "../../common";
 import { LexerSnapshot } from "../../lexer";
-import { DefaultLocale, Locale } from "../../localization";
-import { CombinatorialParser, IParser, IParserState, IParserStateUtils, RecursiveDescentParser } from "../../parser";
+import { DefaultLocale } from "../../localization";
+import {
+    CombinatorialParser,
+    IParser,
+    IParserState,
+    IParserStateUtils,
+    RecursiveDescentParser,
+    TParserStateOverrides,
+} from "../../parser";
 import { ParseSettings } from "../../settings";
 import { TestFileUtils } from "../testUtils";
 import { BenchmarkParser, BenchmarkState, FunctionTimestamp } from "./benchmarkParser";
@@ -43,9 +50,13 @@ for (const [parseSettings, parserName] of Parsers) {
 
 writeReport(ResourceDirectory, allSummaries);
 
-function benchmarkStateFactory(lexerSnapshot: LexerSnapshot, baseParser: IParser<IParserState>): BenchmarkState {
+function benchmarkStateFactory(
+    lexerSnapshot: LexerSnapshot,
+    overrides: TParserStateOverrides | undefined,
+    baseParser: IParser<IParserState>,
+): BenchmarkState {
     return {
-        ...IParserStateUtils.stateFactory(undefined, lexerSnapshot, 0, Locale.en_US),
+        ...IParserStateUtils.stateFactory(lexerSnapshot, overrides),
         baseParser,
         functionTimestamps: new Map(),
         functionTimestampCounter: 0,
@@ -56,8 +67,8 @@ function benchmarkParseSettingsFactory(baseParser: IParser<IParserState>): Parse
     return {
         maybeCancellationToken: undefined,
         parser: BenchmarkParser,
-        parserStateFactory: (_cancellationToken: ICancellationToken | undefined, lexerSnapshot: LexerSnapshot) =>
-            benchmarkStateFactory(lexerSnapshot, baseParser),
+        parserStateFactory: (lexerSnapshot: LexerSnapshot, overrides: TParserStateOverrides | undefined) =>
+            benchmarkStateFactory(lexerSnapshot, overrides, baseParser),
         maybeParserOptions: undefined,
         locale: DefaultLocale,
     };

--- a/src/test/resourceTest/benchmark.ts
+++ b/src/test/resourceTest/benchmark.ts
@@ -15,7 +15,7 @@ import {
     IParserState,
     IParserStateUtils,
     RecursiveDescentParser,
-    TParserStateOverrides,
+    TParserStateFactoryOverrides,
 } from "../../parser";
 import { ParseSettings } from "../../settings";
 import { TestFileUtils } from "../testUtils";
@@ -52,7 +52,7 @@ writeReport(ResourceDirectory, allSummaries);
 
 function benchmarkStateFactory(
     lexerSnapshot: LexerSnapshot,
-    maybeOverrides: TParserStateOverrides | undefined,
+    maybeOverrides: TParserStateFactoryOverrides | undefined,
     baseParser: IParser<IParserState>,
 ): BenchmarkState {
     return {
@@ -67,7 +67,7 @@ function benchmarkParseSettingsFactory(baseParser: IParser<IParserState>): Parse
     return {
         maybeCancellationToken: undefined,
         parser: BenchmarkParser,
-        parserStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParserStateOverrides | undefined) =>
+        parserStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParserStateFactoryOverrides | undefined) =>
             benchmarkStateFactory(lexerSnapshot, maybeOverrides, baseParser),
         maybeParserOptions: undefined,
         locale: DefaultLocale,

--- a/src/test/resourceTest/benchmarkParser.ts
+++ b/src/test/resourceTest/benchmarkParser.ts
@@ -288,7 +288,9 @@ export function benchmarkStateFactory<S extends IParserState = IParserState>(
     baseParser: IParser<IParserState>,
 ): BenchmarkState {
     return {
-        ...IParserStateUtils.stateFactory(parseSettings.maybeCancellationToken, lexerSnapshot, 0, parseSettings.locale),
+        ...IParserStateUtils.stateFactory(lexerSnapshot, {
+            maybeCancellationToken: parseSettings.maybeCancellationToken,
+        }),
         baseParser,
         functionTimestamps: new Map(),
         functionTimestampCounter: 0,


### PR DESCRIPTION
Generalized the default parserStateFactory (`IParserStateUtils.stateFactory`). It now accepts `Partial<Omit<S>>` instead of a hard coded list of parameters.