### PR TITLE
Remove ParseOptions

### DIFF
--- a/src/parser/IParser/IParser.ts
+++ b/src/parser/IParser/IParser.ts
@@ -18,10 +18,6 @@ export interface ParseOk<S extends IParseState = IParseState> {
     readonly state: S;
 }
 
-export interface ParserOptions<S extends IParseState = IParseState> {
-    readonly maybeEntryPoint: ((state: S, parser: IParser<S>) => Ast.TNode) | undefined;
-}
-
 export interface IParser<S extends IParseState = IParseState, C extends IParseStateCheckpoint = IParseStateCheckpoint> {
     readonly createCheckpoint: (state: S) => C;
     readonly restoreFromCheckpoint: (state: S, checkpoint: C) => void;

--- a/src/parser/IParser/IParserUtils.ts
+++ b/src/parser/IParser/IParserUtils.ts
@@ -15,10 +15,10 @@ export function tryParse<S extends IParseState = IParseState>(
     parseSettings: ParseSettings<S>,
     lexerSnapshot: LexerSnapshot,
 ): TriedParse<S> {
-    const maybeEntryPointFn: ((state: S, parser: IParser<S>) => Ast.TNode) | undefined =
-        parseSettings?.maybeParserOptions?.maybeEntryPoint;
+    const maybeParserEntryPointFn: ((state: S, parser: IParser<S>) => Ast.TNode) | undefined =
+        parseSettings?.maybeParserEntryPointFn;
 
-    if (maybeEntryPointFn === undefined) {
+    if (maybeParserEntryPointFn === undefined) {
         return tryParseDocument<S>(parseSettings, lexerSnapshot) as TriedParse<S>;
     }
 
@@ -27,7 +27,7 @@ export function tryParse<S extends IParseState = IParseState>(
         locale: parseSettings.locale,
     });
     try {
-        const root: Ast.TNode = maybeEntryPointFn(parseState, parseSettings.parser);
+        const root: Ast.TNode = maybeParserEntryPointFn(parseState, parseSettings.parser);
         IParseStateUtils.assertNoMoreTokens(parseState);
         IParseStateUtils.assertNoOpenContext(parseState);
         return ResultUtils.okFactory({

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -2,16 +2,10 @@
 // Licensed under the MIT license.
 
 import { ICancellationToken } from "../common";
+import { Ast } from "../language";
 import { LexerSnapshot } from "../lexer";
 import { DefaultLocale } from "../localization";
-import {
-    CombinatorialParser,
-    IParser,
-    IParseState,
-    IParseStateUtils,
-    ParserOptions,
-    TParseStateFactoryOverrides,
-} from "../parser";
+import { CombinatorialParser, IParser, IParseState, IParseStateUtils, TParseStateFactoryOverrides } from "../parser";
 
 export interface CommonSettings {
     readonly maybeCancellationToken: ICancellationToken | undefined;
@@ -23,11 +17,11 @@ export interface LexSettings extends CommonSettings {}
 
 export interface ParseSettings<S extends IParseState = IParseState> extends CommonSettings {
     readonly parser: IParser<S>;
-    readonly maybeParserOptions: ParserOptions<S> | undefined;
     readonly parseStateFactory: (
         lexerSnapshot: LexerSnapshot,
         maybeOverrides: TParseStateFactoryOverrides | undefined,
     ) => S;
+    readonly maybeParserEntryPointFn: ((state: S, parser: IParser<S>) => Ast.TNode) | undefined;
 }
 
 export type Settings<S extends IParseState = IParseState> = LexSettings & ParseSettings<S>;
@@ -36,7 +30,7 @@ export const DefaultSettings: Settings<IParseState> = {
     maybeCancellationToken: undefined,
     locale: DefaultLocale,
     parser: CombinatorialParser,
-    maybeParserOptions: undefined,
     parseStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParseStateFactoryOverrides | undefined) =>
         IParseStateUtils.stateFactory(lexerSnapshot, maybeOverrides),
+    maybeParserEntryPointFn: undefined,
 };

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -12,8 +12,7 @@ export interface CommonSettings {
     readonly locale: string;
 }
 
-// tslint:disable-next-line: no-empty-interface
-export interface LexSettings extends CommonSettings {}
+export type LexSettings = CommonSettings;
 
 export interface ParseSettings<S extends IParseState = IParseState> extends CommonSettings {
     readonly parser: IParser<S>;

--- a/src/test/libraryTest/parser/error.ts
+++ b/src/test/libraryTest/parser/error.ts
@@ -64,9 +64,7 @@ describe("Parser.Error", () => {
             const customSettings: Settings = {
                 ...DefaultSettings,
                 parser: RecursiveDescentParser,
-                maybeParserOptions: {
-                    maybeEntryPoint: RecursiveDescentParser.readIdentifier,
-                },
+                maybeParserEntryPointFn: RecursiveDescentParser.readIdentifier,
             };
             const text: string = "a b";
             const innerError: ParseError.TInnerParseError = TestAssertUtils.assertGetParseErr(customSettings, text)

--- a/src/test/libraryTest/parser/simple.ts
+++ b/src/test/libraryTest/parser/simple.ts
@@ -100,9 +100,7 @@ describe("Parser.AbridgedNode", () => {
             const customSettings: Settings = {
                 ...DefaultSettings,
                 parser: RecursiveDescentParser,
-                maybeParserOptions: {
-                    maybeEntryPoint: RecursiveDescentParser.readParameterSpecificationList,
-                },
+                maybeParserEntryPointFn: RecursiveDescentParser.readParameterSpecificationList,
             };
             const triedLexParse: Task.TriedLexParse = Task.tryLexParse(
                 customSettings,

--- a/src/test/resourceTest/benchmark.ts
+++ b/src/test/resourceTest/benchmark.ts
@@ -66,11 +66,11 @@ function benchmarkStateFactory(
 function benchmarkParseSettingsFactory(baseParser: IParser<IParseState>): ParseSettings<BenchmarkState> {
     return {
         maybeCancellationToken: undefined,
+        locale: DefaultLocale,
         parser: BenchmarkParser,
         parseStateFactory: (lexerSnapshot: LexerSnapshot, maybeOverrides: TParseStateFactoryOverrides | undefined) =>
             benchmarkStateFactory(lexerSnapshot, maybeOverrides, baseParser),
-        maybeParserOptions: undefined,
-        locale: DefaultLocale,
+        maybeParserEntryPointFn: undefined,
     };
 }
 


### PR DESCRIPTION
It ended being a duplication of ParseSettings. Combining the two into one, ParseSettings.