### PR TITLE
Add TypeUtils.nameOf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.2.13",
+    "version": "0.2.14",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/stringUtils.ts
+++ b/src/powerquery-parser/common/stringUtils.ts
@@ -54,6 +54,10 @@ export function graphemePositionFrom(
     };
 }
 
+export function normalizeIdentifier(text: string): string {
+    return isQuotedIdentifier(text) ? text.slice(2, text.length - 1) : text;
+}
+
 export function isIdentifier(text: string, allowTrailingPeriod: boolean): boolean {
     return maybeIdentifierLength(text, 0, allowTrailingPeriod) === text.length;
 }

--- a/src/powerquery-parser/inspection/scope/scopeItem.ts
+++ b/src/powerquery-parser/inspection/scope/scopeItem.ts
@@ -12,11 +12,11 @@ export type TScopeItem =
     | UndefinedScopeItem;
 
 export const enum ScopeItemKind {
-    KeyValuePair = "KeyValuePair",
-    Undefined = "Undefined",
     Each = "Each",
+    KeyValuePair = "KeyValuePair",
     Parameter = "Parameter",
     SectionMember = "SectionMember",
+    Undefined = "Undefined",
 }
 
 export interface IScopeItem {

--- a/src/powerquery-parser/language/type/type.ts
+++ b/src/powerquery-parser/language/type/type.ts
@@ -62,6 +62,7 @@ export type TPrimitiveType =
     | Null
     | Number
     | Record
+    | Text
     | Table
     | Text
     | Time
@@ -268,6 +269,7 @@ export interface TableTypePrimaryExpression extends IExtendedType {
 // ---------- Non-nullable primitive singletons ----------
 // -------------------------------------------------------
 
+export const ActionInstance: IPrimitiveType<TypeKind.Action> = primitiveTypeFactory(TypeKind.Action, false);
 export const AnyInstance: IPrimitiveType<TypeKind.Any> = primitiveTypeFactory(TypeKind.Any, false);
 export const AnyNonNullInstance: IPrimitiveType<TypeKind.AnyNonNull> = primitiveTypeFactory(TypeKind.AnyNonNull, false);
 export const BinaryInstance: IPrimitiveType<TypeKind.Binary> = primitiveTypeFactory(TypeKind.Binary, false);
@@ -282,24 +284,24 @@ export const FunctionInstance: IPrimitiveType<TypeKind.Function> = primitiveType
 export const ListInstance: IPrimitiveType<TypeKind.List> = primitiveTypeFactory(TypeKind.List, false);
 export const LogicalInstance: IPrimitiveType<TypeKind.Logical> = primitiveTypeFactory(TypeKind.Logical, false);
 export const NoneInstance: IPrimitiveType<TypeKind.None> = primitiveTypeFactory(TypeKind.None, false);
+export const NotApplicableInstance: IPrimitiveType<TypeKind.NotApplicable> = primitiveTypeFactory(
+    TypeKind.NotApplicable,
+    false,
+);
 export const NullInstance: IPrimitiveType<TypeKind.Null> = primitiveTypeFactory(TypeKind.Null, false);
 export const NumberInstance: IPrimitiveType<TypeKind.Number> = primitiveTypeFactory(TypeKind.Number, false);
 export const RecordInstance: IPrimitiveType<TypeKind.Record> = primitiveTypeFactory(TypeKind.Record, false);
 export const TableInstance: IPrimitiveType<TypeKind.Table> = primitiveTypeFactory(TypeKind.Table, false);
 export const TextInstance: IPrimitiveType<TypeKind.Text> = primitiveTypeFactory(TypeKind.Text, false);
-export const TypePrimitiveInstance: IPrimitiveType<TypeKind.Type> = primitiveTypeFactory(TypeKind.Type, false);
-export const ActionInstance: IPrimitiveType<TypeKind.Action> = primitiveTypeFactory(TypeKind.Action, false);
 export const TimeInstance: IPrimitiveType<TypeKind.Time> = primitiveTypeFactory(TypeKind.Time, false);
-export const NotApplicableInstance: IPrimitiveType<TypeKind.NotApplicable> = primitiveTypeFactory(
-    TypeKind.NotApplicable,
-    false,
-);
+export const TypePrimitiveInstance: IPrimitiveType<TypeKind.Type> = primitiveTypeFactory(TypeKind.Type, false);
 export const UnknownInstance: IPrimitiveType<TypeKind.Unknown> = primitiveTypeFactory(TypeKind.Unknown, false);
 
 // ---------------------------------------------------
 // ---------- Nullable primitive singletons ----------
 // ---------------------------------------------------
 
+export const NullableActionInstance: IPrimitiveType<TypeKind.Action> = primitiveTypeFactory(TypeKind.Action, true);
 export const NullableAnyInstance: IPrimitiveType<TypeKind.Any> = primitiveTypeFactory(TypeKind.Any, true);
 export const NullableBinaryInstance: IPrimitiveType<TypeKind.Binary> = primitiveTypeFactory(TypeKind.Binary, true);
 export const NullableDateInstance: IPrimitiveType<TypeKind.Date> = primitiveTypeFactory(TypeKind.Date, true);
@@ -322,18 +324,17 @@ export const NullableFunctionInstance: IPrimitiveType<TypeKind.Function> = primi
 export const NullableListInstance: IPrimitiveType<TypeKind.List> = primitiveTypeFactory(TypeKind.List, true);
 export const NullableLogicalInstance: IPrimitiveType<TypeKind.Logical> = primitiveTypeFactory(TypeKind.Logical, true);
 export const NullableNoneInstance: IPrimitiveType<TypeKind.None> = primitiveTypeFactory(TypeKind.None, true);
+export const NullableNotApplicableInstance: IPrimitiveType<TypeKind.NotApplicable> = primitiveTypeFactory(
+    TypeKind.NotApplicable,
+    true,
+);
 export const NullableNullInstance: IPrimitiveType<TypeKind.Null> = primitiveTypeFactory(TypeKind.Null, true);
 export const NullableNumberInstance: IPrimitiveType<TypeKind.Number> = primitiveTypeFactory(TypeKind.Number, true);
 export const NullableRecordInstance: IPrimitiveType<TypeKind.Record> = primitiveTypeFactory(TypeKind.Record, true);
 export const NullableTableInstance: IPrimitiveType<TypeKind.Table> = primitiveTypeFactory(TypeKind.Table, true);
 export const NullableTextInstance: IPrimitiveType<TypeKind.Text> = primitiveTypeFactory(TypeKind.Text, true);
-export const NullableTypeInstance: IPrimitiveType<TypeKind.Type> = primitiveTypeFactory(TypeKind.Type, true);
-export const NullableActionInstance: IPrimitiveType<TypeKind.Action> = primitiveTypeFactory(TypeKind.Action, true);
 export const NullableTimeInstance: IPrimitiveType<TypeKind.Time> = primitiveTypeFactory(TypeKind.Time, true);
-export const NullableNotApplicableInstance: IPrimitiveType<TypeKind.NotApplicable> = primitiveTypeFactory(
-    TypeKind.NotApplicable,
-    true,
-);
+export const NullableTypeInstance: IPrimitiveType<TypeKind.Type> = primitiveTypeFactory(TypeKind.Type, true);
 export const NullableUnknownInstance: IPrimitiveType<TypeKind.Unknown> = primitiveTypeFactory(TypeKind.Unknown, true);
 
 // ----------------------------------------------

--- a/src/powerquery-parser/language/type/type.ts
+++ b/src/powerquery-parser/language/type/type.ts
@@ -62,7 +62,6 @@ export type TPrimitiveType =
     | Null
     | Number
     | Record
-    | Text
     | Table
     | Text
     | Time

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -207,7 +207,7 @@ export function nameOf(type: Type.TType): string {
             return type.unionedTypePairs.map((subtype: Type.TType) => nameOf(subtype)).join(" | ");
 
         case Type.ExtendedTypeKind.DefinedFunction:
-            return prefixNullableIfRequired(type, nameOfFunctionSignature(type));
+            return prefixNullableIfRequired(type, nameOfFunctionSignature(type, true));
 
         case Type.ExtendedTypeKind.DefinedList:
             return prefixNullableIfRequired(type, `{${nameOfIterable(type.elements)}}`);
@@ -222,22 +222,22 @@ export function nameOf(type: Type.TType): string {
             return prefixNullableIfRequired(type, `table ${nameOfFieldSpecificationList(type)}`);
 
         case Type.ExtendedTypeKind.FunctionType:
-            return prefixNullableIfRequired(type, nameOfFunctionSignature(type));
+            return prefixNullableIfRequired(type, `type function ${nameOfFunctionSignature(type, false)}`);
 
         case Type.ExtendedTypeKind.ListType:
             return prefixNullableIfRequired(type, `type {${nameOf(type.itemType)}}`);
 
         case Type.ExtendedTypeKind.PrimaryPrimitiveType:
-            return prefixNullableIfRequired(type, nameOf(type.primitiveType));
+            return prefixNullableIfRequired(type, `type ${nameOf(type.primitiveType)}`);
 
         case Type.ExtendedTypeKind.RecordType:
             return prefixNullableIfRequired(type, `type ${nameOfFieldSpecificationList(type)}`);
 
         case Type.ExtendedTypeKind.TableType:
-            return prefixNullableIfRequired(type, `type table [${nameOfFieldSpecificationList(type)}]`);
+            return prefixNullableIfRequired(type, `type table ${nameOfFieldSpecificationList(type)}`);
 
         case Type.ExtendedTypeKind.TableTypePrimaryExpression:
-            return prefixNullableIfRequired(type, `type table ${type.primaryExpression}`);
+            return prefixNullableIfRequired(type, `type table ${nameOf(type.primaryExpression)}`);
 
         case undefined:
             return prefixNullableIfRequired(type, nameOfTypeKind(type.kind));
@@ -356,7 +356,7 @@ function nameOfFieldSpecificationList(type: Type.FieldSpecificationList): string
     return `[${pairs}]`;
 }
 
-function nameOfFunctionSignature(type: Type.FunctionSignature): string {
+function nameOfFunctionSignature(type: Type.FunctionSignature, includeFatArrow: boolean): string {
     const parameters: string = type.parameters
         .map((parameter: Type.FunctionParameter) => {
             let partial: string = `${parameter.nameLiteral}:`;
@@ -377,7 +377,7 @@ function nameOfFunctionSignature(type: Type.FunctionSignature): string {
         })
         .join(", ");
 
-    return `(${parameters}) => ${nameOf(type.returnType)}`;
+    return `(${parameters})${includeFatArrow ? " => " : " "}${nameOf(type.returnType)}`;
 }
 
 function nameOfIterable(collection: ReadonlyArray<Type.TType>): string {

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -201,40 +201,40 @@ export function isFunctionSignature(type: Type.TType): type is Type.TType & Type
     );
 }
 
-export function nameOf(type: Type.TType, locale: string): string {
+export function nameOf(type: Type.TType): string {
     switch (type.maybeExtendedKind) {
         case Type.ExtendedTypeKind.AnyUnion:
-            return type.unionedTypePairs.map((subtype: Type.TType) => nameOf(subtype, locale)).join(" | ");
+            return type.unionedTypePairs.map((subtype: Type.TType) => nameOf(subtype)).join(" | ");
 
         case Type.ExtendedTypeKind.DefinedFunction:
-            return prefixNullableIfRequired(type, nameOfFunctionSignature(type, locale));
+            return prefixNullableIfRequired(type, nameOfFunctionSignature(type));
 
         case Type.ExtendedTypeKind.DefinedList:
-            return prefixNullableIfRequired(type, `{${nameOfIterable(type.elements, locale)}}`);
+            return prefixNullableIfRequired(type, `{${nameOfIterable(type.elements)}}`);
 
         case Type.ExtendedTypeKind.DefinedListType:
-            return prefixNullableIfRequired(type, `type {${nameOfIterable(type.itemTypes, locale)}}`);
+            return prefixNullableIfRequired(type, `type {${nameOfIterable(type.itemTypes)}}`);
 
         case Type.ExtendedTypeKind.DefinedRecord:
-            return prefixNullableIfRequired(type, nameOfFieldSpecificationList(type, locale));
+            return prefixNullableIfRequired(type, nameOfFieldSpecificationList(type));
 
         case Type.ExtendedTypeKind.DefinedTable:
-            return prefixNullableIfRequired(type, `table ${nameOfFieldSpecificationList(type, locale)}`);
+            return prefixNullableIfRequired(type, `table ${nameOfFieldSpecificationList(type)}`);
 
         case Type.ExtendedTypeKind.FunctionType:
-            return prefixNullableIfRequired(type, nameOfFunctionSignature(type, locale));
+            return prefixNullableIfRequired(type, nameOfFunctionSignature(type));
 
         case Type.ExtendedTypeKind.ListType:
-            return prefixNullableIfRequired(type, `type {${nameOf(type.itemType, locale)}}`);
+            return prefixNullableIfRequired(type, `type {${nameOf(type.itemType)}}`);
 
         case Type.ExtendedTypeKind.PrimaryPrimitiveType:
-            return prefixNullableIfRequired(type, nameOf(type.primitiveType, locale));
+            return prefixNullableIfRequired(type, nameOf(type.primitiveType));
 
         case Type.ExtendedTypeKind.RecordType:
-            return prefixNullableIfRequired(type, `type ${nameOfFieldSpecificationList(type, locale)}`);
+            return prefixNullableIfRequired(type, `type ${nameOfFieldSpecificationList(type)}`);
 
         case Type.ExtendedTypeKind.TableType:
-            return prefixNullableIfRequired(type, `type table [${nameOfFieldSpecificationList(type, locale)}]`);
+            return prefixNullableIfRequired(type, `type table [${nameOfFieldSpecificationList(type)}]`);
 
         case Type.ExtendedTypeKind.TableTypePrimaryExpression:
             return prefixNullableIfRequired(type, `type table ${type.primaryExpression}`);
@@ -337,11 +337,11 @@ function nameOfTypeKind(kind: Type.TypeKind): string {
     return kind === Type.TypeKind.NotApplicable ? "not applicable" : kind.toLowerCase();
 }
 
-function nameOfFieldSpecificationList(type: Type.FieldSpecificationList, locale: string): string {
+function nameOfFieldSpecificationList(type: Type.FieldSpecificationList): string {
     const chunks: string[] = [];
 
     for (const [key, value] of type.fields.entries()) {
-        chunks.push(`${StringUtils.normalizeIdentifier(key)}: ${nameOf(value, locale)}`);
+        chunks.push(`${StringUtils.normalizeIdentifier(key)}: ${nameOf(value)}`);
     }
 
     if (type.isOpen === true) {
@@ -353,7 +353,7 @@ function nameOfFieldSpecificationList(type: Type.FieldSpecificationList, locale:
     return `[${pairs}]`;
 }
 
-function nameOfFunctionSignature(type: Type.FunctionSignature, locale: string): string {
+function nameOfFunctionSignature(type: Type.FunctionSignature): string {
     const parameters: string = type.parameters
         .map((parameter: Type.FunctionParameter) => {
             // `foo`
@@ -379,11 +379,11 @@ function nameOfFunctionSignature(type: Type.FunctionSignature, locale: string): 
         })
         .join(", ");
 
-    return `(${parameters}) => ${nameOf(type.returnType, locale)}`;
+    return `(${parameters}) => ${nameOf(type.returnType)}`;
 }
 
-function nameOfIterable(collection: ReadonlyArray<Type.TType>, locale: string): string {
-    return collection.map((item: Type.TType) => prefixNullableIfRequired(item, nameOf(item, locale))).join(", ");
+function nameOfIterable(collection: ReadonlyArray<Type.TType>): string {
+    return collection.map((item: Type.TType) => prefixNullableIfRequired(item, nameOf(item))).join(", ");
 }
 
 function prefixNullableIfRequired(type: Type.TType, name: string): string {

--- a/src/powerquery-parser/localization/templates/template.json
+++ b/src/powerquery-parser/localization/templates/template.json
@@ -309,8 +309,5 @@
     "_tokenKind_semicolon.comment": "The localized representation of a tokenKind enum. Expected to be user facing. {Locked=\"<';'>\"}",
 
     "tokenKind_textLiteral": "text",
-    "_tokenKind_textLiteral.comment": "The localized representation of a tokenKind enum. Expected to be user facing.",
-
-    "typeKind_notApplicable": "not applicable",
-    "_typeKind_notApplicable.comment": "The localized representation of a typeKind. Expected to be user facing."
+    "_tokenKind_textLiteral.comment": "The localized representation of a tokenKind enum. Expected to be user facing."
 }

--- a/src/powerquery-parser/localization/templates/template.json
+++ b/src/powerquery-parser/localization/templates/template.json
@@ -113,6 +113,21 @@
     "tokenKind_ampersand": "ampersand <'&'>",
     "_tokenKind_ampersand.comment": "The localized representation of a tokenKind enum. Expected to be user facing. {Locked=\"<'&'>\"}",
 
+    "scopeItemKind_each": "each",
+    "_scopeItemKind_each.comment": "The localized representation of the scopeItemKind enum. Expected to be user facing. {Locked=\"each\"}",
+
+    "scopeItemKind_keyValuePair": "key value",
+    "_scopeItemKind_keyValuePair.comment": "The localized representation of the scopeItemKind enum. Expected to be user facing.",
+
+    "scopeItemKind_parameter": "parameter",
+    "_scopeItemKind_parameter.comment": "The localized representation of the scopeItemKind enum. Expected to be user facing.",
+
+    "scopeItemKind_sectionMember": "section member",
+    "_scopeItemKind_sectionMember.comment": "The localized representation of the scopeItemKind enum. Expected to be user facing.",
+
+    "scopeItemKind_undefined": "undefined",
+    "_scopeItemKind_undefined.comment": "The localized representation of the scopeItemKind enum. Expected to be user facing.",
+
     "tokenKind_asterisk": "asterisk <'*'>",
     "_tokenKind_asterisk.comment": "The localized representation of a tokenKind enum. Expected to be user facing. {Locked=\"<'*'>\"}",
 
@@ -294,5 +309,8 @@
     "_tokenKind_semicolon.comment": "The localized representation of a tokenKind enum. Expected to be user facing. {Locked=\"<';'>\"}",
 
     "tokenKind_textLiteral": "text",
-    "_tokenKind_textLiteral.comment": "The localized representation of a tokenKind enum. Expected to be user facing."
+    "_tokenKind_textLiteral.comment": "The localized representation of a tokenKind enum. Expected to be user facing.",
+
+    "typeKind_notApplicable": "not applicable",
+    "_typeKind_notApplicable.comment": "The localized representation of a typeKind. Expected to be user facing."
 }

--- a/src/powerquery-parser/localization/templates/template.json
+++ b/src/powerquery-parser/localization/templates/template.json
@@ -113,21 +113,6 @@
     "tokenKind_ampersand": "ampersand <'&'>",
     "_tokenKind_ampersand.comment": "The localized representation of a tokenKind enum. Expected to be user facing. {Locked=\"<'&'>\"}",
 
-    "scopeItemKind_each": "each",
-    "_scopeItemKind_each.comment": "The localized representation of the scopeItemKind enum. Expected to be user facing. {Locked=\"each\"}",
-
-    "scopeItemKind_keyValuePair": "key value",
-    "_scopeItemKind_keyValuePair.comment": "The localized representation of the scopeItemKind enum. Expected to be user facing.",
-
-    "scopeItemKind_parameter": "parameter",
-    "_scopeItemKind_parameter.comment": "The localized representation of the scopeItemKind enum. Expected to be user facing.",
-
-    "scopeItemKind_sectionMember": "section member",
-    "_scopeItemKind_sectionMember.comment": "The localized representation of the scopeItemKind enum. Expected to be user facing.",
-
-    "scopeItemKind_undefined": "undefined",
-    "_scopeItemKind_undefined.comment": "The localized representation of the scopeItemKind enum. Expected to be user facing.",
-
     "tokenKind_asterisk": "asterisk <'*'>",
     "_tokenKind_asterisk.comment": "The localized representation of a tokenKind enum. Expected to be user facing. {Locked=\"<'*'>\"}",
 

--- a/src/test/libraryTest/common/stringUtils.ts
+++ b/src/test/libraryTest/common/stringUtils.ts
@@ -42,4 +42,9 @@ describe("StringUtils", () => {
             it(`""`, () => expect(StringUtils.isGeneralizedIdentifier(`""`), "should be false").to.be.false);
         });
     });
+
+    describe(`normalizeIdentifier`, () => {
+        it(`foo`, () => expect(StringUtils.normalizeIdentifier(`foo`)).to.equal(`foo`));
+        it(`#"foo"`, () => expect(StringUtils.normalizeIdentifier(`#"foo"`)).to.equal(`foo`));
+    });
 });

--- a/src/test/libraryTest/type/typeUtils/typeUtils.ts
+++ b/src/test/libraryTest/type/typeUtils/typeUtils.ts
@@ -4,7 +4,6 @@
 import { expect } from "chai";
 import "mocha";
 
-import { DefaultLocale } from "../../../../powerquery-parser";
 import { Type, TypeUtils } from "../../../../powerquery-parser/language";
 
 interface AbridgedType {
@@ -190,152 +189,169 @@ describe(`TypeUtils`, () => {
         describe(`non extended`, () => {
             describe("non-nullable", () => {
                 it(`${Type.AnyInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.AnyInstance, DefaultLocale)).to.equal("any");
+                    expect(TypeUtils.nameOf(Type.AnyInstance)).to.equal("any");
                 });
                 it(`${Type.AnyNonNullInstance.kind}`, () => {
                     // tslint:disable-next-line: chai-vague-errors
-                    expect(TypeUtils.nameOf(Type.AnyNonNullInstance, DefaultLocale)).to.equal("anynonnull");
+                    expect(TypeUtils.nameOf(Type.AnyNonNullInstance)).to.equal("anynonnull");
                 });
                 it(`${Type.BinaryInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.BinaryInstance, DefaultLocale)).to.equal("binary");
+                    expect(TypeUtils.nameOf(Type.BinaryInstance)).to.equal("binary");
                 });
                 it(`${Type.DateInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.DateInstance, DefaultLocale)).to.equal("date");
+                    expect(TypeUtils.nameOf(Type.DateInstance)).to.equal("date");
                 });
                 it(`${Type.DateTimeInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.DateTimeInstance, DefaultLocale)).to.equal("datetime");
+                    expect(TypeUtils.nameOf(Type.DateTimeInstance)).to.equal("datetime");
                 });
                 it(`${Type.DateTimeZoneInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.DateTimeZoneInstance, DefaultLocale)).to.equal("datetimezone");
+                    expect(TypeUtils.nameOf(Type.DateTimeZoneInstance)).to.equal("datetimezone");
                 });
                 it(`${Type.DurationInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.DurationInstance, DefaultLocale)).to.equal("duration");
+                    expect(TypeUtils.nameOf(Type.DurationInstance)).to.equal("duration");
                 });
                 it(`${Type.FunctionInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.FunctionInstance, DefaultLocale)).to.equal("function");
+                    expect(TypeUtils.nameOf(Type.FunctionInstance)).to.equal("function");
                 });
                 it(`${Type.ListInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.ListInstance, DefaultLocale)).to.equal("list");
+                    expect(TypeUtils.nameOf(Type.ListInstance)).to.equal("list");
                 });
                 it(`${Type.LogicalInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.LogicalInstance, DefaultLocale)).to.equal("logical");
+                    expect(TypeUtils.nameOf(Type.LogicalInstance)).to.equal("logical");
                 });
                 it(`${Type.NoneInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.NoneInstance, DefaultLocale)).to.equal("none");
+                    expect(TypeUtils.nameOf(Type.NoneInstance)).to.equal("none");
                 });
                 it(`${Type.NullInstance.kind}`, () => {
                     // tslint:disable-next-line: chai-vague-errors
-                    expect(TypeUtils.nameOf(Type.NullInstance, DefaultLocale)).to.equal("null");
+                    expect(TypeUtils.nameOf(Type.NullInstance)).to.equal("null");
                 });
                 it(`${Type.NumberInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.NumberInstance, DefaultLocale)).to.equal("number");
+                    expect(TypeUtils.nameOf(Type.NumberInstance)).to.equal("number");
                 });
                 it(`${Type.RecordInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.RecordInstance, DefaultLocale)).to.equal("record");
+                    expect(TypeUtils.nameOf(Type.RecordInstance)).to.equal("record");
                 });
                 it(`${Type.TableInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.TableInstance, DefaultLocale)).to.equal("table");
+                    expect(TypeUtils.nameOf(Type.TableInstance)).to.equal("table");
                 });
                 it(`${Type.TypePrimitiveInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.TypePrimitiveInstance, DefaultLocale)).to.equal("type");
+                    expect(TypeUtils.nameOf(Type.TypePrimitiveInstance)).to.equal("type");
                 });
 
                 it(`${Type.ActionInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.ActionInstance, DefaultLocale)).to.equal("action");
+                    expect(TypeUtils.nameOf(Type.ActionInstance)).to.equal("action");
                 });
                 it(`${Type.TimeInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.TimeInstance, DefaultLocale)).to.equal("time");
+                    expect(TypeUtils.nameOf(Type.TimeInstance)).to.equal("time");
                 });
 
                 it(`${Type.NotApplicableInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.NotApplicableInstance, DefaultLocale)).to.equal("not applicable");
+                    expect(TypeUtils.nameOf(Type.NotApplicableInstance)).to.equal("not applicable");
                 });
                 it(`${Type.UnknownInstance.kind}`, () => {
-                    expect(TypeUtils.nameOf(Type.UnknownInstance, DefaultLocale)).to.equal("unknown");
+                    expect(TypeUtils.nameOf(Type.UnknownInstance)).to.equal("unknown");
                 });
             });
 
             describe("nullable", () => {
                 it(`${Type.NullableAnyInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableAnyInstance, DefaultLocale);
-                    expect(actual).to.equal("any");
+                    const actual: string = TypeUtils.nameOf(Type.NullableAnyInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable any");
                 });
                 // anynonnull can't be nullable
                 it(`${Type.NullableBinaryInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableBinaryInstance, DefaultLocale);
-                    expect(actual).to.equal("binary");
+                    const actual: string = TypeUtils.nameOf(Type.NullableBinaryInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable binary");
                 });
                 it(`${Type.NullableDateInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableDateInstance, DefaultLocale);
-                    expect(actual).to.equal("date");
+                    const actual: string = TypeUtils.nameOf(Type.NullableDateInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable date");
                 });
                 it(`${Type.NullableDateTimeInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableDateTimeInstance, DefaultLocale);
-                    expect(actual).to.equal("datetime");
+                    const actual: string = TypeUtils.nameOf(Type.NullableDateTimeInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable datetime");
                 });
                 it(`${Type.NullableDateTimeZoneInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableDateTimeZoneInstance, DefaultLocale);
-                    expect(actual).to.equal("datetimezone");
+                    const actual: string = TypeUtils.nameOf(Type.NullableDateTimeZoneInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable datetimezone");
                 });
                 it(`${Type.NullableDurationInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableDurationInstance, DefaultLocale);
-                    expect(actual).to.equal("duration");
+                    const actual: string = TypeUtils.nameOf(Type.NullableDurationInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable duration");
                 });
                 it(`${Type.NullableFunctionInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableFunctionInstance, DefaultLocale);
-                    expect(actual).to.equal("function");
+                    const actual: string = TypeUtils.nameOf(Type.NullableFunctionInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable function");
                 });
                 it(`${Type.NullableListInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableListInstance, DefaultLocale);
-                    expect(actual).to.equal("list");
+                    const actual: string = TypeUtils.nameOf(Type.NullableListInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable list");
                 });
                 it(`${Type.NullableLogicalInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableLogicalInstance, DefaultLocale);
-                    expect(actual).to.equal("logical");
+                    const actual: string = TypeUtils.nameOf(Type.NullableLogicalInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable logical");
                 });
                 it(`${Type.NullableNoneInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableNoneInstance, DefaultLocale);
-                    expect(actual).to.equal("none");
+                    const actual: string = TypeUtils.nameOf(Type.NullableNoneInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable none");
                 });
                 it(`${Type.NullableNullInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableNullInstance, DefaultLocale);
+                    const actual: string = TypeUtils.nameOf(Type.NullableNullInstance);
                     // tslint:disable-next-line: chai-vague-errors
-                    expect(actual).to.equal("null");
+                    expect(actual).to.equal("nullable null");
                 });
                 it(`${Type.NullableNumberInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableNumberInstance, DefaultLocale);
-                    expect(actual).to.equal("number");
+                    const actual: string = TypeUtils.nameOf(Type.NullableNumberInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable number");
                 });
                 it(`${Type.NullableRecordInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableRecordInstance, DefaultLocale);
-                    expect(actual).to.equal("record");
+                    const actual: string = TypeUtils.nameOf(Type.NullableRecordInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable record");
                 });
                 it(`${Type.NullableTableInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableTableInstance, DefaultLocale);
-                    expect(actual).to.equal("table");
+                    const actual: string = TypeUtils.nameOf(Type.NullableTableInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable table");
                 });
                 it(`${Type.NullableTypeInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableTypeInstance, DefaultLocale);
-                    expect(actual).to.equal("type");
+                    const actual: string = TypeUtils.nameOf(Type.NullableTypeInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable type");
                 });
 
                 it(`${Type.NullableActionInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableActionInstance, DefaultLocale);
-                    expect(actual).to.equal("action");
+                    const actual: string = TypeUtils.nameOf(Type.NullableActionInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable action");
                 });
                 it(`${Type.NullableTimeInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableTimeInstance, DefaultLocale);
-                    expect(actual).to.equal("time");
+                    const actual: string = TypeUtils.nameOf(Type.NullableTimeInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable time");
                 });
 
                 it(`${Type.NullableNotApplicableInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableNotApplicableInstance, DefaultLocale);
+                    const actual: string = TypeUtils.nameOf(Type.NullableNotApplicableInstance);
                     // tslint:disable-next-line: chai-vague-errors
                     expect(actual).to.equal("nullable not applicable");
                 });
                 it(`${Type.NullableUnknownInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableUnknownInstance, DefaultLocale);
-                    expect(actual).to.equal("unknown");
+                    const actual: string = TypeUtils.nameOf(Type.NullableUnknownInstance);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable unknown");
                 });
             });
         });
@@ -344,7 +360,7 @@ describe(`TypeUtils`, () => {
             describe(`${Type.ExtendedTypeKind.AnyUnion}`, () => {
                 it(`primitives`, () => {
                     const type: Type.TType = TypeUtils.anyUnionFactory([Type.NumberInstance, Type.ListInstance]);
-                    expect(TypeUtils.nameOf(type, DefaultLocale)).to.equal(`number | list`);
+                    expect(TypeUtils.nameOf(type)).to.equal(`number | list`);
                 });
                 it(`complex`, () => {
                     const type: Type.TType = TypeUtils.anyUnionFactory([
@@ -352,7 +368,7 @@ describe(`TypeUtils`, () => {
                         TypeUtils.definedListFactory(false, [Type.TextInstance]),
                         TypeUtils.definedTableFactory(false, new Map([["bar", Type.TextInstance]]), true),
                     ]);
-                    const actual: string = TypeUtils.nameOf(type, DefaultLocale);
+                    const actual: string = TypeUtils.nameOf(type);
                     expect(actual).to.equal(`[foo: number] | {text} | table [bar: text, ...]`);
                 });
             });

--- a/src/test/libraryTest/type/typeUtils/typeUtils.ts
+++ b/src/test/libraryTest/type/typeUtils/typeUtils.ts
@@ -3,16 +3,17 @@
 
 import { expect } from "chai";
 import "mocha";
-import { Language } from "../../../..";
-// import { primitiveTypeFactory } from "../../../../powerquery-parser/language/type/typeUtils";
+
+import { DefaultLocale } from "../../../../powerquery-parser";
+import { Type, TypeUtils } from "../../../../powerquery-parser/language";
 
 interface AbridgedType {
-    readonly kind: Language.Type.TypeKind;
-    readonly maybeExtendedKind: Language.Type.ExtendedTypeKind | undefined;
+    readonly kind: Type.TypeKind;
+    readonly maybeExtendedKind: Type.ExtendedTypeKind | undefined;
     readonly isNullable: boolean;
 }
 
-function abridgedPrimitiveType(kind: Language.Type.TypeKind, isNullable: boolean): AbridgedType {
+function abridgedPrimitiveType(kind: Type.TypeKind, isNullable: boolean): AbridgedType {
     return {
         kind,
         maybeExtendedKind: undefined,
@@ -28,11 +29,11 @@ function assertGetAbridgedTypes(expected: ReadonlyArray<AbridgedType>, actual: R
     expect(actual).deep.equal(expected);
 }
 
-function assertIsAnyUnion(type: Language.Type.TType): asserts type is Language.Type.AnyUnion {
-    expect(type.maybeExtendedKind).to.equal(Language.Type.ExtendedTypeKind.AnyUnion);
+function assertIsAnyUnion(type: Type.TType): asserts type is Type.AnyUnion {
+    expect(type.maybeExtendedKind).to.equal(Type.ExtendedTypeKind.AnyUnion);
 }
 
-function typeToAbridged(type: Language.Type.TType): AbridgedType {
+function typeToAbridged(type: Type.TType): AbridgedType {
     return {
         kind: type.kind,
         maybeExtendedKind: type.maybeExtendedKind,
@@ -40,16 +41,16 @@ function typeToAbridged(type: Language.Type.TType): AbridgedType {
     };
 }
 
-function abridgedTypesFactory(types: ReadonlyArray<Language.Type.TType>): ReadonlyArray<AbridgedType> {
+function abridgedTypesFactory(types: ReadonlyArray<Type.TType>): ReadonlyArray<AbridgedType> {
     return types.map(typeToAbridged);
 }
 
 describe(`TypeUtils`, () => {
     describe(`dedupe`, () => {
         it(`generic, identical`, () => {
-            const expected: AbridgedType = abridgedPrimitiveType(Language.Type.TypeKind.Record, false);
+            const expected: AbridgedType = abridgedPrimitiveType(Type.TypeKind.Record, false);
             const actual: ReadonlyArray<AbridgedType> = abridgedTypesFactory(
-                Language.TypeUtils.dedupe([Language.Type.RecordInstance, Language.Type.RecordInstance]),
+                TypeUtils.dedupe([Type.RecordInstance, Type.RecordInstance]),
             );
             expect(actual.length).to.equal(1);
             assertGetAbridgedType(expected, actual[0]);
@@ -57,137 +58,304 @@ describe(`TypeUtils`, () => {
 
         it(`generic, mixed`, () => {
             const actual: ReadonlyArray<AbridgedType> = abridgedTypesFactory(
-                Language.TypeUtils.dedupe([Language.Type.RecordInstance, Language.Type.NullableRecordInstance]),
+                TypeUtils.dedupe([Type.RecordInstance, Type.NullableRecordInstance]),
             );
             const expected: ReadonlyArray<AbridgedType> = [
-                abridgedPrimitiveType(Language.Type.TypeKind.Record, false),
-                abridgedPrimitiveType(Language.Type.TypeKind.Record, true),
+                abridgedPrimitiveType(Type.TypeKind.Record, false),
+                abridgedPrimitiveType(Type.TypeKind.Record, true),
             ];
             assertGetAbridgedTypes(expected, actual);
         });
 
         it(`early return with any primitive`, () => {
             const actual: ReadonlyArray<AbridgedType> = abridgedTypesFactory(
-                Language.TypeUtils.dedupe([Language.Type.AnyInstance, Language.Type.NullableRecordInstance]),
+                TypeUtils.dedupe([Type.AnyInstance, Type.NullableRecordInstance]),
             );
-            const expected: ReadonlyArray<AbridgedType> = [Language.Type.AnyInstance];
+            const expected: ReadonlyArray<AbridgedType> = [Type.AnyInstance];
             assertGetAbridgedTypes(expected, actual);
         });
 
-        it(`${Language.Type.ExtendedTypeKind.AnyUnion}, combine into a single primitive type`, () => {
-            const deduped: ReadonlyArray<Language.Type.TType> = Language.TypeUtils.dedupe([
-                Language.TypeUtils.anyUnionFactory([Language.Type.RecordInstance, Language.Type.RecordInstance]),
-                Language.TypeUtils.anyUnionFactory([Language.Type.RecordInstance, Language.Type.RecordInstance]),
+        it(`${Type.ExtendedTypeKind.AnyUnion}, combine into a single primitive type`, () => {
+            const deduped: ReadonlyArray<Type.TType> = TypeUtils.dedupe([
+                TypeUtils.anyUnionFactory([Type.RecordInstance, Type.RecordInstance]),
+                TypeUtils.anyUnionFactory([Type.RecordInstance, Type.RecordInstance]),
             ]);
 
             expect(deduped.length).to.equal(1);
 
             const actual: AbridgedType = typeToAbridged(deduped[0]);
-            const expected: AbridgedType = Language.TypeUtils.primitiveTypeFactory(
-                false,
-                Language.Type.TypeKind.Record,
-            );
+            const expected: AbridgedType = TypeUtils.primitiveTypeFactory(false, Type.TypeKind.Record);
             assertGetAbridgedType(expected, actual);
         });
 
-        it(`${Language.Type.ExtendedTypeKind.AnyUnion}, combine into a single AnyUnion`, () => {
-            const deduped: ReadonlyArray<Language.Type.TType> = Language.TypeUtils.dedupe([
-                Language.TypeUtils.anyUnionFactory([Language.Type.RecordInstance, Language.Type.NullableTableInstance]),
-                Language.TypeUtils.anyUnionFactory([Language.Type.RecordInstance, Language.Type.NullableTableInstance]),
+        it(`${Type.ExtendedTypeKind.AnyUnion}, combine into a single AnyUnion`, () => {
+            const deduped: ReadonlyArray<Type.TType> = TypeUtils.dedupe([
+                TypeUtils.anyUnionFactory([Type.RecordInstance, Type.NullableTableInstance]),
+                TypeUtils.anyUnionFactory([Type.RecordInstance, Type.NullableTableInstance]),
             ]);
 
             expect(deduped.length).to.equal(1);
-            const ttype: Language.Type.TType = deduped[0];
+            const ttype: Type.TType = deduped[0];
             assertIsAnyUnion(ttype);
 
             const actual: ReadonlyArray<AbridgedType> = abridgedTypesFactory(ttype.unionedTypePairs);
             const expected: ReadonlyArray<AbridgedType> = [
-                abridgedPrimitiveType(Language.Type.TypeKind.Record, false),
-                abridgedPrimitiveType(Language.Type.TypeKind.Table, true),
+                abridgedPrimitiveType(Type.TypeKind.Record, false),
+                abridgedPrimitiveType(Type.TypeKind.Table, true),
             ];
             assertGetAbridgedTypes(expected, actual);
         });
 
-        it(`${Language.Type.ExtendedTypeKind.AnyUnion}, combine into a single AnyUnion, mixed nullability`, () => {
-            const deduped: ReadonlyArray<Language.Type.TType> = Language.TypeUtils.dedupe([
-                Language.TypeUtils.anyUnionFactory([
-                    Language.Type.NullableRecordInstance,
-                    Language.Type.NullableTableInstance,
-                ]),
-                Language.TypeUtils.anyUnionFactory([Language.Type.RecordInstance, Language.Type.TableInstance]),
+        it(`${Type.ExtendedTypeKind.AnyUnion}, combine into a single AnyUnion, mixed nullability`, () => {
+            const deduped: ReadonlyArray<Type.TType> = TypeUtils.dedupe([
+                TypeUtils.anyUnionFactory([Type.NullableRecordInstance, Type.NullableTableInstance]),
+                TypeUtils.anyUnionFactory([Type.RecordInstance, Type.TableInstance]),
             ]);
 
             expect(deduped.length).to.equal(1);
-            const ttype: Language.Type.TType = deduped[0];
+            const ttype: Type.TType = deduped[0];
             assertIsAnyUnion(ttype);
 
             const actual: ReadonlyArray<AbridgedType> = abridgedTypesFactory(ttype.unionedTypePairs);
             const expected: ReadonlyArray<AbridgedType> = [
-                abridgedPrimitiveType(Language.Type.TypeKind.Record, true),
-                abridgedPrimitiveType(Language.Type.TypeKind.Table, true),
-                abridgedPrimitiveType(Language.Type.TypeKind.Record, false),
-                abridgedPrimitiveType(Language.Type.TypeKind.Table, false),
+                abridgedPrimitiveType(Type.TypeKind.Record, true),
+                abridgedPrimitiveType(Type.TypeKind.Table, true),
+                abridgedPrimitiveType(Type.TypeKind.Record, false),
+                abridgedPrimitiveType(Type.TypeKind.Table, false),
             ];
             assertGetAbridgedTypes(expected, actual);
         });
 
-        it(`${Language.Type.ExtendedTypeKind.AnyUnion}, flatten multi level AnyUnion to single AnyUnion`, () => {
-            const deduped: ReadonlyArray<Language.Type.TType> = Language.TypeUtils.dedupe([
-                Language.TypeUtils.anyUnionFactory([
-                    Language.Type.RecordInstance,
-                    Language.TypeUtils.anyUnionFactory([Language.Type.RecordInstance, Language.Type.NumberInstance]),
+        it(`${Type.ExtendedTypeKind.AnyUnion}, flatten multi level AnyUnion to single AnyUnion`, () => {
+            const deduped: ReadonlyArray<Type.TType> = TypeUtils.dedupe([
+                TypeUtils.anyUnionFactory([
+                    Type.RecordInstance,
+                    TypeUtils.anyUnionFactory([Type.RecordInstance, Type.NumberInstance]),
                 ]),
-                Language.TypeUtils.anyUnionFactory([Language.Type.RecordInstance]),
+                TypeUtils.anyUnionFactory([Type.RecordInstance]),
             ]);
 
             expect(deduped.length).to.equal(1);
-            const ttype: Language.Type.TType = deduped[0];
+            const ttype: Type.TType = deduped[0];
             assertIsAnyUnion(ttype);
 
             const actual: ReadonlyArray<AbridgedType> = abridgedTypesFactory(ttype.unionedTypePairs);
             const expected: ReadonlyArray<AbridgedType> = [
-                abridgedPrimitiveType(Language.Type.TypeKind.Record, false),
-                abridgedPrimitiveType(Language.Type.TypeKind.Number, false),
+                abridgedPrimitiveType(Type.TypeKind.Record, false),
+                abridgedPrimitiveType(Type.TypeKind.Number, false),
             ];
             assertGetAbridgedTypes(expected, actual);
         });
 
-        it(`${Language.Type.ExtendedTypeKind.AnyUnion}, flatten multi level AnyUnion to single AnyUnion`, () => {
-            const deduped: ReadonlyArray<Language.Type.TType> = Language.TypeUtils.dedupe([
-                Language.TypeUtils.anyUnionFactory([
-                    Language.Type.RecordInstance,
-                    Language.TypeUtils.anyUnionFactory([Language.Type.RecordInstance, Language.Type.NumberInstance]),
+        it(`${Type.ExtendedTypeKind.AnyUnion}, flatten multi level AnyUnion to single AnyUnion`, () => {
+            const deduped: ReadonlyArray<Type.TType> = TypeUtils.dedupe([
+                TypeUtils.anyUnionFactory([
+                    Type.RecordInstance,
+                    TypeUtils.anyUnionFactory([Type.RecordInstance, Type.NumberInstance]),
                 ]),
-                Language.TypeUtils.anyUnionFactory([Language.Type.RecordInstance]),
+                TypeUtils.anyUnionFactory([Type.RecordInstance]),
             ]);
 
             expect(deduped.length).to.equal(1);
-            const ttype: Language.Type.TType = deduped[0];
+            const ttype: Type.TType = deduped[0];
             assertIsAnyUnion(ttype);
 
             const actual: ReadonlyArray<AbridgedType> = abridgedTypesFactory(ttype.unionedTypePairs);
             const expected: ReadonlyArray<AbridgedType> = [
-                abridgedPrimitiveType(Language.Type.TypeKind.Record, false),
-                abridgedPrimitiveType(Language.Type.TypeKind.Number, false),
+                abridgedPrimitiveType(Type.TypeKind.Record, false),
+                abridgedPrimitiveType(Type.TypeKind.Number, false),
             ];
             assertGetAbridgedTypes(expected, actual);
         });
 
-        it(`${Language.Type.ExtendedTypeKind.AnyUnion}, early return with any primitive`, () => {
-            const deduped: ReadonlyArray<Language.Type.TType> = Language.TypeUtils.dedupe([
-                Language.TypeUtils.anyUnionFactory([
-                    Language.Type.RecordInstance,
-                    Language.TypeUtils.anyUnionFactory([Language.Type.AnyInstance, Language.Type.NumberInstance]),
+        it(`${Type.ExtendedTypeKind.AnyUnion}, early return with any primitive`, () => {
+            const deduped: ReadonlyArray<Type.TType> = TypeUtils.dedupe([
+                TypeUtils.anyUnionFactory([
+                    Type.RecordInstance,
+                    TypeUtils.anyUnionFactory([Type.AnyInstance, Type.NumberInstance]),
                 ]),
-                Language.TypeUtils.anyUnionFactory([Language.Type.RecordInstance]),
+                TypeUtils.anyUnionFactory([Type.RecordInstance]),
             ]);
 
             expect(deduped.length).to.equal(1);
-            const ttype: Language.Type.TType = deduped[0];
+            const ttype: Type.TType = deduped[0];
 
             const actual: AbridgedType = typeToAbridged(ttype);
-            const expected: AbridgedType = typeToAbridged(Language.Type.AnyInstance);
+            const expected: AbridgedType = typeToAbridged(Type.AnyInstance);
             assertGetAbridgedType(expected, actual);
+        });
+    });
+
+    describe(`nameOf`, () => {
+        describe(`non extended`, () => {
+            describe("non-nullable", () => {
+                it(`${Type.AnyInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.AnyInstance, DefaultLocale)).to.equal("any");
+                });
+                it(`${Type.AnyNonNullInstance.kind}`, () => {
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(TypeUtils.nameOf(Type.AnyNonNullInstance, DefaultLocale)).to.equal("anynonnull");
+                });
+                it(`${Type.BinaryInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.BinaryInstance, DefaultLocale)).to.equal("binary");
+                });
+                it(`${Type.DateInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.DateInstance, DefaultLocale)).to.equal("date");
+                });
+                it(`${Type.DateTimeInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.DateTimeInstance, DefaultLocale)).to.equal("datetime");
+                });
+                it(`${Type.DateTimeZoneInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.DateTimeZoneInstance, DefaultLocale)).to.equal("datetimezone");
+                });
+                it(`${Type.DurationInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.DurationInstance, DefaultLocale)).to.equal("duration");
+                });
+                it(`${Type.FunctionInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.FunctionInstance, DefaultLocale)).to.equal("function");
+                });
+                it(`${Type.ListInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.ListInstance, DefaultLocale)).to.equal("list");
+                });
+                it(`${Type.LogicalInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.LogicalInstance, DefaultLocale)).to.equal("logical");
+                });
+                it(`${Type.NoneInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.NoneInstance, DefaultLocale)).to.equal("none");
+                });
+                it(`${Type.NullInstance.kind}`, () => {
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(TypeUtils.nameOf(Type.NullInstance, DefaultLocale)).to.equal("null");
+                });
+                it(`${Type.NumberInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.NumberInstance, DefaultLocale)).to.equal("number");
+                });
+                it(`${Type.RecordInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.RecordInstance, DefaultLocale)).to.equal("record");
+                });
+                it(`${Type.TableInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.TableInstance, DefaultLocale)).to.equal("table");
+                });
+                it(`${Type.TypePrimitiveInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.TypePrimitiveInstance, DefaultLocale)).to.equal("type");
+                });
+
+                it(`${Type.ActionInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.ActionInstance, DefaultLocale)).to.equal("action");
+                });
+                it(`${Type.TimeInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.TimeInstance, DefaultLocale)).to.equal("time");
+                });
+
+                it(`${Type.NotApplicableInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.NotApplicableInstance, DefaultLocale)).to.equal("not applicable");
+                });
+                it(`${Type.UnknownInstance.kind}`, () => {
+                    expect(TypeUtils.nameOf(Type.UnknownInstance, DefaultLocale)).to.equal("unknown");
+                });
+            });
+
+            describe("nullable", () => {
+                it(`${Type.NullableAnyInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableAnyInstance, DefaultLocale);
+                    expect(actual).to.equal("any");
+                });
+                // anynonnull can't be nullable
+                it(`${Type.NullableBinaryInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableBinaryInstance, DefaultLocale);
+                    expect(actual).to.equal("binary");
+                });
+                it(`${Type.NullableDateInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableDateInstance, DefaultLocale);
+                    expect(actual).to.equal("date");
+                });
+                it(`${Type.NullableDateTimeInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableDateTimeInstance, DefaultLocale);
+                    expect(actual).to.equal("datetime");
+                });
+                it(`${Type.NullableDateTimeZoneInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableDateTimeZoneInstance, DefaultLocale);
+                    expect(actual).to.equal("datetimezone");
+                });
+                it(`${Type.NullableDurationInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableDurationInstance, DefaultLocale);
+                    expect(actual).to.equal("duration");
+                });
+                it(`${Type.NullableFunctionInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableFunctionInstance, DefaultLocale);
+                    expect(actual).to.equal("function");
+                });
+                it(`${Type.NullableListInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableListInstance, DefaultLocale);
+                    expect(actual).to.equal("list");
+                });
+                it(`${Type.NullableLogicalInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableLogicalInstance, DefaultLocale);
+                    expect(actual).to.equal("logical");
+                });
+                it(`${Type.NullableNoneInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableNoneInstance, DefaultLocale);
+                    expect(actual).to.equal("none");
+                });
+                it(`${Type.NullableNullInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableNullInstance, DefaultLocale);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("null");
+                });
+                it(`${Type.NullableNumberInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableNumberInstance, DefaultLocale);
+                    expect(actual).to.equal("number");
+                });
+                it(`${Type.NullableRecordInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableRecordInstance, DefaultLocale);
+                    expect(actual).to.equal("record");
+                });
+                it(`${Type.NullableTableInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableTableInstance, DefaultLocale);
+                    expect(actual).to.equal("table");
+                });
+                it(`${Type.NullableTypeInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableTypeInstance, DefaultLocale);
+                    expect(actual).to.equal("type");
+                });
+
+                it(`${Type.NullableActionInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableActionInstance, DefaultLocale);
+                    expect(actual).to.equal("action");
+                });
+                it(`${Type.NullableTimeInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableTimeInstance, DefaultLocale);
+                    expect(actual).to.equal("time");
+                });
+
+                it(`${Type.NullableNotApplicableInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableNotApplicableInstance, DefaultLocale);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal("nullable not applicable");
+                });
+                it(`${Type.NullableUnknownInstance.kind}`, () => {
+                    const actual: string = TypeUtils.nameOf(Type.NullableUnknownInstance, DefaultLocale);
+                    expect(actual).to.equal("unknown");
+                });
+            });
+        });
+
+        describe(`extended`, () => {
+            describe(`${Type.ExtendedTypeKind.AnyUnion}`, () => {
+                it(`primitives`, () => {
+                    const type: Type.TType = TypeUtils.anyUnionFactory([Type.NumberInstance, Type.ListInstance]);
+                    expect(TypeUtils.nameOf(type, DefaultLocale)).to.equal(`number | list`);
+                });
+                it(`complex`, () => {
+                    const type: Type.TType = TypeUtils.anyUnionFactory([
+                        TypeUtils.definedRecordFactory(false, new Map([["foo", Type.NumberInstance]]), false),
+                        TypeUtils.definedListFactory(false, [Type.TextInstance]),
+                        TypeUtils.definedTableFactory(false, new Map([["bar", Type.TextInstance]]), true),
+                    ]);
+                    const actual: string = TypeUtils.nameOf(type, DefaultLocale);
+                    expect(actual).to.equal(`[foo: number] | {text} | table [bar: text, ...]`);
+                });
+            });
         });
     });
 });

--- a/src/test/libraryTest/type/typeUtils/typeUtils.ts
+++ b/src/test/libraryTest/type/typeUtils/typeUtils.ts
@@ -372,6 +372,197 @@ describe(`TypeUtils`, () => {
                     expect(actual).to.equal(`[foo: number] | {text} | table [bar: text, ...]`);
                 });
             });
+
+            describe(`${Type.ExtendedTypeKind.DefinedFunction}`, () => {
+                it(`() => any`, () => {
+                    const type: Type.DefinedFunction = TypeUtils.definedFunctionFactory(false, [], Type.AnyInstance);
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`() => any`);
+                });
+
+                it(`() => nullable any`, () => {
+                    const type: Type.DefinedFunction = TypeUtils.definedFunctionFactory(
+                        false,
+                        [],
+                        Type.NullableAnyInstance,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`() => nullable any`);
+                });
+
+                it(`(param1 as number, param2 as nullable number, optional param3 as number, optional param4 as nullable number) => any`, () => {
+                    const type: Type.DefinedFunction = TypeUtils.definedFunctionFactory(
+                        false,
+                        [
+                            {
+                                isNullable: false,
+                                isOptional: false,
+                                maybeType: Type.TypeKind.Number,
+                                nameLiteral: "param1",
+                            },
+                            {
+                                isNullable: true,
+                                isOptional: false,
+                                maybeType: Type.TypeKind.Number,
+                                nameLiteral: "param2",
+                            },
+                            {
+                                isNullable: false,
+                                isOptional: true,
+                                maybeType: Type.TypeKind.Number,
+                                nameLiteral: "param3",
+                            },
+                            {
+                                isNullable: true,
+                                isOptional: true,
+                                maybeType: Type.TypeKind.Number,
+                                nameLiteral: "param4",
+                            },
+                        ],
+                        Type.AnyInstance,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(
+                        `(param1: number, param2: nullable number, param3: optional number, param4: optional nullable number) => any`,
+                    );
+                });
+            });
+
+            describe(`${Type.ExtendedTypeKind.DefinedList}`, () => {
+                it(`{}`, () => {
+                    const type: Type.DefinedList = TypeUtils.definedListFactory(false, []);
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`{}`);
+                });
+
+                it(`nullable {}`, () => {
+                    const type: Type.DefinedList = TypeUtils.definedListFactory(true, []);
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`nullable {}`);
+                });
+
+                it(`{number, nullable text}`, () => {
+                    const type: Type.DefinedList = TypeUtils.definedListFactory(false, [
+                        Type.NumberInstance,
+                        Type.NullableTextInstance,
+                    ]);
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`{number, nullable text}`);
+                });
+            });
+
+            describe(`${Type.ExtendedTypeKind.DefinedListType}`, () => {
+                it(`type {}`, () => {
+                    const type: Type.DefinedListType = TypeUtils.definedListTypeFactory(false, []);
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`type {}`);
+                });
+
+                it(`nullable type {}`, () => {
+                    const type: Type.DefinedListType = TypeUtils.definedListTypeFactory(true, []);
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`nullable type {}`);
+                });
+
+                it(`type {number, nullable text}`, () => {
+                    const type: Type.DefinedListType = TypeUtils.definedListTypeFactory(false, [
+                        Type.NumberInstance,
+                        Type.NullableTextInstance,
+                    ]);
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`type {number, nullable text}`);
+                });
+            });
+
+            describe(`${Type.ExtendedTypeKind.DefinedRecord}`, () => {
+                it(`[]`, () => {
+                    const type: Type.DefinedRecord = TypeUtils.definedRecordFactory(false, new Map(), false);
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`[]`);
+                });
+
+                it(`[...]`, () => {
+                    const type: Type.DefinedRecord = TypeUtils.definedRecordFactory(false, new Map(), true);
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`[...]`);
+                });
+
+                it(`[foo: number, bar: nullable text]`, () => {
+                    const type: Type.DefinedRecord = TypeUtils.definedRecordFactory(
+                        false,
+                        new Map<string, Type.TType>([
+                            ["foo", Type.NumberInstance],
+                            ["bar", Type.NullableTextInstance],
+                        ]),
+                        false,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`[foo: number, bar: nullable text]`);
+                });
+
+                it(`[foo: number, bar: nullable text, ...]`, () => {
+                    const type: Type.DefinedRecord = TypeUtils.definedRecordFactory(
+                        false,
+                        new Map<string, Type.TType>([
+                            ["foo", Type.NumberInstance],
+                            ["bar", Type.NullableTextInstance],
+                        ]),
+                        true,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`[foo: number, bar: nullable text, ...]`);
+                });
+            });
+
+            describe(`${Type.ExtendedTypeKind.DefinedTable}`, () => {
+                it(`table []`, () => {
+                    const type: Type.DefinedTable = TypeUtils.definedTableFactory(false, new Map(), false);
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`table []`);
+                });
+
+                it(`table [...]`, () => {
+                    const type: Type.DefinedTable = TypeUtils.definedTableFactory(false, new Map(), true);
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`table [...]`);
+                });
+
+                it(`table [foo: number, bar: nullable text]`, () => {
+                    const type: Type.DefinedTable = TypeUtils.definedTableFactory(
+                        false,
+                        new Map<string, Type.TType>([
+                            ["foo", Type.NumberInstance],
+                            ["bar", Type.NullableTextInstance],
+                        ]),
+                        false,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`table [foo: number, bar: nullable text]`);
+                });
+
+                it(`table [foo: number, bar: nullable text, ...]`, () => {
+                    const type: Type.DefinedTable = TypeUtils.definedTableFactory(
+                        false,
+                        new Map<string, Type.TType>([
+                            ["foo", Type.NumberInstance],
+                            ["bar", Type.NullableTextInstance],
+                        ]),
+                        true,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`table [foo: number, bar: nullable text, ...]`);
+                });
+            });
         });
     });
 });

--- a/src/test/libraryTest/type/typeUtils/typeUtils.ts
+++ b/src/test/libraryTest/type/typeUtils/typeUtils.ts
@@ -493,7 +493,7 @@ describe(`TypeUtils`, () => {
                     expect(actual).to.equal(`[...]`);
                 });
 
-                it(`[foo: number, bar: nullable text]`, () => {
+                it(`[foo = number, bar = nullable text]`, () => {
                     const type: Type.DefinedRecord = TypeUtils.definedRecordFactory(
                         false,
                         new Map<string, Type.TType>([
@@ -507,7 +507,7 @@ describe(`TypeUtils`, () => {
                     expect(actual).to.equal(`[foo: number, bar: nullable text]`);
                 });
 
-                it(`[foo: number, bar: nullable text, ...]`, () => {
+                it(`[foo = number, bar = nullable text, ...]`, () => {
                     const type: Type.DefinedRecord = TypeUtils.definedRecordFactory(
                         false,
                         new Map<string, Type.TType>([
@@ -535,7 +535,7 @@ describe(`TypeUtils`, () => {
                     expect(actual).to.equal(`table [...]`);
                 });
 
-                it(`table [foo: number, bar: nullable text]`, () => {
+                it(`table [foo = number, bar = nullable text]`, () => {
                     const type: Type.DefinedTable = TypeUtils.definedTableFactory(
                         false,
                         new Map<string, Type.TType>([
@@ -549,7 +549,7 @@ describe(`TypeUtils`, () => {
                     expect(actual).to.equal(`table [foo: number, bar: nullable text]`);
                 });
 
-                it(`table [foo: number, bar: nullable text, ...]`, () => {
+                it(`table [foo = number, bar = nullable text, ...]`, () => {
                     const type: Type.DefinedTable = TypeUtils.definedTableFactory(
                         false,
                         new Map<string, Type.TType>([
@@ -561,6 +561,175 @@ describe(`TypeUtils`, () => {
                     const actual: string = TypeUtils.nameOf(type);
                     // tslint:disable-next-line: chai-vague-errors
                     expect(actual).to.equal(`table [foo: number, bar: nullable text, ...]`);
+                });
+            });
+
+            describe(`${Type.ExtendedTypeKind.FunctionType}`, () => {
+                it(`type function () any`, () => {
+                    const type: Type.FunctionType = TypeUtils.functionTypeFactory(false, [], Type.AnyInstance);
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`type function () any`);
+                });
+
+                it(`type function () any`, () => {
+                    const type: Type.FunctionType = TypeUtils.functionTypeFactory(
+                        false,
+                        [
+                            {
+                                isNullable: false,
+                                isOptional: false,
+                                maybeType: Type.TypeKind.Number,
+                                nameLiteral: "param1",
+                            },
+                            {
+                                isNullable: true,
+                                isOptional: false,
+                                maybeType: Type.TypeKind.Number,
+                                nameLiteral: "param2",
+                            },
+                            {
+                                isNullable: false,
+                                isOptional: true,
+                                maybeType: Type.TypeKind.Number,
+                                nameLiteral: "param3",
+                            },
+                            {
+                                isNullable: true,
+                                isOptional: true,
+                                maybeType: Type.TypeKind.Number,
+                                nameLiteral: "param4",
+                            },
+                        ],
+                        Type.AnyInstance,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(
+                        `type function (param1: number, param2: nullable number, param3: optional number, param4: optional nullable number) any`,
+                    );
+                });
+            });
+
+            describe(`${Type.ExtendedTypeKind.ListType}`, () => {
+                it(`type {text}`, () => {
+                    const type: Type.ListType = TypeUtils.listTypeFactory(false, Type.TextInstance);
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`type {text}`);
+                });
+            });
+
+            describe(`${Type.ExtendedTypeKind.PrimaryPrimitiveType}`, () => {
+                it(`type text`, () => {
+                    const type: Type.PrimaryPrimitiveType = TypeUtils.primaryPrimitiveTypeFactory(
+                        false,
+                        Type.TextInstance,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`type text`);
+                });
+            });
+
+            describe(`${Type.ExtendedTypeKind.RecordType}`, () => {
+                it(`type [foo = number]`, () => {
+                    const type: Type.RecordType = TypeUtils.recordTypeFactory(
+                        false,
+                        new Map([["foo", Type.NumberInstance]]),
+                        false,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`type [foo: number]`);
+                });
+
+                it(`type [...]`, () => {
+                    const type: Type.RecordType = TypeUtils.recordTypeFactory(false, new Map(), true);
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`type [...]`);
+                });
+
+                it(`type [foo = number, bar = nullable text]`, () => {
+                    const type: Type.RecordType = TypeUtils.recordTypeFactory(
+                        false,
+                        new Map<string, Type.TType>([
+                            ["foo", Type.NumberInstance],
+                            ["bar", Type.NullableTextInstance],
+                        ]),
+                        false,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`type [foo: number, bar: nullable text]`);
+                });
+
+                it(`type [foo = number, bar = nullable text, ...]`, () => {
+                    const type: Type.RecordType = TypeUtils.recordTypeFactory(
+                        false,
+                        new Map<string, Type.TType>([
+                            ["foo", Type.NumberInstance],
+                            ["bar", Type.NullableTextInstance],
+                        ]),
+                        true,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`type [foo: number, bar: nullable text, ...]`);
+                });
+            });
+
+            describe(`${Type.ExtendedTypeKind.TableType}`, () => {
+                it(`type table [foo = number]`, () => {
+                    const type: Type.TableType = TypeUtils.tableTypeFactory(
+                        false,
+                        new Map([["foo", Type.NumberInstance]]),
+                        false,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`type table [foo: number]`);
+                });
+
+                it(`type table [...]`, () => {
+                    const type: Type.TableType = TypeUtils.tableTypeFactory(false, new Map(), true);
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`type table [...]`);
+                });
+
+                it(`type table [foo = number, bar = nullable text]`, () => {
+                    const type: Type.TableType = TypeUtils.tableTypeFactory(
+                        false,
+                        new Map<string, Type.TType>([
+                            ["foo", Type.NumberInstance],
+                            ["bar", Type.NullableTextInstance],
+                        ]),
+                        false,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`type table [foo: number, bar: nullable text]`);
+                });
+
+                it(`type table [foo = number, bar = nullable text, ...]`, () => {
+                    const type: Type.TableType = TypeUtils.tableTypeFactory(
+                        false,
+                        new Map<string, Type.TType>([
+                            ["foo", Type.NumberInstance],
+                            ["bar", Type.NullableTextInstance],
+                        ]),
+                        true,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    // tslint:disable-next-line: chai-vague-errors
+                    expect(actual).to.equal(`type table [foo: number, bar: nullable text, ...]`);
+                });
+            });
+
+            describe(`${Type.ExtendedTypeKind.TableTypePrimaryExpression}`, () => {
+                // Assumes `foo` is text.
+                it(`type table foo`, () => {
+                    const type: Type.TableTypePrimaryExpression = TypeUtils.tableTypePrimaryExpression(
+                        false,
+                        Type.TextInstance,
+                    );
+                    const actual: string = TypeUtils.nameOf(type);
+                    expect(actual).to.equal(`type table text`);
                 });
             });
         });


### PR DESCRIPTION
Converts a type object created by the type inspector into a human readable string, similar to what TypeScript's Intellisense does.