### PR TITLE
Update parser version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.2.11",
+    "version": "0.2.12",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/parser/IParseState/IParseStateUtils.ts
+++ b/src/parser/IParseState/IParseStateUtils.ts
@@ -293,7 +293,7 @@ export function testIsOnAnyTokenKind(
     expectedAnyTokenKinds: ReadonlyArray<Token.TokenKind>,
 ): ParseError.ExpectedAnyTokenKindError | undefined {
     const isError: boolean =
-        state.maybeCurrentTokenKind === undefined || expectedAnyTokenKinds.indexOf(state.maybeCurrentTokenKind) === -1;
+        state.maybeCurrentTokenKind === undefined || !expectedAnyTokenKinds.includes(state.maybeCurrentTokenKind);
 
     if (isError) {
         const maybeToken: ParseError.TokenWithColumnNumber | undefined = maybeCurrentTokenWithColumnNumber(state);

--- a/src/parser/disambiguation/disambiguation.ts
+++ b/src/parser/disambiguation/disambiguation.ts
@@ -8,7 +8,7 @@ import { IParseState } from "../IParseState";
 
 export type TAmbiguousBracketNode = Ast.FieldProjection | Ast.FieldSelector | Ast.RecordExpression;
 
-export type TAmbiguousParenthesisNode = Ast.FunctionExpression | Ast.ParenthesizedExpression;
+export type TAmbiguousParenthesisNode = Ast.FunctionExpression | Ast.ParenthesizedExpression | Ast.TLogicalExpression;
 
 export const enum DismabiguationBehavior {
     Strict = "Strict",

--- a/src/parser/disambiguation/disambiguationUtils.ts
+++ b/src/parser/disambiguation/disambiguationUtils.ts
@@ -321,7 +321,7 @@ function readParenthesizedExpressionOrBinOpExpression<S extends IParseState>(
     Assert.isTrue(
         leftMostNode.kind === Ast.NodeKind.Constant &&
             leftMostNode.constantKind === Language.Constant.WrapperConstantKind.LeftParenthesis,
-        "leftMostNode should be a LeftParenthesis",
+        `leftMostNode should be a ${Ast.NodeKind.Constant} with a constantKind of ${Language.Constant.WrapperConstantKind.LeftParenthesis}`,
     );
 
     return node;

--- a/src/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
+++ b/src/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
@@ -1,12 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { NodeIdMap } from "..";
+import { NodeIdMap, XorNodeUtils } from "..";
 import { Assert } from "../../../common";
 import { Ast } from "../../../language";
 import { AstNodeById, Collection } from "../nodeIdMap";
 import { TXorNode, XorNodeKind } from "../xorNode";
 import { maybeXor } from "./commonSelectors";
+
+export function assertGetLeftMostAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode {
+    return XorNodeUtils.assertGetAst(
+        Assert.asDefined(
+            maybeLeftMostXor(nodeIdMapCollection, nodeId),
+            `nodeId does not exist in nodeIdMapCollection`,
+            { nodeId },
+        ),
+    );
+}
 
 export function assertGetLeftMostXor(nodeIdMapCollection: Collection, nodeId: number): TXorNode {
     return Assert.asDefined(

--- a/src/parser/parsers/naive.ts
+++ b/src/parser/parsers/naive.ts
@@ -357,22 +357,8 @@ export function readExpression<S extends IParseState = IParseState>(state: S, pa
         case Token.TokenKind.KeywordTry:
             return parser.readErrorHandlingExpression(state, parser);
 
-        case Token.TokenKind.LeftParenthesis: {
-            const maybeDisambiguation:
-                | Disambiguation.ParenthesisDisambiguation
-                | undefined = DisambiguationUtils.maybeDisambiguateParenthesis(state, parser);
-
-            if (
-                maybeDisambiguation &&
-                maybeDisambiguation === Disambiguation.ParenthesisDisambiguation.FunctionExpression
-            ) {
-                return parser.readFunctionExpression(state, parser);
-            } else if (state.disambiguationBehavior === Disambiguation.DismabiguationBehavior.Strict) {
-                throw IParseStateUtils.unterminatedParenthesesError(state);
-            } else {
-                return parser.readNullCoalescingExpression(state, parser);
-            }
-        }
+        case Token.TokenKind.LeftParenthesis:
+            return DisambiguationUtils.readAmbiguousParenthesis(state, parser);
 
         default:
             return parser.readNullCoalescingExpression(state, parser);

--- a/src/test/libraryTest/inspection/scope.ts
+++ b/src/test/libraryTest/inspection/scope.ts
@@ -1248,14 +1248,14 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         kind: ScopeItemKind.KeyValuePair,
                         isRecursive: true,
                         keyNodeId: 6,
-                        maybeValueNodeId: 8,
+                        maybeValueNodeId: 10,
                     },
                     {
                         identifier: "y",
                         kind: ScopeItemKind.KeyValuePair,
                         isRecursive: false,
-                        keyNodeId: 15,
-                        maybeValueNodeId: 19,
+                        keyNodeId: 17,
+                        maybeValueNodeId: 21,
                     },
                 ];
                 const actual: AbridgedNodeScope = abridgedScopeItemsFactory(
@@ -1274,7 +1274,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         kind: ScopeItemKind.KeyValuePair,
                         isRecursive: false,
                         keyNodeId: 6,
-                        maybeValueNodeId: 8,
+                        maybeValueNodeId: 10,
                     },
                 ];
                 const actual: AbridgedNodeScope = abridgedScopeItemsFactory(

--- a/src/test/libraryTest/inspection/scope.ts
+++ b/src/test/libraryTest/inspection/scope.ts
@@ -1248,14 +1248,14 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         kind: ScopeItemKind.KeyValuePair,
                         isRecursive: true,
                         keyNodeId: 6,
-                        maybeValueNodeId: 10,
+                        maybeValueNodeId: 9,
                     },
                     {
                         identifier: "y",
                         kind: ScopeItemKind.KeyValuePair,
                         isRecursive: false,
-                        keyNodeId: 17,
-                        maybeValueNodeId: 21,
+                        keyNodeId: 16,
+                        maybeValueNodeId: 20,
                     },
                 ];
                 const actual: AbridgedNodeScope = abridgedScopeItemsFactory(
@@ -1274,7 +1274,7 @@ describe(`subset Inspection - Scope - Identifier`, () => {
                         kind: ScopeItemKind.KeyValuePair,
                         isRecursive: false,
                         keyNodeId: 6,
-                        maybeValueNodeId: 10,
+                        maybeValueNodeId: 9,
                     },
                 ];
                 const actual: AbridgedNodeScope = abridgedScopeItemsFactory(

--- a/src/test/libraryTest/parser/error.ts
+++ b/src/test/libraryTest/parser/error.ts
@@ -63,8 +63,8 @@ describe("Parser.Error", () => {
         expect((innerError as ParseError.UnterminatedSequence).kind).to.equal(SequenceKind.Bracket, innerError.message);
     });
 
-    it("UnterminatedSequence (Parenthesis): let x = (", () => {
-        const text: string = "let x = (";
+    it("WIP UnterminatedSequence (Parenthesis): let x = (1", () => {
+        const text: string = "let x = (1";
         const innerError: ParseError.TInnerParseError = TestAssertUtils.assertGetParseErr(
             DefaultSettingsWithStrict,
             text,

--- a/src/test/libraryTest/parser/error.ts
+++ b/src/test/libraryTest/parser/error.ts
@@ -63,7 +63,7 @@ describe("Parser.Error", () => {
         expect((innerError as ParseError.UnterminatedSequence).kind).to.equal(SequenceKind.Bracket, innerError.message);
     });
 
-    it("WIP UnterminatedSequence (Parenthesis): let x = (1", () => {
+    it("UnterminatedSequence (Parenthesis): let x = (1", () => {
         const text: string = "let x = (1";
         const innerError: ParseError.TInnerParseError = TestAssertUtils.assertGetParseErr(
             DefaultSettingsWithStrict,

--- a/src/test/libraryTest/parser/simple.ts
+++ b/src/test/libraryTest/parser/simple.ts
@@ -1396,7 +1396,7 @@ describe("Parser.AbridgedNode", () => {
 
     // Ast.NodeKind.ParameterList covered by many
 
-    describe(`ABC ${Ast.NodeKind.ParenthesizedExpression}`, () => {
+    describe(`${Ast.NodeKind.ParenthesizedExpression}`, () => {
         it(`(1)`, () => {
             const text: string = `(1)`;
             const expected: ReadonlyArray<AbridgedNode> = [
@@ -1404,6 +1404,20 @@ describe("Parser.AbridgedNode", () => {
                 [Ast.NodeKind.Constant, 0],
                 [Ast.NodeKind.LiteralExpression, 1],
                 [Ast.NodeKind.Constant, 2],
+            ];
+            assertAbridgeNodes(text, expected);
+        });
+
+        it(`(1) + 1`, () => {
+            const text: string = `(1) + 1`;
+            const expected: ReadonlyArray<AbridgedNode> = [
+                [Ast.NodeKind.ArithmeticExpression, undefined],
+                [Ast.NodeKind.ParenthesizedExpression, 0],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.LiteralExpression, 1],
+                [Ast.NodeKind.Constant, 2],
+                [Ast.NodeKind.Constant, 1],
+                [Ast.NodeKind.LiteralExpression, 2],
             ];
             assertAbridgeNodes(text, expected);
         });
@@ -1421,6 +1435,23 @@ describe("Parser.AbridgedNode", () => {
                 [Ast.NodeKind.LiteralExpression, 3],
                 [Ast.NodeKind.Constant, 4],
                 [Ast.NodeKind.LiteralExpression, 5],
+                [Ast.NodeKind.Constant, 2],
+                [Ast.NodeKind.Constant, 1],
+                [Ast.NodeKind.LiteralExpression, 2],
+            ];
+            assertAbridgeNodes(text, expected);
+        });
+
+        it(`((1)) and true`, () => {
+            const text: string = `((1)) and true`;
+            const expected: ReadonlyArray<AbridgedNode> = [
+                [Ast.NodeKind.LogicalExpression, undefined],
+                [Ast.NodeKind.ParenthesizedExpression, 0],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.ParenthesizedExpression, 1],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.LiteralExpression, 1],
+                [Ast.NodeKind.Constant, 2],
                 [Ast.NodeKind.Constant, 2],
                 [Ast.NodeKind.Constant, 1],
                 [Ast.NodeKind.LiteralExpression, 2],

--- a/src/test/libraryTest/parser/simple.ts
+++ b/src/test/libraryTest/parser/simple.ts
@@ -1396,15 +1396,37 @@ describe("Parser.AbridgedNode", () => {
 
     // Ast.NodeKind.ParameterList covered by many
 
-    it(`${Ast.NodeKind.ParenthesizedExpression}`, () => {
-        const text: string = `(1)`;
-        const expected: ReadonlyArray<AbridgedNode> = [
-            [Ast.NodeKind.ParenthesizedExpression, undefined],
-            [Ast.NodeKind.Constant, 0],
-            [Ast.NodeKind.LiteralExpression, 1],
-            [Ast.NodeKind.Constant, 2],
-        ];
-        assertAbridgeNodes(text, expected);
+    describe(`ABC ${Ast.NodeKind.ParenthesizedExpression}`, () => {
+        it(`(1)`, () => {
+            const text: string = `(1)`;
+            const expected: ReadonlyArray<AbridgedNode> = [
+                [Ast.NodeKind.ParenthesizedExpression, undefined],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.LiteralExpression, 1],
+                [Ast.NodeKind.Constant, 2],
+            ];
+            assertAbridgeNodes(text, expected);
+        });
+
+        it(`(if true then true else false) and true`, () => {
+            const text: string = `(if true then true else false) and true`;
+            const expected: ReadonlyArray<AbridgedNode> = [
+                [Ast.NodeKind.LogicalExpression, undefined],
+                [Ast.NodeKind.ParenthesizedExpression, 0],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.IfExpression, 1],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.LiteralExpression, 1],
+                [Ast.NodeKind.Constant, 2],
+                [Ast.NodeKind.LiteralExpression, 3],
+                [Ast.NodeKind.Constant, 4],
+                [Ast.NodeKind.LiteralExpression, 5],
+                [Ast.NodeKind.Constant, 2],
+                [Ast.NodeKind.Constant, 1],
+                [Ast.NodeKind.LiteralExpression, 2],
+            ];
+            assertAbridgeNodes(text, expected);
+        });
     });
 
     describe(`${Ast.NodeKind.PrimitiveType}`, () => {


### PR DESCRIPTION
Other than bumping the version number up, this PR mostly tweaks how reading of parenthesized expressions is done. Previously it would incorrectly parse binary operation expressions where the first operand was a parenthesized expression.