### PR TITLE
Update APIs for language-services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1427,9 +1427,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/language/type/type.ts
+++ b/src/powerquery-parser/language/type/type.ts
@@ -202,6 +202,10 @@ export interface IPrimitiveLiteral extends IExtendedType {
     readonly literal: string;
 }
 
+export interface IPrimitiveType<T extends TypeKind = TypeKind> extends IType<T> {
+    readonly maybeExtendedKind: undefined;
+}
+
 // ------------------------------------------
 // ---------- Non-IType Interfaces ----------
 // ------------------------------------------
@@ -214,10 +218,6 @@ export interface FieldSpecificationList {
 export interface FunctionSignature {
     readonly parameters: ReadonlyArray<FunctionParameter>;
     readonly returnType: PqType;
-}
-
-export interface IPrimitiveType<T extends TypeKind = TypeKind> extends IType<T> {
-    readonly maybeExtendedKind: undefined;
 }
 
 export interface SimplifiedNullablePrimitiveType {

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -79,14 +79,18 @@ export function isCompatibleWithFunctionSignature(
 }
 
 export function isCompatibleWithFunctionParameter(
-    left: Type.FunctionParameter,
+    left: Type.PqType | undefined,
     right: Type.FunctionParameter,
 ): boolean {
-    return (
-        left.isNullable === right.isNullable &&
-        left.isOptional === right.isOptional &&
-        (right.maybeType === undefined || left.maybeType === right.maybeType)
-    );
+    if (left === undefined) {
+        return right.isOptional;
+    } else if (left.isNullable && !right.isNullable) {
+        return false;
+    } else if (right.maybeType) {
+        return left.kind === right.maybeType;
+    } else {
+        return true;
+    }
 }
 
 function isCompatibleWithAny(left: Type.PqType, right: Type.TAny): boolean | undefined {

--- a/src/powerquery-parser/language/type/typeUtils/nameOf.ts
+++ b/src/powerquery-parser/language/type/typeUtils/nameOf.ts
@@ -84,7 +84,7 @@ export function nameOfFunctionSignature(type: Type.FunctionSignature, includeFat
     return `(${parameters})${includeFatArrow ? " =>" : ""} ${nameOf(type.returnType)}`;
 }
 
-function nameOfTypeKind(kind: Type.TypeKind): string {
+export function nameOfTypeKind(kind: Type.TypeKind): string {
     return kind === Type.TypeKind.NotApplicable ? "not applicable" : kind.toLowerCase();
 }
 

--- a/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
@@ -73,32 +73,26 @@ export function typeCheckInvocation(
     const numArgs: number = args.length;
     const numParameters: number = parameters.length;
 
-    const upperBound: number = numParameters;
-
     const extraneousArgs: ReadonlyArray<number> =
         numArgs > numParameters ? ArrayUtils.range(numArgs - numParameters, numParameters) : [];
 
-    const missingArgs: ReadonlyArray<number> =
-        numParameters > numArgs
-            ? ArrayUtils.range(numParameters - numArgs, numArgs).filter(
-                  (parameterIndex: number) => !parameters[parameterIndex].isOptional,
-              )
-            : [];
-
     const validArgs: number[] = [];
+    const missingArgs: number[] = [];
     const invalidArgs: Mismatch<number, Type.PqType | undefined, Type.FunctionParameter>[] = [];
-    for (let index: number = 0; index < upperBound; index += 1) {
+    for (let index: number = 0; index < numParameters; index += 1) {
         const maybeArg: Type.PqType | undefined = args[index];
         const parameter: Type.FunctionParameter = parameters[index];
 
         if (isCompatibleWithFunctionParameter(maybeArg, parameter)) {
             validArgs.push(index);
-        } else {
+        } else if (maybeArg !== undefined) {
             invalidArgs.push({
                 key: index,
                 expected: parameter,
                 actual: maybeArg,
             });
+        } else {
+            missingArgs.push(index);
         }
     }
 

--- a/src/test/libraryTest/type/typeUtils/typeCheck.ts
+++ b/src/test/libraryTest/type/typeUtils/typeCheck.ts
@@ -56,7 +56,7 @@ describe(`TypeUtils.typeCheck`, () => {
             expect(actual).to.deep.equal(expected);
         });
 
-        it(`missing parameter`, () => {
+        it(`missing required parameter`, () => {
             const args: ReadonlyArray<Language.Type.PqType> = [];
             const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.definedFunctionFactory(
                 false,
@@ -79,6 +79,34 @@ describe(`TypeUtils.typeCheck`, () => {
                 invalid: [],
                 extraneous: [],
                 missing: [0],
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`missing optional parameter`, () => {
+            const args: ReadonlyArray<Language.Type.PqType> = [];
+            const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.definedFunctionFactory(
+                false,
+                [
+                    {
+                        isNullable: false,
+                        isOptional: true,
+                        maybeType: Language.Type.TypeKind.Number,
+                        nameLiteral: "foo",
+                    },
+                ],
+                Language.Type.ActionInstance,
+            );
+            const actual: Language.TypeUtils.CheckedInvocation = Language.TypeUtils.typeCheckInvocation(
+                args,
+                definedFunction,
+            );
+            const expected: Language.TypeUtils.CheckedInvocation = {
+                valid: [0],
+                invalid: [],
+                extraneous: [],
+                missing: [],
             };
 
             expect(actual).to.deep.equal(expected);

--- a/src/test/libraryTest/type/typeUtils/typeCheck.ts
+++ b/src/test/libraryTest/type/typeUtils/typeCheck.ts
@@ -34,6 +34,204 @@ function assertAbridgedEqual(actual: AbridgedChecked, expected: AbridgedChecked)
 }
 
 describe(`TypeUtils.typeCheck`, () => {
+    describe(`typeCheckInvocation`, () => {
+        it(`extraneous parameter`, () => {
+            const args: ReadonlyArray<Language.Type.PqType> = [Language.Type.ActionInstance];
+            const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.definedFunctionFactory(
+                false,
+                [],
+                Language.Type.ActionInstance,
+            );
+            const actual: Language.TypeUtils.CheckedInvocation = Language.TypeUtils.typeCheckInvocation(
+                args,
+                definedFunction,
+            );
+            const expected: Language.TypeUtils.CheckedInvocation = {
+                valid: [],
+                invalid: [],
+                extraneous: [0],
+                missing: [],
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`missing parameter`, () => {
+            const args: ReadonlyArray<Language.Type.PqType> = [];
+            const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.definedFunctionFactory(
+                false,
+                [
+                    {
+                        isNullable: false,
+                        isOptional: false,
+                        maybeType: Language.Type.TypeKind.Number,
+                        nameLiteral: "foo",
+                    },
+                ],
+                Language.Type.ActionInstance,
+            );
+            const actual: Language.TypeUtils.CheckedInvocation = Language.TypeUtils.typeCheckInvocation(
+                args,
+                definedFunction,
+            );
+            const expected: Language.TypeUtils.CheckedInvocation = {
+                valid: [],
+                invalid: [],
+                extraneous: [],
+                missing: [0],
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`valid parameter`, () => {
+            const args: ReadonlyArray<Language.Type.PqType> = [Language.TypeUtils.numberLiteralFactory(false, "1")];
+            const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.definedFunctionFactory(
+                false,
+                [
+                    {
+                        isNullable: false,
+                        isOptional: false,
+                        maybeType: Language.Type.TypeKind.Number,
+                        nameLiteral: "foo",
+                    },
+                ],
+                Language.Type.ActionInstance,
+            );
+            const actual: Language.TypeUtils.CheckedInvocation = Language.TypeUtils.typeCheckInvocation(
+                args,
+                definedFunction,
+            );
+            const expected: Language.TypeUtils.CheckedInvocation = {
+                valid: [0],
+                invalid: [],
+                extraneous: [],
+                missing: [],
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`valid multiple parameters`, () => {
+            const args: ReadonlyArray<Language.Type.PqType> = [
+                Language.TypeUtils.numberLiteralFactory(false, "1"),
+                Language.TypeUtils.textLiteralFactory(false, `"cat"`),
+            ];
+            const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.definedFunctionFactory(
+                false,
+                [
+                    {
+                        isNullable: false,
+                        isOptional: false,
+                        maybeType: Language.Type.TypeKind.Number,
+                        nameLiteral: "foo",
+                    },
+                    {
+                        isNullable: false,
+                        isOptional: false,
+                        maybeType: Language.Type.TypeKind.Text,
+                        nameLiteral: "bar",
+                    },
+                ],
+                Language.Type.ActionInstance,
+            );
+            const actual: Language.TypeUtils.CheckedInvocation = Language.TypeUtils.typeCheckInvocation(
+                args,
+                definedFunction,
+            );
+            const expected: Language.TypeUtils.CheckedInvocation = {
+                valid: [0, 1],
+                invalid: [],
+                extraneous: [],
+                missing: [],
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`invalid parameter`, () => {
+            const args: ReadonlyArray<Language.Type.PqType> = [Language.TypeUtils.textLiteralFactory(false, `""`)];
+            const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.definedFunctionFactory(
+                false,
+                [
+                    {
+                        isNullable: false,
+                        isOptional: false,
+                        maybeType: Language.Type.TypeKind.Number,
+                        nameLiteral: "foo",
+                    },
+                ],
+                Language.Type.ActionInstance,
+            );
+            const actual: Language.TypeUtils.CheckedInvocation = Language.TypeUtils.typeCheckInvocation(
+                args,
+                definedFunction,
+            );
+            const expected: Language.TypeUtils.CheckedInvocation = {
+                valid: [],
+                invalid: [
+                    {
+                        key: 0,
+                        actual: args[0],
+                        expected: definedFunction.parameters[0],
+                    },
+                ],
+                extraneous: [],
+                missing: [],
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`invalid multiple parameter`, () => {
+            const args: ReadonlyArray<Language.Type.PqType> = [
+                Language.Type.LogicalInstance,
+                Language.Type.FunctionInstance,
+            ];
+            const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.definedFunctionFactory(
+                false,
+                [
+                    {
+                        isNullable: false,
+                        isOptional: false,
+                        maybeType: Language.Type.TypeKind.Number,
+                        nameLiteral: "foo",
+                    },
+                    {
+                        isNullable: false,
+                        isOptional: false,
+                        maybeType: Language.Type.TypeKind.Text,
+                        nameLiteral: "bar",
+                    },
+                ],
+                Language.Type.ActionInstance,
+            );
+            const actual: Language.TypeUtils.CheckedInvocation = Language.TypeUtils.typeCheckInvocation(
+                args,
+                definedFunction,
+            );
+            const expected: Language.TypeUtils.CheckedInvocation = {
+                valid: [],
+                invalid: [
+                    {
+                        key: 0,
+                        actual: args[0],
+                        expected: definedFunction.parameters[0],
+                    },
+                    {
+                        key: 1,
+                        actual: args[1],
+                        expected: definedFunction.parameters[1],
+                    },
+                ],
+                extraneous: [],
+                missing: [],
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+    });
+
     describe(`Table.RenameColumns`, () => {
         it(`list with two text elements, valid`, () => {
             const valueType: Language.Type.DefinedList = Language.TypeUtils.definedListFactory(false, [

--- a/src/test/libraryTest/type/typeUtils/typeCheck.ts
+++ b/src/test/libraryTest/type/typeUtils/typeCheck.ts
@@ -56,7 +56,7 @@ describe(`TypeUtils.typeCheck`, () => {
             expect(actual).to.deep.equal(expected);
         });
 
-        it(`missing required parameter`, () => {
+        it(`WIP missing required parameter`, () => {
             const args: ReadonlyArray<Language.Type.PqType> = [];
             const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.definedFunctionFactory(
                 false,

--- a/src/test/libraryTest/type/typeUtils/typeCheck.ts
+++ b/src/test/libraryTest/type/typeUtils/typeCheck.ts
@@ -15,6 +15,7 @@ interface AbridgedChecked<K = number | string> {
 function abridgedCheckedFactory(actual: Language.TypeUtils.TChecked): AbridgedChecked {
     const mismatched: ReadonlyArray<Language.TypeUtils.Mismatch<
         string | number,
+        Language.Type.PqType | Language.Type.FunctionParameter,
         Language.Type.PqType | Language.Type.FunctionParameter
     >> = actual.invalid;
     return {


### PR DESCRIPTION
* `nameOfTypeKind` has been made public
* added `typeCheckInvocation`
* corrected implementation `isCompatibleWithFunctionParameter`