### PR TITLE
Add normalized key field to KeyValuePair

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { NodeIdMap, NodeIdMapUtils, TXorNode, XorNodeKind, XorNodeUtils } from ".";
-import { Assert, MapUtils } from "../../common";
+import { Assert, MapUtils, StringUtils } from "../../common";
 import { Ast } from "../../language";
 
 export interface KeyValuePair<T extends Ast.GeneralizedIdentifier | Ast.Identifier> {
@@ -10,6 +10,7 @@ export interface KeyValuePair<T extends Ast.GeneralizedIdentifier | Ast.Identifi
     readonly key: T;
     readonly pairKind: PairKind;
     readonly keyLiteral: string;
+    readonly normalizedKeyLiteral: string;
     readonly maybeValue: TXorNode | undefined;
 }
 
@@ -253,10 +254,13 @@ export function iterSection(
     if (section.kind === XorNodeKind.Ast) {
         return (section.node as Ast.Section).sectionMembers.elements.map((sectionMember: Ast.SectionMember) => {
             const namePairedExpression: Ast.IdentifierPairedExpression = sectionMember.namePairedExpression;
+            const keyLiteral: string = namePairedExpression.key.literal;
+
             return {
                 source: XorNodeUtils.createAstNode(namePairedExpression),
                 key: namePairedExpression.key,
-                keyLiteral: namePairedExpression.key.literal,
+                keyLiteral,
+                normalizedKeyLiteral: StringUtils.normalizeIdentifier(keyLiteral),
                 maybeValue: XorNodeUtils.createAstNode(namePairedExpression.value),
                 pairKind: PairKind.SectionMember,
             };
@@ -296,11 +300,13 @@ export function iterSection(
             continue;
         }
         const key: Ast.Identifier = maybeKey;
+        const keyLiteral: string = key.literal;
 
         partial.push({
             source: keyValuePair,
             key,
-            keyLiteral: key.literal,
+            keyLiteral,
+            normalizedKeyLiteral: StringUtils.normalizeIdentifier(keyLiteral),
             maybeValue: NodeIdMapUtils.maybeChildXorByAttributeIndex(
                 nodeIdMapCollection,
                 keyValuePairNodeId,
@@ -331,11 +337,13 @@ function iterKeyValuePairs<T extends Ast.GeneralizedIdentifier | Ast.Identifier>
             break;
         }
         const key: T = maybeKey as T & (Ast.GeneralizedIdentifier | Ast.Identifier);
+        const keyLiteral: string = key.literal;
 
         partial.push({
             source: keyValuePair,
             key,
-            keyLiteral: key.literal,
+            keyLiteral,
+            normalizedKeyLiteral: StringUtils.normalizeIdentifier(keyLiteral),
             maybeValue: NodeIdMapUtils.maybeChildXorByAttributeIndex(
                 nodeIdMapCollection,
                 keyValuePair.node.id,

--- a/src/test/libraryTest/parser/nodeIdMapUtils.ts
+++ b/src/test/libraryTest/parser/nodeIdMapUtils.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect } from "chai";
+import "mocha";
+import { DefaultSettings, Task } from "../../..";
+import { Assert, MapUtils } from "../../../powerquery-parser";
+import { Ast } from "../../../powerquery-parser/language";
+import { NodeIdMapIterator, NodeIdMapUtils, TXorNode } from "../../../powerquery-parser/parser";
+import { RecordKeyValuePair } from "../../../powerquery-parser/parser/nodeIdMap/nodeIdMapIterator";
+import { TestAssertUtils } from "../../testUtils";
+
+describe("nodeIdMapIterator", () => {
+    describe(`iterRecord`, () => {
+        it(`normalize record key`, () => {
+            const text: string = `let key = [#"foo" = bar] in key`;
+            const parseOk: Task.ParseTaskOk = TestAssertUtils.assertGetLexParseOk(DefaultSettings, text);
+            const recordIds: Set<number> = MapUtils.assertGet(
+                parseOk.nodeIdMapCollection.idsByNodeKind,
+                Ast.NodeKind.RecordExpression,
+            );
+            expect(recordIds.size).to.equal(1);
+
+            const recordId: number = Assert.asDefined([...recordIds.values()][0]);
+            const record: TXorNode = NodeIdMapUtils.assertGetXor(parseOk.nodeIdMapCollection, recordId);
+            const recordKeyValuePairs: ReadonlyArray<RecordKeyValuePair> = NodeIdMapIterator.iterRecord(
+                parseOk.nodeIdMapCollection,
+                record,
+            );
+
+            expect(recordKeyValuePairs.length).to.equal(1);
+
+            const keyValuePair: RecordKeyValuePair = recordKeyValuePairs[0];
+            expect(keyValuePair.normalizedKeyLiteral).to.equal("foo");
+        });
+    });
+});


### PR DESCRIPTION
Added the field `normalizedKeyLiteral` to `IKeyValuePair`. Eg.

`[#"foo" = 1]` has a keyLiteral == `#"foo"` and a normalizedKeyLiteral == `foo`
`[#"s p a c e" = 1]` has a keyLiteral == `#"s p a c e"` and a normalizedKeyLiteral == `#"s p a c e"`