### PR TITLE
Rename Parser -> Parse

### DIFF
--- a/src/inspection/autocomplete/commonTypes.ts
+++ b/src/inspection/autocomplete/commonTypes.ts
@@ -3,7 +3,7 @@
 
 import { CommonError, Result } from "../../common";
 import { Constant, Keyword, Token, Type } from "../../language";
-import { IParserState, ParseError, TXorNode } from "../../parser";
+import { IParseState, ParseError, TXorNode } from "../../parser";
 
 export type TriedAutocompleteFieldAccess = Result<AutocompleteFieldAccess | undefined, CommonError.CommonError>;
 
@@ -51,8 +51,8 @@ export interface TrailingToken extends Token.Token {
     readonly isInOrOnPosition: boolean;
 }
 
-export interface AdditionalParse<S extends IParserState = IParserState> {
+export interface AdditionalParse<S extends IParseState = IParseState> {
     readonly root: TXorNode;
-    readonly parserState: S;
+    readonly parseState: S;
     readonly maybeParseError: ParseError.ParseError<S> | undefined;
 }

--- a/src/inspection/autocomplete/task.ts
+++ b/src/inspection/autocomplete/task.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Token } from "../../language";
-import { IParserState, NodeIdMap, ParseError } from "../../parser";
+import { IParseState, NodeIdMap, ParseError } from "../../parser";
 import { ParseSettings } from "../../settings";
 import { TMaybeActiveNode } from "../activeNode";
 import { TypeCache } from "../type/commonTypes";
@@ -20,15 +20,15 @@ import {
     TriedAutocompletePrimitiveType,
 } from "./commonTypes";
 
-export function autocomplete<S extends IParserState = IParserState>(
+export function autocomplete<S extends IParseState = IParseState>(
     parseSettings: ParseSettings<S>,
-    parserState: S,
+    parseState: S,
     typeCache: TypeCache,
     maybeActiveNode: TMaybeActiveNode,
     maybeParseError: ParseError.ParseError<S> | undefined,
 ): Autocomplete {
-    const nodeIdMapCollection: NodeIdMap.Collection = parserState.contextState.nodeIdMapCollection;
-    const leafNodeIds: ReadonlyArray<number> = parserState.contextState.leafNodeIds;
+    const nodeIdMapCollection: NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
+    const leafNodeIds: ReadonlyArray<number> = parseState.contextState.leafNodeIds;
 
     let maybeTrailingToken: TrailingToken | undefined;
     if (maybeParseError !== undefined) {
@@ -40,7 +40,7 @@ export function autocomplete<S extends IParserState = IParserState>(
 
     const triedFieldAccess: TriedAutocompleteFieldAccess = tryAutocompleteFieldAccess(
         parseSettings,
-        parserState,
+        parseState,
         maybeActiveNode,
         typeCache,
         maybeParseError,
@@ -56,7 +56,7 @@ export function autocomplete<S extends IParserState = IParserState>(
 
     const triedLanguageConstant: TriedAutocompleteLanguageConstant = tryAutocompleteLanguageConstant(
         parseSettings,
-        parserState,
+        parseState,
         maybeActiveNode,
         maybeParseError,
     );

--- a/src/inspection/task.ts
+++ b/src/inspection/task.ts
@@ -1,6 +1,6 @@
 import { ResultUtils } from "../common";
 import { TriedExpectedType, tryExpectedType } from "../language/type/expectedType";
-import { AncestryUtils, IParserState, NodeIdMap, ParseError, TXorNode } from "../parser";
+import { AncestryUtils, IParseState, NodeIdMap, ParseError, TXorNode } from "../parser";
 import { ParseSettings } from "../settings";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "./activeNode";
 import { autocomplete } from "./autocomplete";
@@ -11,14 +11,14 @@ import { ScopeById, TriedNodeScope, tryNodeScope } from "./scope";
 import { TriedScopeType, tryScopeType } from "./type";
 import { TypeCache } from "./type/commonTypes";
 
-export function inspection<S extends IParserState = IParserState>(
+export function inspection<S extends IParseState = IParseState>(
     parseSettings: ParseSettings<S>,
-    parserState: S,
+    parseState: S,
     maybeParseError: ParseError.ParseError<S> | undefined,
     position: Position,
 ): Inspection {
-    const nodeIdMapCollection: NodeIdMap.Collection = parserState.contextState.nodeIdMapCollection;
-    const leafNodeIds: ReadonlyArray<number> = parserState.contextState.leafNodeIds;
+    const nodeIdMapCollection: NodeIdMap.Collection = parseState.contextState.nodeIdMapCollection;
+    const leafNodeIds: ReadonlyArray<number> = parseState.contextState.leafNodeIds;
 
     // We should only get an undefined for activeNode iff the document is empty
     const maybeActiveNode: TMaybeActiveNode = ActiveNodeUtils.maybeActiveNode(
@@ -66,7 +66,7 @@ export function inspection<S extends IParserState = IParserState>(
 
     return {
         maybeActiveNode,
-        autocomplete: autocomplete(parseSettings, parserState, typeCache, maybeActiveNode, maybeParseError),
+        autocomplete: autocomplete(parseSettings, parseState, typeCache, maybeActiveNode, maybeParseError),
         triedInvokeExpression,
         triedNodeScope,
         triedScopeType,

--- a/src/parser/IParseState/IParseState.ts
+++ b/src/parser/IParseState/IParseState.ts
@@ -6,11 +6,11 @@ import { ICancellationToken } from "../../common";
 import { Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 
-export type TParserStateFactoryOverrides = Partial<
-    Omit<IParserState, "lexerSnapshot" | "maybeCurrentToken" | "maybeCurrentTokenKind" | "maybeCurrentContextNode">
+export type TParseStateFactoryOverrides = Partial<
+    Omit<IParseState, "lexerSnapshot" | "maybeCurrentToken" | "maybeCurrentTokenKind" | "maybeCurrentContextNode">
 >;
 
-export interface IParserState {
+export interface IParseState {
     readonly lexerSnapshot: LexerSnapshot;
     readonly maybeCancellationToken: ICancellationToken | undefined;
     readonly locale: string;

--- a/src/parser/IParseState/index.ts
+++ b/src/parser/IParseState/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as IParseStateUtils from "./IParseStateUtils";
+
+export { IParseStateUtils };
+export * from "./IParseState";

--- a/src/parser/IParser/IParser.ts
+++ b/src/parser/IParser/IParser.ts
@@ -1,31 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IParserState, ParseError } from "..";
+import { IParseState, ParseError } from "..";
 import { Result } from "../../common";
 import { Ast } from "../../language";
 
-export type TriedParse<S extends IParserState = IParserState> = Result<ParseOk<S>, ParseError.TParseError<S>>;
+export type TriedParse<S extends IParseState = IParseState> = Result<ParseOk<S>, ParseError.TParseError<S>>;
 
-export interface IParserStateCheckpoint {
+export interface IParseStateCheckpoint {
     readonly tokenIndex: number;
     readonly contextStateIdCounter: number;
     readonly maybeContextNodeId: number | undefined;
 }
 
-export interface ParseOk<S extends IParserState = IParserState> {
+export interface ParseOk<S extends IParseState = IParseState> {
     readonly root: Ast.TNode;
     readonly state: S;
 }
 
-export interface ParserOptions<S extends IParserState = IParserState> {
+export interface ParserOptions<S extends IParseState = IParseState> {
     readonly maybeEntryPoint: ((state: S, parser: IParser<S>) => Ast.TNode) | undefined;
 }
 
-export interface IParser<
-    S extends IParserState = IParserState,
-    C extends IParserStateCheckpoint = IParserStateCheckpoint
-> {
+export interface IParser<S extends IParseState = IParseState, C extends IParseStateCheckpoint = IParseStateCheckpoint> {
     readonly createCheckpoint: (state: S) => C;
     readonly restoreFromCheckpoint: (state: S, checkpoint: C) => void;
 
@@ -136,7 +133,7 @@ export interface IParser<
         state: S,
         parser: IParser<S>,
         allowOpenMarker: boolean,
-        testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
+        testPostCommaError: (state: IParseState) => ParseError.TInnerParseError | undefined,
     ) => Ast.FieldSpecificationList;
     readonly readListType: (state: S, parser: IParser<S>) => Ast.ListType;
     readonly readFunctionType: (state: S, parser: IParser<S>) => Ast.FunctionType;
@@ -155,7 +152,7 @@ export interface IParser<
         state: S,
         parser: IParser<S>,
         onePairRequired: boolean,
-        testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
+        testPostCommaError: (state: IParseState) => ParseError.TInnerParseError | undefined,
     ) => Ast.ICsvArray<Ast.GeneralizedIdentifierPairedAnyLiteral>;
     readonly readListLiteral: (state: S, parser: IParser<S>) => Ast.ListLiteral;
     readonly readAnyLiteral: (state: S, parser: IParser<S>) => Ast.TAnyLiteral;
@@ -165,14 +162,14 @@ export interface IParser<
         state: S,
         parser: IParser<S>,
         onePairRequired: boolean,
-        testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
+        testPostCommaError: (state: IParseState) => ParseError.TInnerParseError | undefined,
     ) => Ast.ICsvArray<Ast.IdentifierPairedExpression>;
     readonly readIdentifierPairedExpression: (state: S, parser: IParser<S>) => Ast.IdentifierPairedExpression;
     readonly readGeneralizedIdentifierPairedExpressions: (
         state: S,
         parser: IParser<S>,
         onePairRequired: boolean,
-        testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
+        testPostCommaError: (state: IParseState) => ParseError.TInnerParseError | undefined,
     ) => Ast.ICsvArray<Ast.GeneralizedIdentifierPairedExpression>;
     readonly readGeneralizedIdentifierPairedExpression: (
         state: S,

--- a/src/parser/IParserState/index.ts
+++ b/src/parser/IParserState/index.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-import * as IParserStateUtils from "./IParserStateUtils";
-
-export { IParserStateUtils };
-export * from "./IParserState";

--- a/src/parser/error.ts
+++ b/src/parser/error.ts
@@ -4,9 +4,9 @@
 import { Assert, CommonError, StringUtils } from "../common";
 import { Token } from "../language";
 import { Localization, LocalizationUtils } from "../localization";
-import { IParserState } from "./IParserState";
+import { IParseState } from "./IParseState";
 
-export type TParseError<S extends IParserState = IParserState> = CommonError.CommonError | ParseError<S>;
+export type TParseError<S extends IParseState = IParseState> = CommonError.CommonError | ParseError<S>;
 
 export type TInnerParseError =
     | ExpectedAnyTokenKindError
@@ -28,7 +28,7 @@ export const enum SequenceKind {
     Parenthesis = "Parenthesis",
 }
 
-export class ParseError<S extends IParserState = IParserState> extends Error {
+export class ParseError<S extends IParseState = IParseState> extends Error {
     constructor(readonly innerError: TInnerParseError, readonly state: S) {
         super(innerError.message);
         Object.setPrototypeOf(this, ParseError.prototype);
@@ -140,16 +140,16 @@ export interface TokenWithColumnNumber {
     readonly columnNumber: number;
 }
 
-export function assertIsParseError<S extends IParserState = IParserState>(error: any): error is ParseError<S> {
+export function assertIsParseError<S extends IParseState = IParseState>(error: any): error is ParseError<S> {
     Assert.isTrue(isParseError(error), "isParseError(error)");
     return true;
 }
 
-export function isParseError<S extends IParserState = IParserState>(error: any): error is ParseError<S> {
+export function isParseError<S extends IParseState = IParseState>(error: any): error is ParseError<S> {
     return error instanceof ParseError;
 }
 
-export function isTParseError<S extends IParserState = IParserState>(error: any): error is TParseError<S> {
+export function isTParseError<S extends IParseState = IParseState>(error: any): error is TParseError<S> {
     return isParseError(error) || CommonError.isCommonError(error);
 }
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -6,6 +6,6 @@ import * as ParseError from "./error";
 export { ParseError };
 export * from "./context";
 export * from "./IParser";
-export * from "./IParserState";
+export * from "./IParseState";
 export * from "./nodeIdMap";
 export * from "./parsers";

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -15,8 +15,8 @@ import {
 import { Ast, AstUtils, Constant, ConstantUtils, Token } from "../../language";
 import { LexerSnapshot } from "../../lexer";
 import { Disambiguation, DisambiguationUtils } from "../disambiguation";
-import { IParser, IParserStateCheckpoint } from "../IParser";
-import { IParserState, IParserStateUtils } from "../IParserState";
+import { IParser, IParseStateCheckpoint } from "../IParser";
+import { IParseState, IParseStateUtils } from "../IParseState";
 import { NodeIdMapUtils } from "../nodeIdMap";
 
 type TriedReadPrimaryType = Result<
@@ -48,32 +48,32 @@ const GeneralizedIdentifierTerminatorTokenKinds: ReadonlyArray<Token.TokenKind> 
 // ---------- 12.1.6 Identifiers ----------
 // ----------------------------------------
 
-export function readIdentifier<S extends IParserState = IParserState>(
-    state: IParserState,
+export function readIdentifier<S extends IParseState = IParseState>(
+    state: IParseState,
     _parser: IParser<S>,
 ): Ast.Identifier {
     const nodeKind: Ast.NodeKind.Identifier = Ast.NodeKind.Identifier;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const literal: string = readTokenKind(state, Token.TokenKind.Identifier);
 
     const astNode: Ast.Identifier = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: true,
         literal,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
 // This behavior matches the C# parser and not the language specification.
-export function readGeneralizedIdentifier<S extends IParserState = IParserState>(
+export function readGeneralizedIdentifier<S extends IParseState = IParseState>(
     state: S,
     _parser: IParser<S>,
 ): Ast.GeneralizedIdentifier {
     const nodeKind: Ast.NodeKind.GeneralizedIdentifier = Ast.NodeKind.GeneralizedIdentifier;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const tokenRangeStartIndex: number = state.tokenIndex;
     let tokenRangeEndIndex: number = tokenRangeStartIndex;
@@ -88,7 +88,7 @@ export function readGeneralizedIdentifier<S extends IParserState = IParserState>
     if (tokenRangeStartIndex === tokenRangeEndIndex) {
         throw new ParseError.ExpectedGeneralizedIdentifierError(
             state.locale,
-            IParserStateUtils.maybeTokenWithColumnNumber(state, state.tokenIndex + 1),
+            IParseStateUtils.maybeTokenWithColumnNumber(state, state.tokenIndex + 1),
         );
     }
 
@@ -105,50 +105,50 @@ export function readGeneralizedIdentifier<S extends IParserState = IParserState>
     ) {
         throw new ParseError.ExpectedGeneralizedIdentifierError(
             state.locale,
-            IParserStateUtils.maybeTokenWithColumnNumber(state, state.tokenIndex + 1),
+            IParseStateUtils.maybeTokenWithColumnNumber(state, state.tokenIndex + 1),
         );
     }
 
     const astNode: Ast.GeneralizedIdentifier = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: true,
         literal,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
-export function readKeyword<S extends IParserState = IParserState>(
-    state: IParserState,
+export function readKeyword<S extends IParseState = IParseState>(
+    state: IParseState,
     _parser: IParser<S>,
 ): Ast.IdentifierExpression {
     const identifierExpressionNodeKind: Ast.NodeKind.IdentifierExpression = Ast.NodeKind.IdentifierExpression;
-    IParserStateUtils.startContext(state, identifierExpressionNodeKind);
+    IParseStateUtils.startContext(state, identifierExpressionNodeKind);
 
     // Keywords can't have a "@" prefix constant
-    IParserStateUtils.incrementAttributeCounter(state);
+    IParseStateUtils.incrementAttributeCounter(state);
 
     const identifierNodeKind: Ast.NodeKind.Identifier = Ast.NodeKind.Identifier;
-    IParserStateUtils.startContext(state, identifierNodeKind);
+    IParseStateUtils.startContext(state, identifierNodeKind);
 
     const literal: string = readToken(state);
     const identifier: Ast.Identifier = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: identifierNodeKind,
         isLeaf: true,
         literal,
     };
-    IParserStateUtils.endContext(state, identifier);
+    IParseStateUtils.endContext(state, identifier);
 
     const identifierExpression: Ast.IdentifierExpression = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: identifierExpressionNodeKind,
         isLeaf: false,
         maybeInclusiveConstant: undefined,
         identifier,
     };
-    IParserStateUtils.endContext(state, identifierExpression);
+    IParseStateUtils.endContext(state, identifierExpression);
     return identifierExpression;
 }
 
@@ -156,7 +156,7 @@ export function readKeyword<S extends IParserState = IParserState>(
 // ---------- 12.2.1 Documents ----------
 // --------------------------------------
 
-export function readDocument<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TDocument {
+export function readDocument<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.TDocument {
     state.maybeCancellationToken?.throwIfCancelled();
 
     let document: Ast.TDocument;
@@ -165,12 +165,12 @@ export function readDocument<S extends IParserState = IParserState>(state: S, pa
     // If both fail then return the error which parsed more tokens.
     try {
         document = parser.readExpression(state, parser);
-        IParserStateUtils.assertNoMoreTokens(state);
-        IParserStateUtils.assertNoOpenContext(state);
+        IParseStateUtils.assertNoMoreTokens(state);
+        IParseStateUtils.assertNoOpenContext(state);
     } catch (expressionError) {
         // Fast backup deletes context state, but we want to preserve it for the case
         // where both parsing an expression and section document error out.
-        const expressionCheckpoint: IParserStateCheckpoint = parser.createCheckpoint(state);
+        const expressionCheckpoint: IParseStateCheckpoint = parser.createCheckpoint(state);
         const expressionErrorContextState: ParseContext.State = state.contextState;
 
         // Reset the parser's state.
@@ -185,8 +185,8 @@ export function readDocument<S extends IParserState = IParserState>(state: S, pa
 
         try {
             document = readSectionDocument(state, parser);
-            IParserStateUtils.assertNoMoreTokens(state);
-            IParserStateUtils.assertNoOpenContext(state);
+            IParseStateUtils.assertNoMoreTokens(state);
+            IParseStateUtils.assertNoOpenContext(state);
         } catch (sectionError) {
             let triedError: Error;
             if (expressionCheckpoint.tokenIndex > /* sectionErrorState */ state.tokenIndex) {
@@ -208,10 +208,10 @@ export function readDocument<S extends IParserState = IParserState>(state: S, pa
 // ---------- 12.2.2 Section Documents ----------
 // ----------------------------------------------
 
-export function readSectionDocument<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.Section {
+export function readSectionDocument<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.Section {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.Section = Ast.NodeKind.Section;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const maybeLiteralAttributes: Ast.RecordLiteral | undefined = maybeReadLiteralAttributes(state, parser);
     const sectionConstant: Ast.IConstant<Constant.KeywordConstantKind.Section> = readTokenKindAsConstant(
@@ -221,10 +221,10 @@ export function readSectionDocument<S extends IParserState = IParserState>(state
     );
 
     let maybeName: Ast.Identifier | undefined;
-    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.Identifier)) {
+    if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.Identifier)) {
         maybeName = parser.readIdentifier(state, parser);
     } else {
-        IParserStateUtils.incrementAttributeCounter(state);
+        IParseStateUtils.incrementAttributeCounter(state);
     }
 
     const semicolonConstant: Ast.IConstant<Constant.MiscConstantKind.Semicolon> = readTokenKindAsConstant(
@@ -235,7 +235,7 @@ export function readSectionDocument<S extends IParserState = IParserState>(state
     const sectionMembers: Ast.IArrayWrapper<Ast.SectionMember> = parser.readSectionMembers(state, parser);
 
     const astNode: Ast.Section = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         maybeLiteralAttributes,
@@ -244,17 +244,17 @@ export function readSectionDocument<S extends IParserState = IParserState>(state
         semicolonConstant,
         sectionMembers,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
-export function readSectionMembers<S extends IParserState = IParserState>(
+export function readSectionMembers<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.IArrayWrapper<Ast.SectionMember> {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.ArrayWrapper = Ast.NodeKind.ArrayWrapper;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const totalTokens: number = state.lexerSnapshot.tokens.length;
     const sectionMembers: Ast.SectionMember[] = [];
@@ -263,22 +263,22 @@ export function readSectionMembers<S extends IParserState = IParserState>(
     }
 
     const astNode: Ast.IArrayWrapper<Ast.SectionMember> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         elements: sectionMembers,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
-export function readSectionMember<S extends IParserState = IParserState>(
+export function readSectionMember<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.SectionMember {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.SectionMember = Ast.NodeKind.SectionMember;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const maybeLiteralAttributes: Ast.RecordLiteral | undefined = maybeReadLiteralAttributes(state, parser);
     const maybeSharedConstant:
@@ -296,7 +296,7 @@ export function readSectionMember<S extends IParserState = IParserState>(
     );
 
     const astNode: Ast.SectionMember = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         maybeLiteralAttributes,
@@ -304,7 +304,7 @@ export function readSectionMember<S extends IParserState = IParserState>(
         namePairedExpression,
         semicolonConstant,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
@@ -316,7 +316,7 @@ export function readSectionMember<S extends IParserState = IParserState>(
 // ---------- NullCoalescing ----------
 // ------------------------------------
 
-export function readNullCoalescingExpression<S extends IParserState = IParserState>(
+export function readNullCoalescingExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.TExpression {
@@ -340,7 +340,7 @@ export function readNullCoalescingExpression<S extends IParserState = IParserSta
     );
 }
 
-export function readExpression<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TExpression {
+export function readExpression<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.TExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
     switch (state.maybeCurrentTokenKind) {
@@ -371,7 +371,7 @@ export function readExpression<S extends IParserState = IParserState>(state: S, 
 // ---------- 12.2.3.2 Logical expressions ----------
 // --------------------------------------------------
 
-export function readLogicalExpression<S extends IParserState = IParserState>(
+export function readLogicalExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.TLogicalExpression {
@@ -396,10 +396,7 @@ export function readLogicalExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.3 Is expression ----------
 // --------------------------------------------
 
-export function readIsExpression<S extends IParserState = IParserState>(
-    state: S,
-    parser: IParser<S>,
-): Ast.TIsExpression {
+export function readIsExpression<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.TIsExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
     return recursiveReadBinOpExpression<
@@ -419,13 +416,13 @@ export function readIsExpression<S extends IParserState = IParserState>(
 }
 
 // sub-item of 12.2.3.3 Is expression
-export function readNullablePrimitiveType<S extends IParserState = IParserState>(
+export function readNullablePrimitiveType<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.TNullablePrimitiveType {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    if (IParserStateUtils.isOnConstantKind(state, Constant.LanguageConstantKind.Nullable)) {
+    if (IParseStateUtils.isOnConstantKind(state, Constant.LanguageConstantKind.Nullable)) {
         return readPairedConstant(
             state,
             Ast.NodeKind.NullablePrimitiveType,
@@ -441,10 +438,7 @@ export function readNullablePrimitiveType<S extends IParserState = IParserState>
 // ---------- 12.2.3.4 As expression ----------
 // --------------------------------------------
 
-export function readAsExpression<S extends IParserState = IParserState>(
-    state: S,
-    parser: IParser<S>,
-): Ast.TAsExpression {
+export function readAsExpression<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.TAsExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
     return recursiveReadBinOpExpression<
@@ -467,7 +461,7 @@ export function readAsExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.5 Equality expression ----------
 // --------------------------------------------------
 
-export function readEqualityExpression<S extends IParserState = IParserState>(
+export function readEqualityExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.TEqualityExpression {
@@ -492,7 +486,7 @@ export function readEqualityExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.6 Relational expression ----------
 // ----------------------------------------------------
 
-export function readRelationalExpression<S extends IParserState = IParserState>(
+export function readRelationalExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.TRelationalExpression {
@@ -517,7 +511,7 @@ export function readRelationalExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.7 Arithmetic expressions ----------
 // -----------------------------------------------------
 
-export function readArithmeticExpression<S extends IParserState = IParserState>(
+export function readArithmeticExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.TArithmeticExpression {
@@ -542,13 +536,13 @@ export function readArithmeticExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.8 Metadata expression ----------
 // --------------------------------------------------
 
-export function readMetadataExpression<S extends IParserState = IParserState>(
+export function readMetadataExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.TMetadataExpression {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.MetadataExpression = Ast.NodeKind.MetadataExpression;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const left: Ast.TUnaryExpression = parser.readUnaryExpression(state, parser);
     const maybeMetaConstant:
@@ -564,7 +558,7 @@ export function readMetadataExpression<S extends IParserState = IParserState>(
         const right: Ast.TUnaryExpression = parser.readUnaryExpression(state, parser);
 
         const astNode: Ast.MetadataExpression = {
-            ...IParserStateUtils.assertGetContextNodeMetadata(state),
+            ...IParseStateUtils.assertGetContextNodeMetadata(state),
             kind: nodeKind,
             isLeaf: false,
             left,
@@ -572,10 +566,10 @@ export function readMetadataExpression<S extends IParserState = IParserState>(
             right,
         };
 
-        IParserStateUtils.endContext(state, astNode);
+        IParseStateUtils.endContext(state, astNode);
         return astNode;
     } else {
-        IParserStateUtils.deleteContext(state, undefined);
+        IParseStateUtils.deleteContext(state, undefined);
         return left;
     }
 }
@@ -584,7 +578,7 @@ export function readMetadataExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.9 Unary expression ----------
 // -----------------------------------------------
 
-export function readUnaryExpression<S extends IParserState = IParserState>(
+export function readUnaryExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.TUnaryExpression {
@@ -598,10 +592,10 @@ export function readUnaryExpression<S extends IParserState = IParserState>(
     }
 
     const unaryNodeKind: Ast.NodeKind.UnaryExpression = Ast.NodeKind.UnaryExpression;
-    IParserStateUtils.startContext(state, unaryNodeKind);
+    IParseStateUtils.startContext(state, unaryNodeKind);
 
     const arrayNodeKind: Ast.NodeKind.ArrayWrapper = Ast.NodeKind.ArrayWrapper;
-    IParserStateUtils.startContext(state, arrayNodeKind);
+    IParseStateUtils.startContext(state, arrayNodeKind);
 
     const operatorConstants: Ast.IConstant<Constant.UnaryOperatorKind>[] = [];
     while (maybeOperator) {
@@ -611,23 +605,23 @@ export function readUnaryExpression<S extends IParserState = IParserState>(
         maybeOperator = ConstantUtils.maybeUnaryOperatorKindFrom(state.maybeCurrentTokenKind);
     }
     const operators: Ast.IArrayWrapper<Ast.IConstant<Constant.UnaryOperatorKind>> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: arrayNodeKind,
         isLeaf: false,
         elements: operatorConstants,
     };
-    IParserStateUtils.endContext(state, operators);
+    IParseStateUtils.endContext(state, operators);
 
     const typeExpression: Ast.TTypeExpression = parser.readTypeExpression(state, parser);
 
     const astNode: Ast.UnaryExpression = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: unaryNodeKind,
         isLeaf: false,
         operators,
         typeExpression,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
@@ -635,7 +629,7 @@ export function readUnaryExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.10 Primary expression ----------
 // --------------------------------------------------
 
-export function readPrimaryExpression<S extends IParserState = IParserState>(
+export function readPrimaryExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.TPrimaryExpression {
@@ -687,21 +681,21 @@ export function readPrimaryExpression<S extends IParserState = IParserState>(
         }
     }
 
-    if (IParserStateUtils.isRecursivePrimaryExpressionNext(state)) {
+    if (IParseStateUtils.isRecursivePrimaryExpressionNext(state)) {
         return parser.readRecursivePrimaryExpression(state, parser, primaryExpression);
     } else {
         return primaryExpression;
     }
 }
 
-export function readRecursivePrimaryExpression<S extends IParserState = IParserState>(
+export function readRecursivePrimaryExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
     head: Ast.TPrimaryExpression,
 ): Ast.RecursivePrimaryExpression {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.RecursivePrimaryExpression = Ast.NodeKind.RecursivePrimaryExpression;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const nodeIdMapCollection: NodeIdMap.Collection = state.contextState.nodeIdMapCollection;
     const currentContextNode: ParseContext.Node = Assert.asDefined(
@@ -750,7 +744,7 @@ export function readRecursivePrimaryExpression<S extends IParserState = IParserS
 
     // Begin normal parsing.
     const recursiveArrayNodeKind: Ast.NodeKind.ArrayWrapper = Ast.NodeKind.ArrayWrapper;
-    IParserStateUtils.startContext(state, recursiveArrayNodeKind);
+    IParseStateUtils.startContext(state, recursiveArrayNodeKind);
 
     const recursiveExpressions: (Ast.InvokeExpression | Ast.ItemAccessExpression | Ast.TFieldAccessExpression)[] = [];
     let continueReadingValues: boolean = true;
@@ -779,21 +773,21 @@ export function readRecursivePrimaryExpression<S extends IParserState = IParserS
     const recursiveArray: Ast.IArrayWrapper<
         Ast.InvokeExpression | Ast.ItemAccessExpression | Ast.TFieldAccessExpression
     > = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: recursiveArrayNodeKind,
         isLeaf: false,
         elements: recursiveExpressions,
     };
-    IParserStateUtils.endContext(state, recursiveArray);
+    IParseStateUtils.endContext(state, recursiveArray);
 
     const astNode: Ast.RecursivePrimaryExpression = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         head,
         recursiveExpressions: recursiveArray,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
@@ -801,13 +795,13 @@ export function readRecursivePrimaryExpression<S extends IParserState = IParserS
 // ---------- 12.2.3.11 Literal expression ----------
 // --------------------------------------------------
 
-export function readLiteralExpression<S extends IParserState = IParserState>(
-    state: IParserState,
+export function readLiteralExpression<S extends IParseState = IParseState>(
+    state: IParseState,
     _parser: IParser<S>,
 ): Ast.LiteralExpression {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.LiteralExpression = Ast.NodeKind.LiteralExpression;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const expectedTokenKinds: ReadonlyArray<Token.TokenKind> = [
         Token.TokenKind.HexLiteral,
@@ -819,7 +813,7 @@ export function readLiteralExpression<S extends IParserState = IParserState>(
         Token.TokenKind.NullLiteral,
         Token.TokenKind.TextLiteral,
     ];
-    const maybeErr: ParseError.ExpectedAnyTokenKindError | undefined = IParserStateUtils.testIsOnAnyTokenKind(
+    const maybeErr: ParseError.ExpectedAnyTokenKindError | undefined = IParseStateUtils.testIsOnAnyTokenKind(
         state,
         expectedTokenKinds,
     );
@@ -835,13 +829,13 @@ export function readLiteralExpression<S extends IParserState = IParserState>(
 
     const literal: string = readToken(state);
     const astNode: Ast.LiteralExpression = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: true,
         literal,
         literalKind,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
@@ -849,13 +843,13 @@ export function readLiteralExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.16 12.2.3.12 Identifier expression ----------
 // ---------------------------------------------------------------
 
-export function readIdentifierExpression<S extends IParserState = IParserState>(
+export function readIdentifierExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.IdentifierExpression {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.IdentifierExpression = Ast.NodeKind.IdentifierExpression;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const maybeInclusiveConstant:
         | Ast.IConstant<Constant.MiscConstantKind.AtSign>
@@ -863,13 +857,13 @@ export function readIdentifierExpression<S extends IParserState = IParserState>(
     const identifier: Ast.Identifier = parser.readIdentifier(state, parser);
 
     const astNode: Ast.IdentifierExpression = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         maybeInclusiveConstant,
         identifier,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
@@ -877,7 +871,7 @@ export function readIdentifierExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.14 Parenthesized expression ----------
 // --------------------------------------------------------
 
-export function readParenthesizedExpression<S extends IParserState = IParserState>(
+export function readParenthesizedExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.ParenthesizedExpression {
@@ -907,13 +901,13 @@ export function readParenthesizedExpression<S extends IParserState = IParserStat
 // ---------- 12.2.3.15 Not-implemented expression ----------
 // ----------------------------------------------------------
 
-export function readNotImplementedExpression<S extends IParserState = IParserState>(
+export function readNotImplementedExpression<S extends IParseState = IParseState>(
     state: S,
     _parser: IParser<S>,
 ): Ast.NotImplementedExpression {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.NotImplementedExpression = Ast.NodeKind.NotImplementedExpression;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const ellipsisConstant: Ast.IConstant<Constant.MiscConstantKind.Ellipsis> = readTokenKindAsConstant(
         state,
@@ -922,12 +916,12 @@ export function readNotImplementedExpression<S extends IParserState = IParserSta
     );
 
     const astNode: Ast.NotImplementedExpression = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         ellipsisConstant,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
@@ -935,13 +929,13 @@ export function readNotImplementedExpression<S extends IParserState = IParserSta
 // ---------- 12.2.3.16 Invoke expression ----------
 // -------------------------------------------------
 
-export function readInvokeExpression<S extends IParserState = IParserState>(
+export function readInvokeExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.InvokeExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.RightParenthesis);
+    const continueReadingValues: boolean = !IParseStateUtils.isNextTokenKind(state, Token.TokenKind.RightParenthesis);
     return readWrapped(
         state,
         Ast.NodeKind.InvokeExpression,
@@ -974,13 +968,13 @@ export function readInvokeExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.17 List expression ----------
 // -----------------------------------------------
 
-export function readListExpression<S extends IParserState = IParserState>(
+export function readListExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.ListExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.RightBrace);
+    const continueReadingValues: boolean = !IParseStateUtils.isNextTokenKind(state, Token.TokenKind.RightBrace);
     return readWrapped(
         state,
         Ast.NodeKind.ListExpression,
@@ -997,13 +991,13 @@ export function readListExpression<S extends IParserState = IParserState>(
     );
 }
 
-export function readListItem<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TListItem {
+export function readListItem<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.TListItem {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.RangeExpression = Ast.NodeKind.RangeExpression;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const left: Ast.TExpression = parser.readExpression(state, parser);
-    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.DotDot)) {
+    if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.DotDot)) {
         const rangeConstant: Ast.IConstant<Constant.MiscConstantKind.DotDot> = readTokenKindAsConstant(
             state,
             Token.TokenKind.DotDot,
@@ -1011,7 +1005,7 @@ export function readListItem<S extends IParserState = IParserState>(state: S, pa
         );
         const right: Ast.TExpression = parser.readExpression(state, parser);
         const astNode: Ast.RangeExpression = {
-            ...IParserStateUtils.assertGetContextNodeMetadata(state),
+            ...IParseStateUtils.assertGetContextNodeMetadata(state),
             kind: nodeKind,
             isLeaf: false,
             left,
@@ -1019,10 +1013,10 @@ export function readListItem<S extends IParserState = IParserState>(state: S, pa
             right,
         };
 
-        IParserStateUtils.endContext(state, astNode);
+        IParseStateUtils.endContext(state, astNode);
         return astNode;
     } else {
-        IParserStateUtils.deleteContext(state, undefined);
+        IParseStateUtils.deleteContext(state, undefined);
         return left;
     }
 }
@@ -1031,13 +1025,13 @@ export function readListItem<S extends IParserState = IParserState>(state: S, pa
 // ---------- 12.2.3.18 Record expression ----------
 // -------------------------------------------------
 
-export function readRecordExpression<S extends IParserState = IParserState>(
+export function readRecordExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.RecordExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.RightBracket);
+    const continueReadingValues: boolean = !IParseStateUtils.isNextTokenKind(state, Token.TokenKind.RightBracket);
     return readWrapped(
         state,
         Ast.NodeKind.RecordExpression,
@@ -1058,7 +1052,7 @@ export function readRecordExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.19 Item access expression ----------
 // ------------------------------------------------------
 
-export function readItemAccessExpression<S extends IParserState = IParserState>(
+export function readItemAccessExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.ItemAccessExpression {
@@ -1078,7 +1072,7 @@ export function readItemAccessExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.20 Field access expression ----------
 // -------------------------------------------------------
 
-export function readFieldSelection<S extends IParserState = IParserState>(
+export function readFieldSelection<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.FieldSelector {
@@ -1087,7 +1081,7 @@ export function readFieldSelection<S extends IParserState = IParserState>(
     return readFieldSelector(state, parser, true);
 }
 
-export function readFieldProjection<S extends IParserState = IParserState>(
+export function readFieldProjection<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.FieldProjection {
@@ -1108,7 +1102,7 @@ export function readFieldProjection<S extends IParserState = IParserState>(
     );
 }
 
-export function readFieldSelector<S extends IParserState = IParserState>(
+export function readFieldSelector<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
     allowOptional: boolean,
@@ -1129,13 +1123,13 @@ export function readFieldSelector<S extends IParserState = IParserState>(
 // ---------- 12.2.3.21 Function expression ----------
 // ---------------------------------------------------
 
-export function readFunctionExpression<S extends IParserState = IParserState>(
+export function readFunctionExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.FunctionExpression {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.FunctionExpression = Ast.NodeKind.FunctionExpression;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const parameters: Ast.IParameterList<Ast.AsNullablePrimitiveType | undefined> = parser.readParameterList(
         state,
@@ -1153,7 +1147,7 @@ export function readFunctionExpression<S extends IParserState = IParserState>(
     const expression: Ast.TExpression = parser.readExpression(state, parser);
 
     const astNode: Ast.FunctionExpression = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         parameters,
@@ -1161,11 +1155,11 @@ export function readFunctionExpression<S extends IParserState = IParserState>(
         fatArrowConstant,
         expression,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
-export function readParameterList<S extends IParserState = IParserState>(
+export function readParameterList<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.IParameterList<Ast.AsNullablePrimitiveType | undefined> {
@@ -1174,7 +1168,7 @@ export function readParameterList<S extends IParserState = IParserState>(
     return genericReadParameterList(state, parser, () => maybeReadAsNullablePrimitiveType(state, parser));
 }
 
-function maybeReadAsNullablePrimitiveType<S extends IParserState = IParserState>(
+function maybeReadAsNullablePrimitiveType<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.AsNullablePrimitiveType | undefined {
@@ -1183,13 +1177,13 @@ function maybeReadAsNullablePrimitiveType<S extends IParserState = IParserState>
     return maybeReadPairedConstant(
         state,
         Ast.NodeKind.AsNullablePrimitiveType,
-        () => IParserStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordAs),
+        () => IParseStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordAs),
         () => readTokenKindAsConstant(state, Token.TokenKind.KeywordAs, Constant.KeywordConstantKind.As),
         () => parser.readNullablePrimitiveType(state, parser),
     );
 }
 
-export function readAsType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.AsType {
+export function readAsType<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.AsType {
     state.maybeCancellationToken?.throwIfCancelled();
 
     return readPairedConstant(
@@ -1204,7 +1198,7 @@ export function readAsType<S extends IParserState = IParserState>(state: S, pars
 // ---------- 12.2.3.22 Each expression ----------
 // -----------------------------------------------
 
-export function readEachExpression<S extends IParserState = IParserState>(
+export function readEachExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.EachExpression {
@@ -1222,13 +1216,13 @@ export function readEachExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.23 Let expression ----------
 // ----------------------------------------------
 
-export function readLetExpression<S extends IParserState = IParserState>(
+export function readLetExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.LetExpression {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.LetExpression = Ast.NodeKind.LetExpression;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const letConstant: Ast.IConstant<Constant.KeywordConstantKind.Let> = readTokenKindAsConstant(
         state,
@@ -1238,8 +1232,8 @@ export function readLetExpression<S extends IParserState = IParserState>(
     const identifierPairedExpression: Ast.ICsvArray<Ast.IdentifierPairedExpression> = parser.readIdentifierPairedExpressions(
         state,
         parser,
-        !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.KeywordIn),
-        IParserStateUtils.testCsvContinuationLetExpression,
+        !IParseStateUtils.isNextTokenKind(state, Token.TokenKind.KeywordIn),
+        IParseStateUtils.testCsvContinuationLetExpression,
     );
     const inConstant: Ast.IConstant<Constant.KeywordConstantKind.In> = readTokenKindAsConstant(
         state,
@@ -1249,7 +1243,7 @@ export function readLetExpression<S extends IParserState = IParserState>(
     const expression: Ast.TExpression = parser.readExpression(state, parser);
 
     const astNode: Ast.LetExpression = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: Ast.NodeKind.LetExpression,
         isLeaf: false,
         letConstant,
@@ -1257,7 +1251,7 @@ export function readLetExpression<S extends IParserState = IParserState>(
         inConstant,
         expression,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
@@ -1265,13 +1259,10 @@ export function readLetExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.24 If expression ----------
 // ---------------------------------------------
 
-export function readIfExpression<S extends IParserState = IParserState>(
-    state: S,
-    parser: IParser<S>,
-): Ast.IfExpression {
+export function readIfExpression<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.IfExpression {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.IfExpression = Ast.NodeKind.IfExpression;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const ifConstant: Ast.IConstant<Constant.KeywordConstantKind.If> = readTokenKindAsConstant(
         state,
@@ -1295,7 +1286,7 @@ export function readIfExpression<S extends IParserState = IParserState>(
     const falseExpression: Ast.TExpression = parser.readExpression(state, parser);
 
     const astNode: Ast.IfExpression = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         ifConstant,
@@ -1305,7 +1296,7 @@ export function readIfExpression<S extends IParserState = IParserState>(
         elseConstant,
         falseExpression,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
@@ -1313,13 +1304,13 @@ export function readIfExpression<S extends IParserState = IParserState>(
 // ---------- 12.2.3.25 Type expression ----------
 // -----------------------------------------------
 
-export function readTypeExpression<S extends IParserState = IParserState>(
+export function readTypeExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.TTypeExpression {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordType)) {
+    if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordType)) {
         return readPairedConstant(
             state,
             Ast.NodeKind.TypePrimaryType,
@@ -1331,7 +1322,7 @@ export function readTypeExpression<S extends IParserState = IParserState>(
     }
 }
 
-export function readType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TType {
+export function readType<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.TType {
     state.maybeCancellationToken?.throwIfCancelled();
 
     const triedReadPrimaryType: TriedReadPrimaryType = tryReadPrimaryType(state, parser);
@@ -1342,7 +1333,7 @@ export function readType<S extends IParserState = IParserState>(state: S, parser
     }
 }
 
-export function readPrimaryType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TPrimaryType {
+export function readPrimaryType<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.TPrimaryType {
     state.maybeCancellationToken?.throwIfCancelled();
 
     const triedReadPrimaryType: TriedReadPrimaryType = tryReadPrimaryType(state, parser);
@@ -1353,10 +1344,10 @@ export function readPrimaryType<S extends IParserState = IParserState>(state: S,
     }
 }
 
-export function readRecordType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.RecordType {
+export function readRecordType<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.RecordType {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.RecordType = Ast.NodeKind.RecordType;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const fields: Ast.FieldSpecificationList = parser.readFieldSpecificationList(
         state,
@@ -1366,19 +1357,19 @@ export function readRecordType<S extends IParserState = IParserState>(state: S, 
     );
 
     const astNode: Ast.RecordType = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         fields,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
-export function readTableType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TableType {
+export function readTableType<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.TableType {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.TableType = Ast.NodeKind.TableType;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const tableConstant: Ast.IConstant<Constant.PrimitiveTypeConstantKind.Table> = readConstantKind(
         state,
@@ -1398,25 +1389,25 @@ export function readTableType<S extends IParserState = IParserState>(state: S, p
     }
 
     const astNode: Ast.TableType = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         tableConstant,
         rowType,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
-export function readFieldSpecificationList<S extends IParserState = IParserState>(
+export function readFieldSpecificationList<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
     allowOpenMarker: boolean,
-    testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
+    testPostCommaError: (state: IParseState) => ParseError.TInnerParseError | undefined,
 ): Ast.FieldSpecificationList {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.FieldSpecificationList = Ast.NodeKind.FieldSpecificationList;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const leftBracketConstant: Ast.IConstant<Constant.WrapperConstantKind.LeftBracket> = readTokenKindAsConstant(
         state,
@@ -1428,7 +1419,7 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
     let isOnOpenRecordMarker: boolean = false;
 
     const fieldArrayNodeKind: Ast.NodeKind.ArrayWrapper = Ast.NodeKind.ArrayWrapper;
-    IParserStateUtils.startContext(state, fieldArrayNodeKind);
+    IParseStateUtils.startContext(state, fieldArrayNodeKind);
 
     while (continueReadingValues) {
         const maybeErr: ParseError.TInnerParseError | undefined = testPostCommaError(state);
@@ -1436,7 +1427,7 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
             throw maybeErr;
         }
 
-        if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.Ellipsis)) {
+        if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.Ellipsis)) {
             if (allowOpenMarker) {
                 if (isOnOpenRecordMarker) {
                     throw fieldSpecificationListReadError(state, false);
@@ -1447,12 +1438,12 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
             } else {
                 throw fieldSpecificationListReadError(state, allowOpenMarker);
             }
-        } else if (IParserStateUtils.isOnGeneralizedIdentifierStart(state)) {
+        } else if (IParseStateUtils.isOnGeneralizedIdentifierStart(state)) {
             const csvNodeKind: Ast.NodeKind.Csv = Ast.NodeKind.Csv;
-            IParserStateUtils.startContext(state, csvNodeKind);
+            IParseStateUtils.startContext(state, csvNodeKind);
 
             const fieldSpecificationNodeKind: Ast.NodeKind.FieldSpecification = Ast.NodeKind.FieldSpecification;
-            IParserStateUtils.startContext(state, fieldSpecificationNodeKind);
+            IParseStateUtils.startContext(state, fieldSpecificationNodeKind);
 
             const maybeOptionalConstant:
                 | Ast.IConstant<Constant.LanguageConstantKind.Optional>
@@ -1466,14 +1457,14 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
             );
 
             const field: Ast.FieldSpecification = {
-                ...IParserStateUtils.assertGetContextNodeMetadata(state),
+                ...IParseStateUtils.assertGetContextNodeMetadata(state),
                 kind: fieldSpecificationNodeKind,
                 isLeaf: false,
                 maybeOptionalConstant,
                 name,
                 maybeFieldTypeSpecification,
             };
-            IParserStateUtils.endContext(state, field);
+            IParseStateUtils.endContext(state, field);
 
             const maybeCommaConstant:
                 | Ast.IConstant<Constant.MiscConstantKind.Comma>
@@ -1485,13 +1476,13 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
             continueReadingValues = maybeCommaConstant !== undefined;
 
             const csv: Ast.ICsv<Ast.FieldSpecification> = {
-                ...IParserStateUtils.assertGetContextNodeMetadata(state),
+                ...IParseStateUtils.assertGetContextNodeMetadata(state),
                 kind: csvNodeKind,
                 isLeaf: false,
                 node: field,
                 maybeCommaConstant,
             };
-            IParserStateUtils.endContext(state, csv);
+            IParseStateUtils.endContext(state, csv);
             fields.push(csv);
         } else {
             throw fieldSpecificationListReadError(state, allowOpenMarker);
@@ -1499,12 +1490,12 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
     }
 
     const fieldArray: Ast.ICsvArray<Ast.FieldSpecification> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: fieldArrayNodeKind,
         elements: fields,
         isLeaf: false,
     };
-    IParserStateUtils.endContext(state, fieldArray);
+    IParseStateUtils.endContext(state, fieldArray);
 
     let maybeOpenRecordMarkerConstant: Ast.IConstant<Constant.MiscConstantKind.Ellipsis> | undefined = undefined;
     if (isOnOpenRecordMarker) {
@@ -1522,7 +1513,7 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
     );
 
     const astNode: Ast.FieldSpecificationList = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         openWrapperConstant: leftBracketConstant,
@@ -1530,17 +1521,17 @@ export function readFieldSpecificationList<S extends IParserState = IParserState
         maybeOpenRecordMarkerConstant,
         closeWrapperConstant: rightBracketConstant,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
-function maybeReadFieldTypeSpecification<S extends IParserState = IParserState>(
+function maybeReadFieldTypeSpecification<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.FieldTypeSpecification | undefined {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.FieldTypeSpecification = Ast.NodeKind.FieldTypeSpecification;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const maybeEqualConstant: Ast.IConstant<Constant.MiscConstantKind.Equal> | undefined = maybeReadTokenKindAsConstant(
         state,
@@ -1551,34 +1542,34 @@ function maybeReadFieldTypeSpecification<S extends IParserState = IParserState>(
         const fieldType: Ast.TType = parser.readType(state, parser);
 
         const astNode: Ast.FieldTypeSpecification = {
-            ...IParserStateUtils.assertGetContextNodeMetadata(state),
+            ...IParseStateUtils.assertGetContextNodeMetadata(state),
             kind: Ast.NodeKind.FieldTypeSpecification,
             isLeaf: false,
             equalConstant: maybeEqualConstant,
             fieldType,
         };
-        IParserStateUtils.endContext(state, astNode);
+        IParseStateUtils.endContext(state, astNode);
         return astNode;
     } else {
-        IParserStateUtils.incrementAttributeCounter(state);
-        IParserStateUtils.deleteContext(state, undefined);
+        IParseStateUtils.incrementAttributeCounter(state);
+        IParseStateUtils.deleteContext(state, undefined);
         return undefined;
     }
 }
 
-function fieldSpecificationListReadError(state: IParserState, allowOpenMarker: boolean): Error | undefined {
+function fieldSpecificationListReadError(state: IParseState, allowOpenMarker: boolean): Error | undefined {
     if (allowOpenMarker) {
         const expectedTokenKinds: ReadonlyArray<Token.TokenKind> = [
             Token.TokenKind.Identifier,
             Token.TokenKind.Ellipsis,
         ];
-        return IParserStateUtils.testIsOnAnyTokenKind(state, expectedTokenKinds);
+        return IParseStateUtils.testIsOnAnyTokenKind(state, expectedTokenKinds);
     } else {
-        return IParserStateUtils.testIsOnTokenKind(state, Token.TokenKind.Identifier);
+        return IParseStateUtils.testIsOnTokenKind(state, Token.TokenKind.Identifier);
     }
 }
 
-export function readListType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.ListType {
+export function readListType<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.ListType {
     state.maybeCancellationToken?.throwIfCancelled();
 
     return readWrapped(
@@ -1591,13 +1582,10 @@ export function readListType<S extends IParserState = IParserState>(state: S, pa
     );
 }
 
-export function readFunctionType<S extends IParserState = IParserState>(
-    state: S,
-    parser: IParser<S>,
-): Ast.FunctionType {
+export function readFunctionType<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.FunctionType {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.FunctionType = Ast.NodeKind.FunctionType;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const functionConstant: Ast.IConstant<Constant.PrimitiveTypeConstantKind.Function> = readConstantKind(
         state,
@@ -1607,40 +1595,40 @@ export function readFunctionType<S extends IParserState = IParserState>(
     const functionReturnType: Ast.AsType = parser.readAsType(state, parser);
 
     const astNode: Ast.FunctionType = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         functionConstant,
         parameters,
         functionReturnType,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
-function tryReadPrimaryType<S extends IParserState = IParserState>(state: S, parser: IParser<S>): TriedReadPrimaryType {
+function tryReadPrimaryType<S extends IParseState = IParseState>(state: S, parser: IParser<S>): TriedReadPrimaryType {
     const isTableTypeNext: boolean =
-        IParserStateUtils.isOnConstantKind(state, Constant.PrimitiveTypeConstantKind.Table) &&
-        (IParserStateUtils.isNextTokenKind(state, Token.TokenKind.LeftBracket) ||
-            IParserStateUtils.isNextTokenKind(state, Token.TokenKind.LeftParenthesis) ||
-            IParserStateUtils.isNextTokenKind(state, Token.TokenKind.AtSign) ||
-            IParserStateUtils.isNextTokenKind(state, Token.TokenKind.Identifier));
+        IParseStateUtils.isOnConstantKind(state, Constant.PrimitiveTypeConstantKind.Table) &&
+        (IParseStateUtils.isNextTokenKind(state, Token.TokenKind.LeftBracket) ||
+            IParseStateUtils.isNextTokenKind(state, Token.TokenKind.LeftParenthesis) ||
+            IParseStateUtils.isNextTokenKind(state, Token.TokenKind.AtSign) ||
+            IParseStateUtils.isNextTokenKind(state, Token.TokenKind.Identifier));
     const isFunctionTypeNext: boolean =
-        IParserStateUtils.isOnConstantKind(state, Constant.PrimitiveTypeConstantKind.Function) &&
-        IParserStateUtils.isNextTokenKind(state, Token.TokenKind.LeftParenthesis);
+        IParseStateUtils.isOnConstantKind(state, Constant.PrimitiveTypeConstantKind.Function) &&
+        IParseStateUtils.isNextTokenKind(state, Token.TokenKind.LeftParenthesis);
 
-    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBracket)) {
+    if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBracket)) {
         return ResultUtils.okFactory(parser.readRecordType(state, parser));
-    } else if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBrace)) {
+    } else if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBrace)) {
         return ResultUtils.okFactory(parser.readListType(state, parser));
     } else if (isTableTypeNext) {
         return ResultUtils.okFactory(parser.readTableType(state, parser));
     } else if (isFunctionTypeNext) {
         return ResultUtils.okFactory(parser.readFunctionType(state, parser));
-    } else if (IParserStateUtils.isOnConstantKind(state, Constant.LanguageConstantKind.Nullable)) {
+    } else if (IParseStateUtils.isOnConstantKind(state, Constant.LanguageConstantKind.Nullable)) {
         return ResultUtils.okFactory(parser.readNullableType(state, parser));
     } else {
-        const checkpoint: IParserStateCheckpoint = parser.createCheckpoint(state);
+        const checkpoint: IParseStateCheckpoint = parser.createCheckpoint(state);
         const triedReadPrimitiveType: TriedReadPrimaryType = tryReadPrimitiveType(state, parser);
 
         if (ResultUtils.isErr(triedReadPrimitiveType)) {
@@ -1650,7 +1638,7 @@ function tryReadPrimaryType<S extends IParserState = IParserState>(state: S, par
     }
 }
 
-export function readParameterSpecificationList<S extends IParserState = IParserState>(
+export function readParameterSpecificationList<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.IParameterList<Ast.AsType> {
@@ -1659,10 +1647,7 @@ export function readParameterSpecificationList<S extends IParserState = IParserS
     return genericReadParameterList(state, parser, () => parser.readAsType(state, parser));
 }
 
-export function readNullableType<S extends IParserState = IParserState>(
-    state: S,
-    parser: IParser<S>,
-): Ast.NullableType {
+export function readNullableType<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.NullableType {
     state.maybeCancellationToken?.throwIfCancelled();
 
     return readPairedConstant(
@@ -1677,7 +1662,7 @@ export function readNullableType<S extends IParserState = IParserState>(
 // ---------- 12.2.3.26 Error raising expression ----------
 // --------------------------------------------------------
 
-export function readErrorRaisingExpression<S extends IParserState = IParserState>(
+export function readErrorRaisingExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.ErrorRaisingExpression {
@@ -1695,13 +1680,13 @@ export function readErrorRaisingExpression<S extends IParserState = IParserState
 // ---------- 12.2.3.27 Error handling expression ----------
 // ---------------------------------------------------------
 
-export function readErrorHandlingExpression<S extends IParserState = IParserState>(
+export function readErrorHandlingExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.ErrorHandlingExpression {
     state.maybeCancellationToken?.throwIfCancelled();
     const nodeKind: Ast.NodeKind.ErrorHandlingExpression = Ast.NodeKind.ErrorHandlingExpression;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const tryConstant: Ast.IConstant<Constant.KeywordConstantKind.Try> = readTokenKindAsConstant(
         state,
@@ -1714,20 +1699,20 @@ export function readErrorHandlingExpression<S extends IParserState = IParserStat
     const maybeOtherwiseExpression: Ast.OtherwiseExpression | undefined = maybeReadPairedConstant(
         state,
         otherwiseExpressionNodeKind,
-        () => IParserStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordOtherwise),
+        () => IParseStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordOtherwise),
         () => readTokenKindAsConstant(state, Token.TokenKind.KeywordOtherwise, Constant.KeywordConstantKind.Otherwise),
         () => parser.readExpression(state, parser),
     );
 
     const astNode: Ast.ErrorHandlingExpression = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         tryConstant,
         protectedExpression,
         maybeOtherwiseExpression,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
@@ -1735,13 +1720,13 @@ export function readErrorHandlingExpression<S extends IParserState = IParserStat
 // ---------- 12.2.4 Literal Attributes ----------
 // -----------------------------------------------
 
-export function readRecordLiteral<S extends IParserState = IParserState>(
+export function readRecordLiteral<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.RecordLiteral {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.RightBracket);
+    const continueReadingValues: boolean = !IParseStateUtils.isNextTokenKind(state, Token.TokenKind.RightBracket);
     const wrappedRead: Ast.IWrapped<
         Ast.NodeKind.RecordLiteral,
         Constant.WrapperConstantKind.LeftBracket,
@@ -1767,11 +1752,11 @@ export function readRecordLiteral<S extends IParserState = IParserState>(
     };
 }
 
-export function readFieldNamePairedAnyLiterals<S extends IParserState = IParserState>(
+export function readFieldNamePairedAnyLiterals<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
     continueReadingValues: boolean,
-    testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
+    testPostCommaError: (state: IParseState) => ParseError.TInnerParseError | undefined,
 ): Ast.ICsvArray<Ast.GeneralizedIdentifierPairedAnyLiteral> {
     state.maybeCancellationToken?.throwIfCancelled();
 
@@ -1794,10 +1779,10 @@ export function readFieldNamePairedAnyLiterals<S extends IParserState = IParserS
     );
 }
 
-export function readListLiteral<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.ListLiteral {
+export function readListLiteral<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.ListLiteral {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    const continueReadingValues: boolean = !IParserStateUtils.isNextTokenKind(state, Token.TokenKind.RightBrace);
+    const continueReadingValues: boolean = !IParseStateUtils.isNextTokenKind(state, Token.TokenKind.RightBrace);
     const wrappedRead: Ast.IWrapped<
         Ast.NodeKind.ListLiteral,
         Constant.WrapperConstantKind.LeftBrace,
@@ -1823,19 +1808,19 @@ export function readListLiteral<S extends IParserState = IParserState>(state: S,
     };
 }
 
-export function readAnyLiteral<S extends IParserState = IParserState>(state: S, parser: IParser<S>): Ast.TAnyLiteral {
+export function readAnyLiteral<S extends IParseState = IParseState>(state: S, parser: IParser<S>): Ast.TAnyLiteral {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBracket)) {
+    if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBracket)) {
         return parser.readRecordLiteral(state, parser);
-    } else if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBrace)) {
+    } else if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBrace)) {
         return parser.readListLiteral(state, parser);
     } else {
         return parser.readLiteralExpression(state, parser);
     }
 }
 
-export function readPrimitiveType<S extends IParserState = IParserState>(
+export function readPrimitiveType<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.PrimitiveType {
@@ -1849,20 +1834,20 @@ export function readPrimitiveType<S extends IParserState = IParserState>(
     }
 }
 
-function tryReadPrimitiveType<S extends IParserState = IParserState>(
+function tryReadPrimitiveType<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): TriedReadPrimitiveType {
     const nodeKind: Ast.NodeKind.PrimitiveType = Ast.NodeKind.PrimitiveType;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
-    const checkpoint: IParserStateCheckpoint = parser.createCheckpoint(state);
+    const checkpoint: IParseStateCheckpoint = parser.createCheckpoint(state);
     const expectedTokenKinds: ReadonlyArray<Token.TokenKind> = [
         Token.TokenKind.Identifier,
         Token.TokenKind.KeywordType,
         Token.TokenKind.NullLiteral,
     ];
-    const maybeErr: ParseError.ExpectedAnyTokenKindError | undefined = IParserStateUtils.testIsOnAnyTokenKind(
+    const maybeErr: ParseError.ExpectedAnyTokenKindError | undefined = IParseStateUtils.testIsOnAnyTokenKind(
         state,
         expectedTokenKinds,
     );
@@ -1872,7 +1857,7 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
     }
 
     let primitiveTypeKind: Constant.PrimitiveTypeConstantKind;
-    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.Identifier)) {
+    if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.Identifier)) {
         const currentTokenData: string = state.lexerSnapshot.tokens[state.tokenIndex].data;
 
         switch (currentTokenData) {
@@ -1898,7 +1883,7 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
                 break;
 
             default:
-                const token: Token.Token = IParserStateUtils.assertGetTokenAt(state, state.tokenIndex);
+                const token: Token.Token = IParseStateUtils.assertGetTokenAt(state, state.tokenIndex);
                 parser.restoreFromCheckpoint(state, checkpoint);
                 return ResultUtils.errFactory(
                     new ParseError.InvalidPrimitiveTypeError(
@@ -1908,10 +1893,10 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
                     ),
                 );
         }
-    } else if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordType)) {
+    } else if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.KeywordType)) {
         primitiveTypeKind = Constant.PrimitiveTypeConstantKind.Type;
         readToken(state);
-    } else if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.NullLiteral)) {
+    } else if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.NullLiteral)) {
         primitiveTypeKind = Constant.PrimitiveTypeConstantKind.Null;
         readToken(state);
     } else {
@@ -1923,12 +1908,12 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
     }
 
     const astNode: Ast.PrimitiveType = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: true,
         primitiveTypeKind,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return ResultUtils.okFactory(astNode);
 }
 
@@ -1936,11 +1921,11 @@ function tryReadPrimitiveType<S extends IParserState = IParserState>(
 // ---------- key-value pairs ----------
 // -------------------------------------
 
-export function readIdentifierPairedExpressions<S extends IParserState = IParserState>(
+export function readIdentifierPairedExpressions<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
     continueReadingValues: boolean,
-    testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
+    testPostCommaError: (state: IParseState) => ParseError.TInnerParseError | undefined,
 ): Ast.ICsvArray<Ast.IdentifierPairedExpression> {
     state.maybeCancellationToken?.throwIfCancelled();
 
@@ -1952,11 +1937,11 @@ export function readIdentifierPairedExpressions<S extends IParserState = IParser
     );
 }
 
-export function readGeneralizedIdentifierPairedExpressions<S extends IParserState = IParserState>(
+export function readGeneralizedIdentifierPairedExpressions<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
     continueReadingValues: boolean,
-    testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
+    testPostCommaError: (state: IParseState) => ParseError.TInnerParseError | undefined,
 ): Ast.ICsvArray<Ast.GeneralizedIdentifierPairedExpression> {
     state.maybeCancellationToken?.throwIfCancelled();
 
@@ -1968,7 +1953,7 @@ export function readGeneralizedIdentifierPairedExpressions<S extends IParserStat
     );
 }
 
-export function readGeneralizedIdentifierPairedExpression<S extends IParserState = IParserState>(
+export function readGeneralizedIdentifierPairedExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.GeneralizedIdentifierPairedExpression {
@@ -1987,7 +1972,7 @@ export function readGeneralizedIdentifierPairedExpression<S extends IParserState
     );
 }
 
-export function readIdentifierPairedExpression<S extends IParserState = IParserState>(
+export function readIdentifierPairedExpression<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.IdentifierPairedExpression {
@@ -2011,7 +1996,7 @@ export function readIdentifierPairedExpression<S extends IParserState = IParserS
 //
 // The reason the code is duplicated across two functions is because I can't think of a cleaner way to do it.
 function recursiveReadBinOpExpression<
-    S extends IParserState,
+    S extends IParseState,
     Kind extends Ast.TBinOpExpressionNodeKind,
     Left,
     Op extends Constant.TBinOpExpressionOperator,
@@ -2023,13 +2008,13 @@ function recursiveReadBinOpExpression<
     maybeOperatorFrom: (tokenKind: Token.TokenKind | undefined) => Op | undefined,
     rightReader: () => Right,
 ): Left | Ast.IBinOpExpression<Kind, Left, Op, Right> {
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
     const left: Left = leftReader();
 
     // If no operator, return Left
     const maybeOperator: Op | undefined = maybeOperatorFrom(state.maybeCurrentTokenKind);
     if (maybeOperator === undefined) {
-        IParserStateUtils.deleteContext(state, undefined);
+        IParseStateUtils.deleteContext(state, undefined);
         return left;
     }
     const operatorConstant: Ast.TConstant & Ast.IConstant<Op> = readTokenKindAsConstant(
@@ -2045,14 +2030,14 @@ function recursiveReadBinOpExpression<
     >(state, nodeKind, maybeOperatorFrom, rightReader);
 
     const astNode: Ast.IBinOpExpression<Kind, Left, Op, Right> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         left,
         operatorConstant,
         right,
     };
-    IParserStateUtils.endContext(state, (astNode as unknown) as Ast.TNode);
+    IParseStateUtils.endContext(state, (astNode as unknown) as Ast.TNode);
 
     return astNode;
 }
@@ -2061,7 +2046,7 @@ function recursiveReadBinOpExpression<
 // where their TokenRange's are represented by brackets:
 // 1 + [2 + [3]]
 function recursiveReadBinOpExpressionHelper<
-    S extends IParserState,
+    S extends IParseState,
     Kind extends Ast.TBinOpExpressionNodeKind,
     OperatorKind extends Constant.TBinOpExpressionOperator,
     Right
@@ -2071,12 +2056,12 @@ function recursiveReadBinOpExpressionHelper<
     maybeOperatorFrom: (tokenKind: Token.TokenKind | undefined) => OperatorKind | undefined,
     rightReader: () => Right,
 ): Right | Ast.IBinOpExpression<Kind, Right, OperatorKind, Right> {
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
     const rightAsLeft: Right = rightReader();
 
     const maybeOperator: OperatorKind | undefined = maybeOperatorFrom(state.maybeCurrentTokenKind);
     if (maybeOperator === undefined) {
-        IParserStateUtils.deleteContext(state, undefined);
+        IParseStateUtils.deleteContext(state, undefined);
         return rightAsLeft;
     }
     const operatorConstant: Ast.TConstant & Ast.IConstant<OperatorKind> = readTokenKindAsConstant(
@@ -2092,32 +2077,32 @@ function recursiveReadBinOpExpressionHelper<
     >(state, nodeKind, maybeOperatorFrom, rightReader);
 
     const astNode: Ast.IBinOpExpression<Kind, Right, OperatorKind, Right> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         left: rightAsLeft,
         operatorConstant,
         right,
     };
-    IParserStateUtils.endContext(state, (astNode as unknown) as Ast.TNode);
+    IParseStateUtils.endContext(state, (astNode as unknown) as Ast.TNode);
 
     return astNode;
 }
 
-function readCsvArray<S extends IParserState, T extends Ast.TCsvType>(
+function readCsvArray<S extends IParseState, T extends Ast.TCsvType>(
     state: S,
     valueReader: () => T,
     continueReadingValues: boolean,
-    testPostCommaError: (state: IParserState) => ParseError.TInnerParseError | undefined,
+    testPostCommaError: (state: IParseState) => ParseError.TInnerParseError | undefined,
 ): Ast.TCsvArray & Ast.ICsvArray<T> {
     const nodeKind: Ast.NodeKind.ArrayWrapper = Ast.NodeKind.ArrayWrapper;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const elements: Ast.ICsv<T>[] = [];
 
     while (continueReadingValues) {
         const csvNodeKind: Ast.NodeKind.Csv = Ast.NodeKind.Csv;
-        IParserStateUtils.startContext(state, csvNodeKind);
+        IParseStateUtils.startContext(state, csvNodeKind);
 
         const maybeErr: ParseError.TInnerParseError | undefined = testPostCommaError(state);
         if (maybeErr) {
@@ -2130,35 +2115,35 @@ function readCsvArray<S extends IParserState, T extends Ast.TCsvType>(
             | undefined = maybeReadTokenKindAsConstant(state, Token.TokenKind.Comma, Constant.MiscConstantKind.Comma);
 
         const element: Ast.TCsv & Ast.ICsv<T> = {
-            ...IParserStateUtils.assertGetContextNodeMetadata(state),
+            ...IParseStateUtils.assertGetContextNodeMetadata(state),
             kind: csvNodeKind,
             isLeaf: false,
             node,
             maybeCommaConstant,
         };
-        IParserStateUtils.endContext(state, element);
+        IParseStateUtils.endContext(state, element);
         elements.push(element);
 
         continueReadingValues = maybeCommaConstant !== undefined;
     }
 
     const astNode: Ast.ICsvArray<T> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         elements,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
-function readKeyValuePair<S extends IParserState, Kind extends Ast.TKeyValuePairNodeKind, Key, Value>(
+function readKeyValuePair<S extends IParseState, Kind extends Ast.TKeyValuePairNodeKind, Key, Value>(
     state: S,
     nodeKind: Kind,
     keyReader: () => Key,
     valueReader: () => Value,
 ): Ast.IKeyValuePair<Kind, Key, Value> {
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const key: Key = keyReader();
     const equalConstant: Ast.IConstant<Constant.MiscConstantKind.Equal> = readTokenKindAsConstant(
@@ -2169,19 +2154,19 @@ function readKeyValuePair<S extends IParserState, Kind extends Ast.TKeyValuePair
     const value: Value = valueReader();
 
     const keyValuePair: Ast.IKeyValuePair<Kind, Key, Value> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         key,
         equalConstant,
         value,
     };
-    IParserStateUtils.endContext(state, (keyValuePair as unknown) as Ast.TKeyValuePair);
+    IParseStateUtils.endContext(state, (keyValuePair as unknown) as Ast.TKeyValuePair);
     return keyValuePair;
 }
 
 function readPairedConstant<
-    S extends IParserState,
+    S extends IParseState,
     Kind extends Ast.TPairedConstantNodeKind,
     ConstantKind extends Constant.TConstantKind,
     Paired
@@ -2191,26 +2176,26 @@ function readPairedConstant<
     constantReader: () => Ast.TConstant & Ast.IConstant<ConstantKind>,
     pairedReader: () => Paired,
 ): Ast.IPairedConstant<Kind, ConstantKind, Paired> {
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const constant: Ast.TConstant & Ast.IConstant<ConstantKind> = constantReader();
     const paired: Paired = pairedReader();
 
     const pairedConstant: Ast.IPairedConstant<Kind, ConstantKind, Paired> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         constant,
         paired,
     };
 
-    IParserStateUtils.endContext(state, (pairedConstant as unknown) as Ast.TPairedConstant);
+    IParseStateUtils.endContext(state, (pairedConstant as unknown) as Ast.TPairedConstant);
 
     return pairedConstant;
 }
 
 function maybeReadPairedConstant<
-    S extends IParserState,
+    S extends IParseState,
     Kind extends Ast.TPairedConstantNodeKind,
     ConstantKind extends Constant.TConstantKind,
     Paired
@@ -2224,34 +2209,34 @@ function maybeReadPairedConstant<
     if (condition()) {
         return readPairedConstant<S, Kind, ConstantKind, Paired>(state, nodeKind, constantReader, pairedReader);
     } else {
-        IParserStateUtils.incrementAttributeCounter(state);
+        IParseStateUtils.incrementAttributeCounter(state);
         return undefined;
     }
 }
 
-function genericReadParameterList<S extends IParserState, T extends Ast.TParameterType>(
+function genericReadParameterList<S extends IParseState, T extends Ast.TParameterType>(
     state: S,
     parser: IParser<S>,
     typeReader: () => T,
 ): Ast.IParameterList<T> {
     const nodeKind: Ast.NodeKind.ParameterList = Ast.NodeKind.ParameterList;
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const leftParenthesisConstant: Ast.IConstant<Constant.WrapperConstantKind.LeftParenthesis> = readTokenKindAsConstant(
         state,
         Token.TokenKind.LeftParenthesis,
         Constant.WrapperConstantKind.LeftParenthesis,
     );
-    let continueReadingValues: boolean = !IParserStateUtils.isOnTokenKind(state, Token.TokenKind.RightParenthesis);
+    let continueReadingValues: boolean = !IParseStateUtils.isOnTokenKind(state, Token.TokenKind.RightParenthesis);
     let reachedOptionalParameter: boolean = false;
 
     const paramterArrayNodeKind: Ast.NodeKind.ArrayWrapper = Ast.NodeKind.ArrayWrapper;
-    IParserStateUtils.startContext(state, paramterArrayNodeKind);
+    IParseStateUtils.startContext(state, paramterArrayNodeKind);
 
     const parameters: Ast.ICsv<Ast.IParameter<T>>[] = [];
     while (continueReadingValues) {
-        IParserStateUtils.startContext(state, Ast.NodeKind.Csv);
-        IParserStateUtils.startContext(state, Ast.NodeKind.Parameter);
+        IParseStateUtils.startContext(state, Ast.NodeKind.Csv);
+        IParseStateUtils.startContext(state, Ast.NodeKind.Parameter);
 
         const maybeErr: ParseError.TInnerParseError | undefined = testCsvContinuationDanglingCommaForParenthesis(state);
         if (maybeErr) {
@@ -2263,7 +2248,7 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
             | undefined = maybeReadConstantKind(state, Constant.LanguageConstantKind.Optional);
 
         if (reachedOptionalParameter && !maybeOptionalConstant) {
-            const token: Token.Token = IParserStateUtils.assertGetTokenAt(state, state.tokenIndex);
+            const token: Token.Token = IParseStateUtils.assertGetTokenAt(state, state.tokenIndex);
             throw new ParseError.RequiredParameterAfterOptionalParameterError(
                 state.locale,
                 token,
@@ -2277,14 +2262,14 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
         const maybeParameterType: T = typeReader();
 
         const parameter: Ast.IParameter<T> = {
-            ...IParserStateUtils.assertGetContextNodeMetadata(state),
+            ...IParseStateUtils.assertGetContextNodeMetadata(state),
             kind: Ast.NodeKind.Parameter,
             isLeaf: false,
             maybeOptionalConstant,
             name,
             maybeParameterType,
         };
-        IParserStateUtils.endContext(state, parameter);
+        IParseStateUtils.endContext(state, parameter);
 
         const maybeCommaConstant:
             | Ast.IConstant<Constant.MiscConstantKind.Comma>
@@ -2292,24 +2277,24 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
         continueReadingValues = maybeCommaConstant !== undefined;
 
         const csv: Ast.ICsv<Ast.IParameter<T>> = {
-            ...IParserStateUtils.assertGetContextNodeMetadata(state),
+            ...IParseStateUtils.assertGetContextNodeMetadata(state),
             kind: Ast.NodeKind.Csv,
             isLeaf: false,
             node: parameter,
             maybeCommaConstant,
         };
-        IParserStateUtils.endContext(state, csv);
+        IParseStateUtils.endContext(state, csv);
 
         parameters.push(csv);
     }
 
     const parameterArray: Ast.ICsvArray<Ast.IParameter<T>> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: paramterArrayNodeKind,
         elements: parameters,
         isLeaf: false,
     };
-    IParserStateUtils.endContext(state, parameterArray);
+    IParseStateUtils.endContext(state, parameterArray);
 
     const rightParenthesisConstant: Ast.IConstant<Constant.WrapperConstantKind.RightParenthesis> = readTokenKindAsConstant(
         state,
@@ -2318,19 +2303,19 @@ function genericReadParameterList<S extends IParserState, T extends Ast.TParamet
     );
 
     const astNode: Ast.IParameterList<T> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         openWrapperConstant: leftParenthesisConstant,
         content: parameterArray,
         closeWrapperConstant: rightParenthesisConstant,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
     return astNode;
 }
 
 function readWrapped<
-    S extends IParserState,
+    S extends IParseState,
     Kind extends Ast.TWrappedNodeKind,
     Open extends Constant.WrapperConstantKind,
     Content,
@@ -2343,7 +2328,7 @@ function readWrapped<
     closeConstantReader: () => Ast.IConstant<Close>,
     allowOptionalConstant: boolean,
 ): WrappedRead<Kind, Open, Content, Close> {
-    IParserStateUtils.startContext(state, nodeKind);
+    IParseStateUtils.startContext(state, nodeKind);
 
     const openWrapperConstant: Ast.IConstant<Open> = openConstantReader();
     const content: Content = contentReader();
@@ -2359,7 +2344,7 @@ function readWrapped<
     }
 
     const wrapped: WrappedRead<Kind, Open, Content, Close> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: false,
         openWrapperConstant,
@@ -2367,7 +2352,7 @@ function readWrapped<
         closeWrapperConstant,
         maybeOptionalConstant,
     };
-    IParserStateUtils.endContext(state, (wrapped as unknown) as Ast.TWrapped);
+    IParseStateUtils.endContext(state, (wrapped as unknown) as Ast.TWrapped);
     return wrapped;
 }
 
@@ -2375,7 +2360,7 @@ function readWrapped<
 // ---------- Helper functions (read) ----------
 // ---------------------------------------------
 
-export function readToken<S extends IParserState = IParserState>(state: S): string {
+export function readToken<S extends IParseState = IParseState>(state: S): string {
     state.maybeCancellationToken?.throwIfCancelled();
 
     const tokens: ReadonlyArray<Token.Token> = state.lexerSnapshot.tokens;
@@ -2394,7 +2379,7 @@ export function readToken<S extends IParserState = IParserState>(state: S): stri
         // That means a correct implementation would have some sort of TokenRange | Eof union type,
         // but there's no clean way to introduce that.
         //
-        // So, for now when a IParserState is Eof when maybeCurrentTokenKind === undefined.
+        // So, for now when a IParseState is Eof when maybeCurrentTokenKind === undefined.
         state.maybeCurrentTokenKind = undefined;
     } else {
         state.maybeCurrentToken = tokens[state.tokenIndex];
@@ -2404,15 +2389,15 @@ export function readToken<S extends IParserState = IParserState>(state: S): stri
     return data;
 }
 
-export function readTokenKindAsConstant<S extends IParserState, ConstantKind extends Constant.TConstantKind>(
+export function readTokenKindAsConstant<S extends IParseState, ConstantKind extends Constant.TConstantKind>(
     state: S,
     tokenKind: Token.TokenKind,
     constantKind: ConstantKind,
 ): Ast.TConstant & Ast.IConstant<ConstantKind> {
     state.maybeCancellationToken?.throwIfCancelled();
-    IParserStateUtils.startContext(state, Ast.NodeKind.Constant);
+    IParseStateUtils.startContext(state, Ast.NodeKind.Constant);
 
-    const maybeErr: ParseError.ExpectedTokenKindError | undefined = IParserStateUtils.testIsOnTokenKind(
+    const maybeErr: ParseError.ExpectedTokenKindError | undefined = IParseStateUtils.testIsOnTokenKind(
         state,
         tokenKind,
     );
@@ -2424,26 +2409,26 @@ export function readTokenKindAsConstant<S extends IParserState, ConstantKind ext
     Assert.isTrue(tokenData === constantKind, `expected tokenData to equal constantKind`, { tokenData, constantKind });
 
     const astNode: Ast.TConstant & Ast.IConstant<ConstantKind> = {
-        ...IParserStateUtils.assertGetContextNodeMetadata(state),
+        ...IParseStateUtils.assertGetContextNodeMetadata(state),
         kind: Ast.NodeKind.Constant,
         isLeaf: true,
         constantKind,
     };
-    IParserStateUtils.endContext(state, astNode);
+    IParseStateUtils.endContext(state, astNode);
 
     return astNode;
 }
 
-export function maybeReadTokenKindAsConstant<S extends IParserState, ConstantKind extends Constant.TConstantKind>(
+export function maybeReadTokenKindAsConstant<S extends IParseState, ConstantKind extends Constant.TConstantKind>(
     state: S,
     tokenKind: Token.TokenKind,
     constantKind: ConstantKind,
 ): (Ast.TConstant & Ast.IConstant<ConstantKind>) | undefined {
     state.maybeCancellationToken?.throwIfCancelled();
 
-    if (IParserStateUtils.isOnTokenKind(state, tokenKind)) {
+    if (IParseStateUtils.isOnTokenKind(state, tokenKind)) {
         const nodeKind: Ast.NodeKind.Constant = Ast.NodeKind.Constant;
-        IParserStateUtils.startContext(state, nodeKind);
+        IParseStateUtils.startContext(state, nodeKind);
 
         const tokenData: string = readToken(state);
         Assert.isTrue(tokenData === constantKind, `expected tokenData to equal constantKind`, {
@@ -2452,22 +2437,22 @@ export function maybeReadTokenKindAsConstant<S extends IParserState, ConstantKin
         });
 
         const astNode: Ast.TConstant & Ast.IConstant<ConstantKind> = {
-            ...IParserStateUtils.assertGetContextNodeMetadata(state),
+            ...IParseStateUtils.assertGetContextNodeMetadata(state),
             kind: nodeKind,
             isLeaf: true,
             constantKind,
         };
-        IParserStateUtils.endContext(state, astNode);
+        IParseStateUtils.endContext(state, astNode);
 
         return astNode;
     } else {
-        IParserStateUtils.incrementAttributeCounter(state);
+        IParseStateUtils.incrementAttributeCounter(state);
         return undefined;
     }
 }
 
-function readTokenKind(state: IParserState, tokenKind: Token.TokenKind): string {
-    const maybeErr: ParseError.ExpectedTokenKindError | undefined = IParserStateUtils.testIsOnTokenKind(
+function readTokenKind(state: IParseState, tokenKind: Token.TokenKind): string {
+    const maybeErr: ParseError.ExpectedTokenKindError | undefined = IParseStateUtils.testIsOnTokenKind(
         state,
         tokenKind,
     );
@@ -2478,7 +2463,7 @@ function readTokenKind(state: IParserState, tokenKind: Token.TokenKind): string 
     return readToken(state);
 }
 
-function readConstantKind<S extends IParserState, ConstantKind extends Constant.TConstantKind>(
+function readConstantKind<S extends IParseState, ConstantKind extends Constant.TConstantKind>(
     state: S,
     constantKind: ConstantKind,
 ): Ast.TConstant & Ast.IConstant<ConstantKind> {
@@ -2487,37 +2472,37 @@ function readConstantKind<S extends IParserState, ConstantKind extends Constant.
     });
 }
 
-function maybeReadConstantKind<S extends IParserState, ConstantKind extends Constant.TConstantKind>(
+function maybeReadConstantKind<S extends IParseState, ConstantKind extends Constant.TConstantKind>(
     state: S,
     constantKind: ConstantKind,
 ): (Ast.TConstant & Ast.IConstant<ConstantKind>) | undefined {
-    if (IParserStateUtils.isOnConstantKind(state, constantKind)) {
+    if (IParseStateUtils.isOnConstantKind(state, constantKind)) {
         const nodeKind: Ast.NodeKind.Constant = Ast.NodeKind.Constant;
-        IParserStateUtils.startContext(state, nodeKind);
+        IParseStateUtils.startContext(state, nodeKind);
 
         readToken(state);
         const astNode: Ast.TConstant & Ast.IConstant<ConstantKind> = {
-            ...IParserStateUtils.assertGetContextNodeMetadata(state),
+            ...IParseStateUtils.assertGetContextNodeMetadata(state),
             kind: nodeKind,
             isLeaf: true,
             constantKind,
         };
-        IParserStateUtils.endContext(state, astNode);
+        IParseStateUtils.endContext(state, astNode);
         return astNode;
     } else {
-        IParserStateUtils.incrementAttributeCounter(state);
+        IParseStateUtils.incrementAttributeCounter(state);
         return undefined;
     }
 }
 
-function maybeReadLiteralAttributes<S extends IParserState = IParserState>(
+function maybeReadLiteralAttributes<S extends IParseState = IParseState>(
     state: S,
     parser: IParser<S>,
 ): Ast.RecordLiteral | undefined {
-    if (IParserStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBracket)) {
+    if (IParseStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBracket)) {
         return parser.readRecordLiteral(state, parser);
     } else {
-        IParserStateUtils.incrementAttributeCounter(state);
+        IParseStateUtils.incrementAttributeCounter(state);
         return undefined;
     }
 }
@@ -2526,20 +2511,20 @@ function maybeReadLiteralAttributes<S extends IParserState = IParserState>(
 // ---------- Helper functions (test functions) ----------
 // -------------------------------------------------------
 
-function testCsvContinuationDanglingCommaForBrace<S extends IParserState = IParserState>(
+function testCsvContinuationDanglingCommaForBrace<S extends IParseState = IParseState>(
     state: S,
 ): ParseError.ExpectedCsvContinuationError | undefined {
-    return IParserStateUtils.testCsvContinuationDanglingComma(state, Token.TokenKind.RightBrace);
+    return IParseStateUtils.testCsvContinuationDanglingComma(state, Token.TokenKind.RightBrace);
 }
 
-function testCsvContinuationDanglingCommaForBracket<S extends IParserState = IParserState>(
+function testCsvContinuationDanglingCommaForBracket<S extends IParseState = IParseState>(
     state: S,
 ): ParseError.ExpectedCsvContinuationError | undefined {
-    return IParserStateUtils.testCsvContinuationDanglingComma(state, Token.TokenKind.RightBracket);
+    return IParseStateUtils.testCsvContinuationDanglingComma(state, Token.TokenKind.RightBracket);
 }
 
-function testCsvContinuationDanglingCommaForParenthesis<S extends IParserState = IParserState>(
+function testCsvContinuationDanglingCommaForParenthesis<S extends IParseState = IParseState>(
     state: S,
 ): ParseError.ExpectedCsvContinuationError | undefined {
-    return IParserStateUtils.testCsvContinuationDanglingComma(state, Token.TokenKind.RightParenthesis);
+    return IParseStateUtils.testCsvContinuationDanglingComma(state, Token.TokenKind.RightParenthesis);
 }

--- a/src/parser/parsers/recursiveDescentParser.ts
+++ b/src/parser/parsers/recursiveDescentParser.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 
 import { NaiveParseSteps } from ".";
-import { IParser, IParserStateCheckpoint, IParserUtils } from "../IParser";
-import { IParserState } from "../IParserState";
+import { IParser, IParserUtils, IParseStateCheckpoint } from "../IParser";
+import { IParseState } from "../IParseState";
 
-export let RecursiveDescentParser: IParser<IParserState> = {
+export let RecursiveDescentParser: IParser<IParseState> = {
     ...NaiveParseSteps,
-    createCheckpoint: (state: IParserState) => IParserUtils.stateCheckpointFactory(state),
-    restoreFromCheckpoint: (state: IParserState, checkpoint: IParserStateCheckpoint) =>
+    createCheckpoint: (state: IParseState) => IParserUtils.stateCheckpointFactory(state),
+    restoreFromCheckpoint: (state: IParseState, checkpoint: IParseStateCheckpoint) =>
         IParserUtils.restoreStateCheckpoint(state, checkpoint),
 };

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -7,10 +7,10 @@ import { DefaultLocale } from "../localization";
 import {
     CombinatorialParser,
     IParser,
-    IParserState,
-    IParserStateUtils,
+    IParseState,
+    IParseStateUtils,
     ParserOptions,
-    TParserStateFactoryOverrides,
+    TParseStateFactoryOverrides,
 } from "../parser";
 
 export interface CommonSettings {
@@ -21,22 +21,22 @@ export interface CommonSettings {
 // tslint:disable-next-line: no-empty-interface
 export interface LexSettings extends CommonSettings {}
 
-export interface ParseSettings<S extends IParserState = IParserState> extends CommonSettings {
+export interface ParseSettings<S extends IParseState = IParseState> extends CommonSettings {
     readonly parser: IParser<S>;
     readonly maybeParserOptions: ParserOptions<S> | undefined;
-    readonly parserStateFactory: (
+    readonly parseStateFactory: (
         lexerSnapshot: LexerSnapshot,
-        maybeOverrides: TParserStateFactoryOverrides | undefined,
+        maybeOverrides: TParseStateFactoryOverrides | undefined,
     ) => S;
 }
 
-export type Settings<S extends IParserState = IParserState> = LexSettings & ParseSettings<S>;
+export type Settings<S extends IParseState = IParseState> = LexSettings & ParseSettings<S>;
 
-export const DefaultSettings: Settings<IParserState> = {
+export const DefaultSettings: Settings<IParseState> = {
     maybeCancellationToken: undefined,
     locale: DefaultLocale,
     parser: CombinatorialParser,
     maybeParserOptions: undefined,
-    parserStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParserStateFactoryOverrides | undefined) =>
-        IParserStateUtils.stateFactory(lexerSnapshot, maybeOverrides),
+    parseStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParseStateFactoryOverrides | undefined) =>
+        IParseStateUtils.stateFactory(lexerSnapshot, maybeOverrides),
 };

--- a/src/task.ts
+++ b/src/task.ts
@@ -8,8 +8,8 @@ import { ActiveNodeUtils, TMaybeActiveNode } from "./inspection/activeNode";
 import { Ast } from "./language";
 import { LexError, LexerSnapshot } from "./lexer";
 import {
-    IParserState,
     IParserUtils,
+    IParseState,
     NodeIdMap,
     ParseContext,
     ParseError,
@@ -20,21 +20,21 @@ import {
 } from "./parser";
 import { LexSettings, ParseSettings } from "./settings/settings";
 
-export type TriedLexParse<S extends IParserState = IParserState> = Result<
+export type TriedLexParse<S extends IParseState = IParseState> = Result<
     LexParseOk<S>,
     LexError.TLexError | ParseError.TParseError<S>
 >;
 
-export type TriedLexParseInspect<S extends IParserState = IParserState> = Result<
+export type TriedLexParseInspect<S extends IParseState = IParseState> = Result<
     LexParseInspectOk<S>,
     CommonError.CommonError | LexError.LexError | ParseError.ParseError
 >;
 
-export interface LexParseOk<S extends IParserState = IParserState> extends ParseOk<S> {
+export interface LexParseOk<S extends IParseState = IParseState> extends ParseOk<S> {
     readonly lexerSnapshot: Lexer.LexerSnapshot;
 }
 
-export interface LexParseInspectOk<S extends IParserState = IParserState> extends Inspection.Inspection {
+export interface LexParseInspectOk<S extends IParseState = IParseState> extends Inspection.Inspection {
     readonly triedParse: TriedParse<S>;
 }
 
@@ -56,19 +56,19 @@ export function tryLex(settings: LexSettings, text: string): Lexer.TriedLexerSna
     return Lexer.trySnapshot(state);
 }
 
-export function tryParse<S extends IParserState = IParserState>(
+export function tryParse<S extends IParseState = IParseState>(
     parseSettings: ParseSettings<S>,
     lexerSnapshot: LexerSnapshot,
 ): TriedParse<S> {
     return IParserUtils.tryParse<S>(parseSettings, lexerSnapshot) as TriedParse<S>;
 }
 
-export function tryInspection<S extends IParserState = IParserState>(
+export function tryInspection<S extends IParseState = IParseState>(
     parseSettings: ParseSettings<S>,
     triedParse: TriedParse<S>,
     position: Inspection.Position,
 ): Inspection.TriedInspection {
-    let parserState: S;
+    let parseState: S;
     let maybeParseError: ParseError.ParseError<S> | undefined;
 
     if (ResultUtils.isErr(triedParse)) {
@@ -82,15 +82,15 @@ export function tryInspection<S extends IParserState = IParserState>(
             maybeParseError = triedParse.error;
         }
 
-        parserState = triedParse.error.state;
+        parseState = triedParse.error.state;
     } else {
-        parserState = triedParse.value.state;
+        parseState = triedParse.value.state;
     }
 
-    return ResultUtils.okFactory(Inspection.inspection(parseSettings, parserState, maybeParseError, position));
+    return ResultUtils.okFactory(Inspection.inspection(parseSettings, parseState, maybeParseError, position));
 }
 
-export function tryLexParse<S extends IParserState = IParserState>(
+export function tryLexParse<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
 ): TriedLexParse<S> {
@@ -111,7 +111,7 @@ export function tryLexParse<S extends IParserState = IParserState>(
     }
 }
 
-export function tryLexParseInspection<S extends IParserState = IParserState>(
+export function tryLexParseInspection<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Inspection.Position,
@@ -136,7 +136,7 @@ export function tryLexParseInspection<S extends IParserState = IParserState>(
     });
 }
 
-export function maybeTriedParseFromTriedLexParse<S extends IParserState>(
+export function maybeTriedParseFromTriedLexParse<S extends IParseState>(
     triedLexParse: TriedLexParse<S>,
 ): TriedParse<S> | undefined {
     let root: Ast.TNode;
@@ -168,7 +168,7 @@ export function maybeTriedParseFromTriedLexParse<S extends IParserState>(
     });
 }
 
-export function rootFromTriedLexParse<S extends IParserState = IParserState>(
+export function rootFromTriedLexParse<S extends IParseState = IParseState>(
     triedLexParse: TriedLexParse<S>,
 ): TXorNode | undefined {
     if (ResultUtils.isOk(triedLexParse)) {
@@ -181,7 +181,7 @@ export function rootFromTriedLexParse<S extends IParserState = IParserState>(
     }
 }
 
-export function rootFromTriedLexParseInspect<S extends IParserState = IParserState>(
+export function rootFromTriedLexParseInspect<S extends IParseState = IParseState>(
     triedLexInspectParseInspect: TriedLexParseInspect<S>,
 ): TXorNode | undefined {
     if (ResultUtils.isOk(triedLexInspectParseInspect)) {

--- a/src/test/libraryTest/inspection/autocomplete/autocompleteFieldAccess.ts
+++ b/src/test/libraryTest/inspection/autocomplete/autocompleteFieldAccess.ts
@@ -6,7 +6,7 @@ import "mocha";
 import { Inspection } from "../../../..";
 import { Assert } from "../../../../common";
 import { AutocompleteItem } from "../../../../inspection";
-import { IParserState } from "../../../../parser";
+import { IParseState } from "../../../../parser";
 import { DefaultSettings, LexSettings, ParseSettings } from "../../../../settings";
 import { TestAssertUtils } from "../../../testUtils";
 
@@ -22,7 +22,7 @@ function abridgedFieldAccess(
     return maybeAutocompleteFieldAccess.autocompleteItems.map((item: AutocompleteItem) => item.key);
 }
 
-function assertGetParseOkAutocompleteOkFieldAccess<S extends IParserState = IParserState>(
+function assertGetParseOkAutocompleteOkFieldAccess<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Inspection.Position,
@@ -32,7 +32,7 @@ function assertGetParseOkAutocompleteOkFieldAccess<S extends IParserState = IPar
     return abridgedFieldAccess(actual.triedFieldAccess.value);
 }
 
-function assertGetParseErrAutocompleteOkFieldAccess<S extends IParserState = IParserState>(
+function assertGetParseErrAutocompleteOkFieldAccess<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Inspection.Position,

--- a/src/test/libraryTest/inspection/autocomplete/autocompleteLanguageConstant.ts
+++ b/src/test/libraryTest/inspection/autocomplete/autocompleteLanguageConstant.ts
@@ -5,11 +5,11 @@ import { expect } from "chai";
 import "mocha";
 import { Inspection, Language } from "../../../..";
 import { Assert } from "../../../../common";
-import { IParserState } from "../../../../parser";
+import { IParseState } from "../../../../parser";
 import { DefaultSettings, LexSettings, ParseSettings } from "../../../../settings";
 import { TestAssertUtils } from "../../../testUtils";
 
-function assertGetParseErrAutocompleteOkLanguageConstant<S extends IParserState = IParserState>(
+function assertGetParseErrAutocompleteOkLanguageConstant<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Inspection.Position,

--- a/src/test/libraryTest/inspection/autocomplete/autocompletePrimitiveType.ts
+++ b/src/test/libraryTest/inspection/autocomplete/autocompletePrimitiveType.ts
@@ -6,11 +6,11 @@ import "mocha";
 import { Inspection } from "../../../..";
 import { Assert } from "../../../../common";
 import { Constant } from "../../../../language";
-import { IParserState } from "../../../../parser";
+import { IParseState } from "../../../../parser";
 import { DefaultSettings, LexSettings, ParseSettings } from "../../../../settings";
 import { TestAssertUtils } from "../../../testUtils";
 
-function assertGetParseOkAutocompleteOkPrimitiveType<S extends IParserState = IParserState>(
+function assertGetParseOkAutocompleteOkPrimitiveType<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Inspection.Position,
@@ -20,7 +20,7 @@ function assertGetParseOkAutocompleteOkPrimitiveType<S extends IParserState = IP
     return actual.triedPrimitiveType.value;
 }
 
-function assertGetParseErrAutocompleteOkPrimitiveType<S extends IParserState = IParserState>(
+function assertGetParseErrAutocompleteOkPrimitiveType<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Inspection.Position,

--- a/src/test/libraryTest/inspection/invokeExpression.ts
+++ b/src/test/libraryTest/inspection/invokeExpression.ts
@@ -7,7 +7,7 @@ import { Inspection } from "../../..";
 import { Assert } from "../../../common";
 import { InvokeExpression, Position } from "../../../inspection";
 import { ActiveNode, ActiveNodeUtils } from "../../../inspection/activeNode";
-import { IParserState, NodeIdMap, ParseContext, ParseError, ParseOk } from "../../../parser";
+import { IParseState, NodeIdMap, ParseContext, ParseError, ParseOk } from "../../../parser";
 import { CommonSettings, DefaultSettings, LexSettings, ParseSettings } from "../../../settings";
 import { TestAssertUtils } from "../../testUtils";
 
@@ -29,7 +29,7 @@ function assertInvokeExpressionOk(
 }
 
 function assertParseOkInvokeExpressionOk(
-    settings: LexSettings & ParseSettings<IParserState>,
+    settings: LexSettings & ParseSettings<IParseState>,
     text: string,
     position: Position,
 ): InvokeExpression | undefined {
@@ -39,7 +39,7 @@ function assertParseOkInvokeExpressionOk(
 }
 
 function assertParseErrInvokeExpressionOk(
-    settings: LexSettings & ParseSettings<IParserState>,
+    settings: LexSettings & ParseSettings<IParseState>,
     text: string,
     position: Position,
 ): InvokeExpression | undefined {

--- a/src/test/libraryTest/inspection/scope.ts
+++ b/src/test/libraryTest/inspection/scope.ts
@@ -8,7 +8,7 @@ import { Assert } from "../../../common";
 import { NodeScope, Position, ScopeItemKind } from "../../../inspection";
 import { ActiveNode, ActiveNodeUtils, TMaybeActiveNode } from "../../../inspection/activeNode";
 import { Ast, Constant } from "../../../language";
-import { IParserState, NodeIdMap, ParseContext, ParseError, ParseOk } from "../../../parser";
+import { IParseState, NodeIdMap, ParseContext, ParseError, ParseOk } from "../../../parser";
 import { CommonSettings, DefaultSettings, LexSettings, ParseSettings } from "../../../settings";
 import { TestAssertUtils } from "../../testUtils";
 
@@ -157,7 +157,7 @@ function assertNodeScopeOk(
 }
 
 export function assertGetParseOkScopeOk(
-    settings: LexSettings & ParseSettings<IParserState>,
+    settings: LexSettings & ParseSettings<IParseState>,
     text: string,
     position: Position,
 ): NodeScope {
@@ -167,7 +167,7 @@ export function assertGetParseOkScopeOk(
 }
 
 export function assertGetParseErrScopeOk(
-    settings: LexSettings & ParseSettings<IParserState>,
+    settings: LexSettings & ParseSettings<IParseState>,
     text: string,
     position: Position,
 ): NodeScope {

--- a/src/test/libraryTest/inspection/type.ts
+++ b/src/test/libraryTest/inspection/type.ts
@@ -8,7 +8,7 @@ import { Assert } from "../../../common";
 import { Position, ScopeTypeByKey } from "../../../inspection";
 import { ActiveNodeUtils } from "../../../inspection/activeNode";
 import { Ast, Type, TypeUtils } from "../../../language";
-import { IParserState, NodeIdMap, ParseContext, ParseError, TXorNode, XorNodeUtils } from "../../../parser";
+import { IParseState, NodeIdMap, ParseContext, ParseError, TXorNode, XorNodeUtils } from "../../../parser";
 import { CommonSettings, DefaultSettings } from "../../../settings";
 import { TestAssertUtils } from "../../testUtils";
 
@@ -25,7 +25,7 @@ function assertParseOkNodeTypeEqual(text: string, expected: Type.TType): void {
 }
 
 function assertParseErrNodeTypeEqual(text: string, expected: Type.TType): void {
-    const parseErr: ParseError.ParseError<IParserState> = TestAssertUtils.assertGetParseErr(DefaultSettings, text);
+    const parseErr: ParseError.ParseError<IParseState> = TestAssertUtils.assertGetParseErr(DefaultSettings, text);
     const root: ParseContext.Node = Assert.asDefined(parseErr.state.contextState.maybeRoot);
 
     const actual: Type.TType = assertGetParseNodeOk(

--- a/src/test/libraryTest/parser/children.ts
+++ b/src/test/libraryTest/parser/children.ts
@@ -5,7 +5,7 @@ import { expect } from "chai";
 import "mocha";
 import { Task } from "../../..";
 import { Ast } from "../../../language";
-import { IParserState, NodeIdMap } from "../../../parser";
+import { IParseState, NodeIdMap } from "../../../parser";
 import { DefaultSettings } from "../../../settings";
 import { TestAssertUtils } from "../../testUtils";
 
@@ -15,7 +15,7 @@ interface ChildIdsByIdEntry {
     readonly kind: Ast.NodeKind;
 }
 
-function actualFactory<S extends IParserState = IParserState>(lexParseOk: Task.LexParseOk<S>): ChildIdsByIdEntry[] {
+function actualFactory<S extends IParseState = IParseState>(lexParseOk: Task.LexParseOk<S>): ChildIdsByIdEntry[] {
     const actual: ChildIdsByIdEntry[] = [];
     const astNodeById: NodeIdMap.AstNodeById = lexParseOk.state.contextState.nodeIdMapCollection.astNodeById;
 

--- a/src/test/libraryTest/parser/columnNumber.ts
+++ b/src/test/libraryTest/parser/columnNumber.ts
@@ -4,13 +4,13 @@
 import { expect } from "chai";
 import "mocha";
 import { Assert } from "../../../common";
-import { IParserState, ParseError } from "../../../parser";
+import { IParseState, ParseError } from "../../../parser";
 import { TokenWithColumnNumber } from "../../../parser/error";
 import { DefaultSettings } from "../../../settings";
 import { TestAssertUtils } from "../../testUtils";
 
 function assertGetExpectedTokenKindError(text: string): ParseError.ExpectedTokenKindError {
-    const error: ParseError.ParseError<IParserState> = TestAssertUtils.assertGetParseErr(DefaultSettings, text);
+    const error: ParseError.ParseError<IParseState> = TestAssertUtils.assertGetParseErr(DefaultSettings, text);
     const innerError: ParseError.TInnerParseError = error.innerError;
 
     Assert.isTrue(

--- a/src/test/resourceTest/benchmark.ts
+++ b/src/test/resourceTest/benchmark.ts
@@ -12,10 +12,10 @@ import { DefaultLocale } from "../../localization";
 import {
     CombinatorialParser,
     IParser,
-    IParserState,
-    IParserStateUtils,
+    IParseState,
+    IParseStateUtils,
     RecursiveDescentParser,
-    TParserStateFactoryOverrides,
+    TParseStateFactoryOverrides,
 } from "../../parser";
 import { ParseSettings } from "../../settings";
 import { TestFileUtils } from "../testUtils";
@@ -52,22 +52,22 @@ writeReport(ResourceDirectory, allSummaries);
 
 function benchmarkStateFactory(
     lexerSnapshot: LexerSnapshot,
-    maybeOverrides: TParserStateFactoryOverrides | undefined,
-    baseParser: IParser<IParserState>,
+    maybeOverrides: TParseStateFactoryOverrides | undefined,
+    baseParser: IParser<IParseState>,
 ): BenchmarkState {
     return {
-        ...IParserStateUtils.stateFactory(lexerSnapshot, maybeOverrides),
+        ...IParseStateUtils.stateFactory(lexerSnapshot, maybeOverrides),
         baseParser,
         functionTimestamps: new Map(),
         functionTimestampCounter: 0,
     };
 }
 
-function benchmarkParseSettingsFactory(baseParser: IParser<IParserState>): ParseSettings<BenchmarkState> {
+function benchmarkParseSettingsFactory(baseParser: IParser<IParseState>): ParseSettings<BenchmarkState> {
     return {
         maybeCancellationToken: undefined,
         parser: BenchmarkParser,
-        parserStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParserStateFactoryOverrides | undefined) =>
+        parseStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParseStateFactoryOverrides | undefined) =>
             benchmarkStateFactory(lexerSnapshot, maybeOverrides, baseParser),
         maybeParserOptions: undefined,
         locale: DefaultLocale,

--- a/src/test/resourceTest/lexParse.ts
+++ b/src/test/resourceTest/lexParse.ts
@@ -1,7 +1,7 @@
 import "mocha";
 import { Task } from "../..";
 import { ResultUtils } from "../../common";
-import { CombinatorialParser, IParser, IParserState, RecursiveDescentParser } from "../../parser";
+import { CombinatorialParser, IParser, IParseState, RecursiveDescentParser } from "../../parser";
 import { DefaultSettings, Settings } from "../../settings";
 
 import * as path from "path";
@@ -26,7 +26,7 @@ function testNameFromFilePath(filePath: string): string {
     return filePath.replace(path.dirname(__filename), ".");
 }
 
-function parseAllFiles<S extends IParserState>(settings: Settings<S>, parserName: string): void {
+function parseAllFiles<S extends IParseState>(settings: Settings<S>, parserName: string): void {
     describe(`Run ${parserName} on lexParseResources directory`, () => {
         const fileDirectory: string = path.join(path.dirname(__filename), "lexParseResources");
 

--- a/src/test/testUtils/assertUtils.ts
+++ b/src/test/testUtils/assertUtils.ts
@@ -6,7 +6,7 @@ import "mocha";
 import { Assert, Inspection, Lexer, Task } from "../..";
 import { Autocomplete, Position } from "../../inspection";
 import { ActiveNodeUtils, TMaybeActiveNode } from "../../inspection/activeNode";
-import { IParserState, IParserUtils, ParseError, ParseOk, TriedParse } from "../../parser";
+import { IParserUtils, IParseState, ParseError, ParseOk, TriedParse } from "../../parser";
 import { LexSettings, ParseSettings } from "../../settings";
 
 // Only works with single line expressions
@@ -24,7 +24,7 @@ export function assertGetTextWithPosition(text: string): [string, Inspection.Pos
     return [text.replace("|", ""), position];
 }
 
-export function assertGetLexParseOk<S extends IParserState = IParserState>(
+export function assertGetLexParseOk<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
 ): Task.LexParseOk<S> {
@@ -33,7 +33,7 @@ export function assertGetLexParseOk<S extends IParserState = IParserState>(
     return triedLexParse.value;
 }
 
-export function assertGetParseErr<S extends IParserState = IParserState>(
+export function assertGetParseErr<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
 ): ParseError.ParseError<S> {
@@ -47,7 +47,7 @@ export function assertGetParseErr<S extends IParserState = IParserState>(
     return triedParse.error;
 }
 
-export function assertGetParseOk<S extends IParserState = IParserState>(
+export function assertGetParseOk<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
 ): ParseOk<S> {
@@ -58,7 +58,7 @@ export function assertGetParseOk<S extends IParserState = IParserState>(
 
 // I only care about errors coming from the parse stage.
 // If I use tryLexParse I might get a CommonError which could have come either from lexing or parsing.
-function assertGetTriedParse<S extends IParserState = IParserState>(
+function assertGetTriedParse<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
 ): TriedParse<S> {
@@ -74,7 +74,7 @@ function assertGetTriedParse<S extends IParserState = IParserState>(
     return IParserUtils.tryParse<S>(settings, lexerSnapshot);
 }
 
-export function assertGetParseOkAutocompleteOk<S extends IParserState = IParserState>(
+export function assertGetParseOkAutocompleteOk<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Position,
@@ -83,7 +83,7 @@ export function assertGetParseOkAutocompleteOk<S extends IParserState = IParserS
     return assertGetAutocompleteOk(settings, parseOk.state, position, undefined);
 }
 
-export function assertGetParseErrAutocompleteOk<S extends IParserState = IParserState>(
+export function assertGetParseErrAutocompleteOk<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     text: string,
     position: Position,
@@ -92,20 +92,20 @@ export function assertGetParseErrAutocompleteOk<S extends IParserState = IParser
     return assertGetAutocompleteOk(settings, parseError.state, position, parseError);
 }
 
-export function assertGetAutocompleteOk<S extends IParserState = IParserState>(
+export function assertGetAutocompleteOk<S extends IParseState = IParseState>(
     parseSettings: ParseSettings<S>,
-    parserState: S,
+    parseState: S,
     position: Position,
     maybeParseError: ParseError.ParseError<S> | undefined,
 ): Autocomplete {
     const maybeActiveNode: TMaybeActiveNode = ActiveNodeUtils.maybeActiveNode(
-        parserState.contextState.nodeIdMapCollection,
-        parserState.contextState.leafNodeIds,
+        parseState.contextState.nodeIdMapCollection,
+        parseState.contextState.leafNodeIds,
         position,
     );
     return Inspection.autocomplete(
         parseSettings,
-        parserState,
+        parseState,
         {
             scopeById: new Map(),
             typeById: new Map(),

--- a/src/test/testUtils/fileUtils.ts
+++ b/src/test/testUtils/fileUtils.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import "mocha";
 import * as path from "path";
 import { Task } from "../..";
-import { IParserState } from "../../parser";
+import { IParseState } from "../../parser";
 import { LexSettings, ParseSettings } from "../../settings";
 
 const PowerQueryExtensions: ReadonlyArray<string> = [".m", ".mout", ".pq", "pqm"];
@@ -42,7 +42,7 @@ export function writeContents(filePath: string, contents: string): void {
     });
 }
 
-export function tryLexParse<S extends IParserState = IParserState>(
+export function tryLexParse<S extends IParseState = IParseState>(
     settings: LexSettings & ParseSettings<S>,
     filePath: string,
 ): Task.TriedLexParse<S> {


### PR DESCRIPTION
~90% of this PR is changing IParserState to IParseState, which is more consistent with the naming scheme for the public API. The remaining changes are similar such as ParserOptions -> ParseOptions.