### PR TITLE
Reverse scopeById and typeById

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,9 @@
         "--colors",
         "--timeout",
         "999999",
-        "${workspaceFolder}/lib/test/libraryTest/**/*.js"
+        "${workspaceFolder}/lib/test/libraryTest/**/*.js",
+        "-g",
+        "WIP"
       ],
       "preLaunchTask": "watch",
       "internalConsoleOptions": "openOnSessionStart"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
         "--colors",
         "--timeout",
         "999999",
-        "${workspaceFolder}/lib/test/libraryTest/**/*.js",
+        "${workspaceFolder}/lib/test/libraryTest/**/*.js"
       ],
       "preLaunchTask": "watch",
       "internalConsoleOptions": "openOnSessionStart"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,8 +15,6 @@
         "--timeout",
         "999999",
         "${workspaceFolder}/lib/test/libraryTest/**/*.js",
-        "-g",
-        "WIP"
       ],
       "preLaunchTask": "watch",
       "internalConsoleOptions": "openOnSessionStart"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1340,9 +1340,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1340,9 +1340,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "tslint-config-prettier": "^1.18.0",
         "tslint-microsoft-contrib": "^6.2.0",
         "tslint-plugin-prettier": "^2.3.0",
-        "typescript": "^3.8.3"
+        "typescript": "^4.1.3"
     },
     "files": [
         "lib/powerquery-parser/**/*"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "tslint-config-prettier": "^1.18.0",
         "tslint-microsoft-contrib": "^6.2.0",
         "tslint-plugin-prettier": "^2.3.0",
-        "typescript": "^4.1.3"
+        "typescript": "^3.8.3"
     },
     "files": [
         "lib/powerquery-parser/**/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.2.12",
+    "version": "0.2.13",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/inspection/type/task.ts
+++ b/src/powerquery-parser/inspection/type/task.ts
@@ -42,11 +42,11 @@ export function tryType(
 ): TriedType {
     const state: InspectTypeState = {
         settings,
-        givenTypeById: maybeTypeCache?.scopeById ?? new Map(),
+        givenTypeById: maybeTypeCache?.typeById ?? new Map(),
         deltaTypeById: new Map(),
         nodeIdMapCollection,
         leafNodeIds,
-        scopeById: maybeTypeCache?.typeById ?? new Map(),
+        scopeById: maybeTypeCache?.scopeById ?? new Map(),
     };
 
     return ResultUtils.ensureResult(settings.locale, () =>


### PR DESCRIPTION
Somehow I was able to assign a `Map<number, NodeScope>` to a `Map<number, Type.TType>` and vice-versa without TypeScript complaining.