### PR TITLE
Update exports for TypeCheck, rename PowerQueryType

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/language/type/type.ts
+++ b/src/powerquery-parser/language/type/type.ts
@@ -6,7 +6,7 @@
 //
 // Extended types are an extension to the Power Query language.
 // For example, you can treat `1` as a subtype of `number`.
-export type PowerQueryType = TPrimitiveType | TExtendedType;
+export type TPowerQueryType = TPrimitiveType | TExtendedType;
 export type TExtendedType =
     | AnyUnion
     | DefinedFunction
@@ -211,13 +211,13 @@ export interface IPrimitiveType<T extends TypeKind = TypeKind> extends IType<T> 
 // ------------------------------------------
 
 export interface FieldSpecificationList {
-    readonly fields: Map<string, PowerQueryType>;
+    readonly fields: Map<string, TPowerQueryType>;
     readonly isOpen: boolean;
 }
 
 export interface FunctionSignature {
     readonly parameters: ReadonlyArray<FunctionParameter>;
-    readonly returnType: PowerQueryType;
+    readonly returnType: TPowerQueryType;
 }
 
 export interface SimplifiedNullablePrimitiveType {
@@ -241,7 +241,7 @@ export interface FunctionParameter {
 export interface AnyUnion extends IExtendedType {
     readonly kind: TypeKind.Any;
     readonly maybeExtendedKind: ExtendedTypeKind.AnyUnion;
-    readonly unionedTypePairs: ReadonlyArray<PowerQueryType>;
+    readonly unionedTypePairs: ReadonlyArray<TPowerQueryType>;
 }
 
 export type DefinedFunction = IExtendedType &
@@ -254,14 +254,14 @@ export type DefinedFunction = IExtendedType &
 export interface DefinedList extends IExtendedType {
     readonly kind: TypeKind.List;
     readonly maybeExtendedKind: ExtendedTypeKind.DefinedList;
-    readonly elements: ReadonlyArray<PowerQueryType>;
+    readonly elements: ReadonlyArray<TPowerQueryType>;
 }
 
 // A ListType for DefinedList
 export interface DefinedListType extends IExtendedType {
     readonly kind: TypeKind.Type;
     readonly maybeExtendedKind: ExtendedTypeKind.DefinedListType;
-    readonly itemTypes: ReadonlyArray<PowerQueryType>;
+    readonly itemTypes: ReadonlyArray<TPowerQueryType>;
 }
 
 export type DefinedRecord = IExtendedType &
@@ -285,7 +285,7 @@ export type FunctionType = IExtendedType &
 export interface ListType extends IExtendedType {
     readonly kind: TypeKind.Type;
     readonly maybeExtendedKind: ExtendedTypeKind.ListType;
-    readonly itemType: PowerQueryType;
+    readonly itemType: TPowerQueryType;
 }
 
 export interface LogicalLiteral extends IPrimitiveLiteral {
@@ -321,7 +321,7 @@ export type TableType = IExtendedType &
 export interface TableTypePrimaryExpression extends IExtendedType {
     readonly kind: TypeKind.Type;
     readonly maybeExtendedKind: ExtendedTypeKind.TableTypePrimaryExpression;
-    readonly primaryExpression: PowerQueryType;
+    readonly primaryExpression: TPowerQueryType;
 }
 
 export interface TextLiteral extends IPrimitiveLiteral {

--- a/src/powerquery-parser/language/type/typeUtils/assert.ts
+++ b/src/powerquery-parser/language/type/typeUtils/assert.ts
@@ -6,192 +6,192 @@ import * as isType from "./isType";
 import { Type } from "..";
 import { CommonError } from "../../../common";
 
-export function assertAsAction(type: Type.PowerQueryType): Type.Action {
+export function assertAsAction(type: Type.TPowerQueryType): Type.Action {
     assertIsAction(type);
     return type;
 }
 
-export function assertAsAny(type: Type.PowerQueryType): Type.TAny {
+export function assertAsAny(type: Type.TPowerQueryType): Type.TAny {
     assertIsAny(type);
     return type;
 }
 
-export function assertAsAnyUnion(type: Type.PowerQueryType): Type.AnyUnion {
+export function assertAsAnyUnion(type: Type.TPowerQueryType): Type.AnyUnion {
     assertIsAnyUnion(type);
     return type;
 }
 
-export function assertAsAnyNonNull(type: Type.PowerQueryType): Type.AnyNonNull {
+export function assertAsAnyNonNull(type: Type.TPowerQueryType): Type.AnyNonNull {
     assertIsAnyNonNull(type);
     return type;
 }
 
-export function assertAsBinary(type: Type.PowerQueryType): Type.Binary {
+export function assertAsBinary(type: Type.TPowerQueryType): Type.Binary {
     assertIsBinary(type);
     return type;
 }
 
-export function assertAsDate(type: Type.PowerQueryType): Type.Date {
+export function assertAsDate(type: Type.TPowerQueryType): Type.Date {
     assertIsDate(type);
     return type;
 }
 
-export function assertAsDateTime(type: Type.PowerQueryType): Type.DateTime {
+export function assertAsDateTime(type: Type.TPowerQueryType): Type.DateTime {
     assertIsDateTime(type);
     return type;
 }
 
-export function assertAsDateTimeZone(type: Type.PowerQueryType): Type.DateTimeZone {
+export function assertAsDateTimeZone(type: Type.TPowerQueryType): Type.DateTimeZone {
     assertIsDateTimeZone(type);
     return type;
 }
 
-export function assertAsDefinedFunction(type: Type.PowerQueryType): Type.DefinedFunction {
+export function assertAsDefinedFunction(type: Type.TPowerQueryType): Type.DefinedFunction {
     assertIsDefinedFunction(type);
     return type;
 }
 
-export function assertAsDefinedList(type: Type.PowerQueryType): Type.DefinedList {
+export function assertAsDefinedList(type: Type.TPowerQueryType): Type.DefinedList {
     assertIsDefinedList(type);
     return type;
 }
 
-export function assertAsDefinedListType(type: Type.PowerQueryType): Type.DefinedListType {
+export function assertAsDefinedListType(type: Type.TPowerQueryType): Type.DefinedListType {
     assertIsDefinedListType(type);
     return type;
 }
 
-export function assertAsDefinedRecord(type: Type.PowerQueryType): Type.DefinedRecord {
+export function assertAsDefinedRecord(type: Type.TPowerQueryType): Type.DefinedRecord {
     assertIsDefinedRecord(type);
     return type;
 }
 
-export function assertAsDefinedTable(type: Type.PowerQueryType): Type.DefinedTable {
+export function assertAsDefinedTable(type: Type.TPowerQueryType): Type.DefinedTable {
     assertIsDefinedTable(type);
     return type;
 }
 
-export function assertAsDuration(type: Type.PowerQueryType): Type.Duration {
+export function assertAsDuration(type: Type.TPowerQueryType): Type.Duration {
     assertIsDuration(type);
     return type;
 }
 
-export function assertAsFunction(type: Type.PowerQueryType): Type.TFunction {
+export function assertAsFunction(type: Type.TPowerQueryType): Type.TFunction {
     assertIsFunction(type);
     return type;
 }
 
-export function assertAsFunctionType(type: Type.PowerQueryType): Type.FunctionType {
+export function assertAsFunctionType(type: Type.TPowerQueryType): Type.FunctionType {
     assertIsFunctionType(type);
     return type;
 }
 
-export function assertAsList(type: Type.PowerQueryType): Type.TList {
+export function assertAsList(type: Type.TPowerQueryType): Type.TList {
     assertIsList(type);
     return type;
 }
 
-export function assertAsLogical(type: Type.PowerQueryType): Type.TLogical {
+export function assertAsLogical(type: Type.TPowerQueryType): Type.TLogical {
     assertIsLogical(type);
     return type;
 }
 
-export function assertAsLogicalLiteral(type: Type.PowerQueryType): Type.LogicalLiteral {
+export function assertAsLogicalLiteral(type: Type.TPowerQueryType): Type.LogicalLiteral {
     assertIsLogicalLiteral(type);
     return type;
 }
 
-export function assertAsNone(type: Type.PowerQueryType): Type.None {
+export function assertAsNone(type: Type.TPowerQueryType): Type.None {
     assertIsNone(type);
     return type;
 }
 
-export function assertAsNotApplicable(type: Type.PowerQueryType): Type.NotApplicable {
+export function assertAsNotApplicable(type: Type.TPowerQueryType): Type.NotApplicable {
     assertIsNotApplicable(type);
     return type;
 }
 
-export function assertAsNull(type: Type.PowerQueryType): Type.Null {
+export function assertAsNull(type: Type.TPowerQueryType): Type.Null {
     assertIsNull(type);
     return type;
 }
 
-export function assertAsNumber(type: Type.PowerQueryType): Type.TNumber {
+export function assertAsNumber(type: Type.TPowerQueryType): Type.TNumber {
     assertIsNumber(type);
     return type;
 }
 
-export function assertAsNumberLiteral(type: Type.PowerQueryType): Type.NumberLiteral {
+export function assertAsNumberLiteral(type: Type.TPowerQueryType): Type.NumberLiteral {
     assertIsNumberLiteral(type);
     return type;
 }
 
-export function assertAsPrimaryPrimitiveType(type: Type.PowerQueryType): Type.PrimaryPrimitiveType {
+export function assertAsPrimaryPrimitiveType(type: Type.TPowerQueryType): Type.PrimaryPrimitiveType {
     assertIsPrimaryPrimitiveType(type);
     return type;
 }
 
-export function assertAsRecord(type: Type.PowerQueryType): Type.TRecord {
+export function assertAsRecord(type: Type.TPowerQueryType): Type.TRecord {
     assertIsRecord(type);
     return type;
 }
 
-export function assertAsRecordType(type: Type.PowerQueryType): Type.RecordType {
+export function assertAsRecordType(type: Type.TPowerQueryType): Type.RecordType {
     assertIsRecordType(type);
     return type;
 }
 
-export function assertAsTable(type: Type.PowerQueryType): Type.TTable {
+export function assertAsTable(type: Type.TPowerQueryType): Type.TTable {
     assertIsTable(type);
     return type;
 }
 
-export function assertAsTableType(type: Type.PowerQueryType): Type.TableType {
+export function assertAsTableType(type: Type.TPowerQueryType): Type.TableType {
     assertIsTableType(type);
     return type;
 }
 
-export function assertAsTableTypePrimaryExpression(type: Type.PowerQueryType): Type.TableTypePrimaryExpression {
+export function assertAsTableTypePrimaryExpression(type: Type.TPowerQueryType): Type.TableTypePrimaryExpression {
     assertIsTableTypePrimaryExpression(type);
     return type;
 }
 
-export function assertAsText(type: Type.PowerQueryType): Type.TText {
+export function assertAsText(type: Type.TPowerQueryType): Type.TText {
     assertIsText(type);
     return type;
 }
 
-export function assertAsTextLiteral(type: Type.PowerQueryType): Type.TextLiteral {
+export function assertAsTextLiteral(type: Type.TPowerQueryType): Type.TextLiteral {
     assertIsTextLiteral(type);
     return type;
 }
 
-export function assertAsTime(type: Type.PowerQueryType): Type.Time {
+export function assertAsTime(type: Type.TPowerQueryType): Type.Time {
     assertIsTime(type);
     return type;
 }
 
-export function assertAsTPrimitiveType(type: Type.PowerQueryType): Type.TPrimitiveType {
+export function assertAsTPrimitiveType(type: Type.TPowerQueryType): Type.TPrimitiveType {
     assertIsTPrimitiveType(type);
     return type;
 }
 
-export function assertAsTLiteral(type: Type.PowerQueryType): Type.TLiteral {
+export function assertAsTLiteral(type: Type.TPowerQueryType): Type.TLiteral {
     assertIsLiteral(type);
     return type;
 }
 
-export function assertAsType(type: Type.PowerQueryType): Type.Type {
+export function assertAsType(type: Type.TPowerQueryType): Type.Type {
     assertIsType(type);
     return type;
 }
 
-export function assertAsUnknown(type: Type.PowerQueryType): Type.Unknown {
+export function assertAsUnknown(type: Type.TPowerQueryType): Type.Unknown {
     assertIsUnknown(type);
     return type;
 }
 
-export function assertIsAction(type: Type.PowerQueryType): asserts type is Type.Action {
+export function assertIsAction(type: Type.TPowerQueryType): asserts type is Type.Action {
     if (!isType.isAction(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -203,7 +203,7 @@ export function assertIsAction(type: Type.PowerQueryType): asserts type is Type.
     }
 }
 
-export function assertIsAny(type: Type.PowerQueryType): asserts type is Type.Any | Type.AnyUnion {
+export function assertIsAny(type: Type.TPowerQueryType): asserts type is Type.Any | Type.AnyUnion {
     if (!isType.isAny(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -215,7 +215,7 @@ export function assertIsAny(type: Type.PowerQueryType): asserts type is Type.Any
     }
 }
 
-export function assertIsAnyUnion(type: Type.PowerQueryType): asserts type is Type.AnyUnion {
+export function assertIsAnyUnion(type: Type.TPowerQueryType): asserts type is Type.AnyUnion {
     if (!isType.isAnyUnion(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -227,7 +227,7 @@ export function assertIsAnyUnion(type: Type.PowerQueryType): asserts type is Typ
     }
 }
 
-export function assertIsAnyNonNull(type: Type.PowerQueryType): asserts type is Type.AnyNonNull {
+export function assertIsAnyNonNull(type: Type.TPowerQueryType): asserts type is Type.AnyNonNull {
     if (!isType.isAnyNonNull(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -239,7 +239,7 @@ export function assertIsAnyNonNull(type: Type.PowerQueryType): asserts type is T
     }
 }
 
-export function assertIsBinary(type: Type.PowerQueryType): asserts type is Type.Binary {
+export function assertIsBinary(type: Type.TPowerQueryType): asserts type is Type.Binary {
     if (!isType.isBinary(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -251,7 +251,7 @@ export function assertIsBinary(type: Type.PowerQueryType): asserts type is Type.
     }
 }
 
-export function assertIsDate(type: Type.PowerQueryType): asserts type is Type.Date {
+export function assertIsDate(type: Type.TPowerQueryType): asserts type is Type.Date {
     if (!isType.isDate(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -263,7 +263,7 @@ export function assertIsDate(type: Type.PowerQueryType): asserts type is Type.Da
     }
 }
 
-export function assertIsDateTime(type: Type.PowerQueryType): asserts type is Type.DateTime {
+export function assertIsDateTime(type: Type.TPowerQueryType): asserts type is Type.DateTime {
     if (!isType.isDateTime(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -275,7 +275,7 @@ export function assertIsDateTime(type: Type.PowerQueryType): asserts type is Typ
     }
 }
 
-export function assertIsDateTimeZone(type: Type.PowerQueryType): asserts type is Type.DateTimeZone {
+export function assertIsDateTimeZone(type: Type.TPowerQueryType): asserts type is Type.DateTimeZone {
     if (!isType.isDateTimeZone(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -287,7 +287,7 @@ export function assertIsDateTimeZone(type: Type.PowerQueryType): asserts type is
     }
 }
 
-export function assertIsDefinedFunction(type: Type.PowerQueryType): asserts type is Type.DefinedFunction {
+export function assertIsDefinedFunction(type: Type.TPowerQueryType): asserts type is Type.DefinedFunction {
     if (!isType.isDefinedFunction(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -299,7 +299,7 @@ export function assertIsDefinedFunction(type: Type.PowerQueryType): asserts type
     }
 }
 
-export function assertIsDefinedList(type: Type.PowerQueryType): asserts type is Type.DefinedList {
+export function assertIsDefinedList(type: Type.TPowerQueryType): asserts type is Type.DefinedList {
     if (!isType.isDefinedList(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -311,7 +311,7 @@ export function assertIsDefinedList(type: Type.PowerQueryType): asserts type is 
     }
 }
 
-export function assertIsDefinedListType(type: Type.PowerQueryType): asserts type is Type.DefinedListType {
+export function assertIsDefinedListType(type: Type.TPowerQueryType): asserts type is Type.DefinedListType {
     if (!isType.isDefinedListType(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -323,7 +323,7 @@ export function assertIsDefinedListType(type: Type.PowerQueryType): asserts type
     }
 }
 
-export function assertIsDefinedRecord(type: Type.PowerQueryType): asserts type is Type.DefinedRecord {
+export function assertIsDefinedRecord(type: Type.TPowerQueryType): asserts type is Type.DefinedRecord {
     if (!isType.isDefinedRecord(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -335,7 +335,7 @@ export function assertIsDefinedRecord(type: Type.PowerQueryType): asserts type i
     }
 }
 
-export function assertIsDefinedTable(type: Type.PowerQueryType): asserts type is Type.DefinedTable {
+export function assertIsDefinedTable(type: Type.TPowerQueryType): asserts type is Type.DefinedTable {
     if (!isType.isDefinedTable(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -347,7 +347,7 @@ export function assertIsDefinedTable(type: Type.PowerQueryType): asserts type is
     }
 }
 
-export function assertIsDuration(type: Type.PowerQueryType): asserts type is Type.Duration {
+export function assertIsDuration(type: Type.TPowerQueryType): asserts type is Type.Duration {
     if (!isType.isDuration(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -359,7 +359,7 @@ export function assertIsDuration(type: Type.PowerQueryType): asserts type is Typ
     }
 }
 
-export function assertIsFunction(type: Type.PowerQueryType): asserts type is Type.TFunction {
+export function assertIsFunction(type: Type.TPowerQueryType): asserts type is Type.TFunction {
     if (!isType.isFunction(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -371,7 +371,7 @@ export function assertIsFunction(type: Type.PowerQueryType): asserts type is Typ
     }
 }
 
-export function assertIsFunctionType(type: Type.PowerQueryType): asserts type is Type.FunctionType {
+export function assertIsFunctionType(type: Type.TPowerQueryType): asserts type is Type.FunctionType {
     if (!isType.isFunctionType(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -383,7 +383,7 @@ export function assertIsFunctionType(type: Type.PowerQueryType): asserts type is
     }
 }
 
-export function assertIsList(type: Type.PowerQueryType): asserts type is Type.TList {
+export function assertIsList(type: Type.TPowerQueryType): asserts type is Type.TList {
     if (!isType.isList(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -395,7 +395,7 @@ export function assertIsList(type: Type.PowerQueryType): asserts type is Type.TL
     }
 }
 
-export function assertIsLiteral(type: Type.PowerQueryType): asserts type is Type.TLiteral {
+export function assertIsLiteral(type: Type.TPowerQueryType): asserts type is Type.TLiteral {
     if (!isType.isLiteral(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -407,7 +407,7 @@ export function assertIsLiteral(type: Type.PowerQueryType): asserts type is Type
     }
 }
 
-export function assertIsLogical(type: Type.PowerQueryType): asserts type is Type.TLogical {
+export function assertIsLogical(type: Type.TPowerQueryType): asserts type is Type.TLogical {
     if (!isType.isLogical(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -419,7 +419,7 @@ export function assertIsLogical(type: Type.PowerQueryType): asserts type is Type
     }
 }
 
-export function assertIsLogicalLiteral(type: Type.PowerQueryType): asserts type is Type.LogicalLiteral {
+export function assertIsLogicalLiteral(type: Type.TPowerQueryType): asserts type is Type.LogicalLiteral {
     if (!isType.isLogicalLiteral(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -431,7 +431,7 @@ export function assertIsLogicalLiteral(type: Type.PowerQueryType): asserts type 
     }
 }
 
-export function assertIsNone(type: Type.PowerQueryType): asserts type is Type.None {
+export function assertIsNone(type: Type.TPowerQueryType): asserts type is Type.None {
     if (!isType.isNone(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -443,7 +443,7 @@ export function assertIsNone(type: Type.PowerQueryType): asserts type is Type.No
     }
 }
 
-export function assertIsNotApplicable(type: Type.PowerQueryType): asserts type is Type.NotApplicable {
+export function assertIsNotApplicable(type: Type.TPowerQueryType): asserts type is Type.NotApplicable {
     if (!isType.isNotApplicable(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -455,7 +455,7 @@ export function assertIsNotApplicable(type: Type.PowerQueryType): asserts type i
     }
 }
 
-export function assertIsNull(type: Type.PowerQueryType): asserts type is Type.Null {
+export function assertIsNull(type: Type.TPowerQueryType): asserts type is Type.Null {
     if (!isType.isNull(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -467,7 +467,7 @@ export function assertIsNull(type: Type.PowerQueryType): asserts type is Type.Nu
     }
 }
 
-export function assertIsNumber(type: Type.PowerQueryType): asserts type is Type.TNumber {
+export function assertIsNumber(type: Type.TPowerQueryType): asserts type is Type.TNumber {
     if (!isType.isNumber(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -479,7 +479,7 @@ export function assertIsNumber(type: Type.PowerQueryType): asserts type is Type.
     }
 }
 
-export function assertIsNumberLiteral(type: Type.PowerQueryType): asserts type is Type.NumberLiteral {
+export function assertIsNumberLiteral(type: Type.TPowerQueryType): asserts type is Type.NumberLiteral {
     if (!isType.isNumber(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -491,7 +491,7 @@ export function assertIsNumberLiteral(type: Type.PowerQueryType): asserts type i
     }
 }
 
-export function assertIsPrimaryPrimitiveType(type: Type.PowerQueryType): asserts type is Type.PrimaryPrimitiveType {
+export function assertIsPrimaryPrimitiveType(type: Type.TPowerQueryType): asserts type is Type.PrimaryPrimitiveType {
     if (!isType.isPrimaryPrimitiveType(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -503,7 +503,7 @@ export function assertIsPrimaryPrimitiveType(type: Type.PowerQueryType): asserts
     }
 }
 
-export function assertIsTPrimitiveType(type: Type.PowerQueryType): asserts type is Type.TPrimitiveType {
+export function assertIsTPrimitiveType(type: Type.TPowerQueryType): asserts type is Type.TPrimitiveType {
     if (!isType.isTPrimitiveType(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -537,7 +537,7 @@ export function assertIsTPrimitiveType(type: Type.PowerQueryType): asserts type 
     }
 }
 
-export function assertIsRecord(type: Type.PowerQueryType): asserts type is Type.TRecord {
+export function assertIsRecord(type: Type.TPowerQueryType): asserts type is Type.TRecord {
     if (!isType.isRecord(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -549,7 +549,7 @@ export function assertIsRecord(type: Type.PowerQueryType): asserts type is Type.
     }
 }
 
-export function assertIsRecordType(type: Type.PowerQueryType): asserts type is Type.RecordType {
+export function assertIsRecordType(type: Type.TPowerQueryType): asserts type is Type.RecordType {
     if (!isType.isRecordType(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -561,7 +561,7 @@ export function assertIsRecordType(type: Type.PowerQueryType): asserts type is T
     }
 }
 
-export function assertIsTable(type: Type.PowerQueryType): asserts type is Type.TTable {
+export function assertIsTable(type: Type.TPowerQueryType): asserts type is Type.TTable {
     if (!isType.isTable(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -573,7 +573,7 @@ export function assertIsTable(type: Type.PowerQueryType): asserts type is Type.T
     }
 }
 
-export function assertIsTableType(type: Type.PowerQueryType): asserts type is Type.TableType {
+export function assertIsTableType(type: Type.TPowerQueryType): asserts type is Type.TableType {
     if (!isType.isTableType(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -586,7 +586,7 @@ export function assertIsTableType(type: Type.PowerQueryType): asserts type is Ty
 }
 
 export function assertIsTableTypePrimaryExpression(
-    type: Type.PowerQueryType,
+    type: Type.TPowerQueryType,
 ): asserts type is Type.TableTypePrimaryExpression {
     if (!isType.isTableTypePrimaryExpression(type)) {
         const details: AssertErrorDetails = {
@@ -599,7 +599,7 @@ export function assertIsTableTypePrimaryExpression(
     }
 }
 
-export function assertIsText(type: Type.PowerQueryType): asserts type is Type.TText {
+export function assertIsText(type: Type.TPowerQueryType): asserts type is Type.TText {
     if (!isType.isText(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -611,7 +611,7 @@ export function assertIsText(type: Type.PowerQueryType): asserts type is Type.TT
     }
 }
 
-export function assertIsTextLiteral(type: Type.PowerQueryType): asserts type is Type.TextLiteral {
+export function assertIsTextLiteral(type: Type.TPowerQueryType): asserts type is Type.TextLiteral {
     if (!isType.isText(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -623,7 +623,7 @@ export function assertIsTextLiteral(type: Type.PowerQueryType): asserts type is 
     }
 }
 
-export function assertIsTime(type: Type.PowerQueryType): asserts type is Type.Time {
+export function assertIsTime(type: Type.TPowerQueryType): asserts type is Type.Time {
     if (!isType.isTime(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -635,7 +635,7 @@ export function assertIsTime(type: Type.PowerQueryType): asserts type is Type.Ti
     }
 }
 
-export function assertIsType(type: Type.PowerQueryType): asserts type is Type.Type {
+export function assertIsType(type: Type.TPowerQueryType): asserts type is Type.Type {
     if (!isType.isType(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,
@@ -647,7 +647,7 @@ export function assertIsType(type: Type.PowerQueryType): asserts type is Type.Ty
     }
 }
 
-export function assertIsUnknown(type: Type.PowerQueryType): asserts type is Type.Unknown {
+export function assertIsUnknown(type: Type.TPowerQueryType): asserts type is Type.Unknown {
     if (!isType.isUnknown(type)) {
         const details: AssertErrorDetails = {
             givenTypeKind: type.kind,

--- a/src/powerquery-parser/language/type/typeUtils/categorize.ts
+++ b/src/powerquery-parser/language/type/typeUtils/categorize.ts
@@ -87,7 +87,7 @@ export type UnknownCategory = ITypeKindCategory<Type.Unknown>;
 export interface AnyCategory extends ITypeKindCategory<Type.Any> {
     readonly anyUnions: ImmutableSet<Type.AnyUnion>;
     // This is a recursive flattening of `AnyUnion.unionedTypePairs`.
-    readonly flattenedAnyUnions: ImmutableSet<Type.PowerQueryType>;
+    readonly flattenedAnyUnions: ImmutableSet<Type.TPowerQueryType>;
 }
 
 export interface FunctionCategory extends ITypeKindCategory<Type.Function> {
@@ -133,7 +133,7 @@ export interface TypeCategory extends ITypeKindCategory<Type.Type> {
 
 // Takes a collection of PowerQueryType and breaks them down into buckets based on their TypeKind,
 // then again on their ExtendedTypeKind.
-export function categorize(types: ReadonlyArray<Type.PowerQueryType>): CategorizedPowerQueryTypes {
+export function categorize(types: ReadonlyArray<Type.TPowerQueryType>): CategorizedPowerQueryTypes {
     const categoryByKind: Map<Type.TypeKind, TCategory> = new Map();
 
     for (const type of types) {
@@ -171,12 +171,12 @@ export function categorize(types: ReadonlyArray<Type.PowerQueryType>): Categoriz
     };
 }
 
-interface ITypeKindCategory<T extends Type.PowerQueryType> {
+interface ITypeKindCategory<T extends Type.TPowerQueryType> {
     readonly kind: T["kind"];
     readonly primitives: ImmutableSet<T>;
 }
 
-function addToCategory(category: TCategory, type: Type.PowerQueryType): TCategory {
+function addToCategory(category: TCategory, type: Type.TPowerQueryType): TCategory {
     // We can't group cases which call `addToCategoryForPrimitive` as they each have a different generic type.
     switch (type.kind) {
         case Type.TypeKind.Action:
@@ -383,7 +383,7 @@ function addToCategoryForNumber(category: NumberCategory, type: Type.TNumber): N
     }
 }
 
-function addToCategoryForPrimitive<T extends Type.PowerQueryType, C extends ITypeKindCategory<T> & TCategory>(
+function addToCategoryForPrimitive<T extends Type.TPowerQueryType, C extends ITypeKindCategory<T> & TCategory>(
     category: TCategory,
     type: T,
 ): ITypeKindCategory<T> & TCategory {
@@ -529,7 +529,7 @@ function addTypeIfUniqueType(category: TypeCategory, type: Type.TType): TypeCate
     }
 }
 
-function assertIsCategoryForType<PowerQueryType extends Type.PowerQueryType, Category extends TCategory>(
+function assertIsCategoryForType<PowerQueryType extends Type.TPowerQueryType, Category extends TCategory>(
     category: TCategory,
     type: PowerQueryType,
 ): asserts category is Category {
@@ -541,7 +541,7 @@ function assertIsCategoryForType<PowerQueryType extends Type.PowerQueryType, Cat
     }
 }
 
-function createCategory(type: Type.PowerQueryType): TCategory {
+function createCategory(type: Type.TPowerQueryType): TCategory {
     switch (type.kind) {
         case Type.TypeKind.Action:
             return createCategoryForPrimitive(type);
@@ -734,7 +734,7 @@ function createCategoryForNumber(type: Type.TNumber): NumberCategory {
     }
 }
 
-function createCategoryForPrimitive<T extends Type.PowerQueryType>(type: T): ITypeKindCategory<T> {
+function createCategoryForPrimitive<T extends Type.TPowerQueryType>(type: T): ITypeKindCategory<T> {
     return {
         kind: type.kind,
         primitives: new ImmutableSet<T>([type], isEqualType),
@@ -871,8 +871,8 @@ function createCategoryForType(type: Type.TType): TypeCategory {
     };
 }
 
-function flattenAnyUnion(anyUnion: Type.AnyUnion): ReadonlyArray<Type.PowerQueryType> {
-    let newUnionedTypePairs: Type.PowerQueryType[] = [];
+function flattenAnyUnion(anyUnion: Type.AnyUnion): ReadonlyArray<Type.TPowerQueryType> {
+    let newUnionedTypePairs: Type.TPowerQueryType[] = [];
 
     for (const item of anyUnion.unionedTypePairs) {
         // If it's an Any primitive then we can do an early return.

--- a/src/powerquery-parser/language/type/typeUtils/factories.ts
+++ b/src/powerquery-parser/language/type/typeUtils/factories.ts
@@ -16,8 +16,8 @@ export function createPrimitiveType<T extends Type.TypeKind>(isNullable: boolean
 
 // If the given types can be simplified/deduped down to a single type then that is returned instead.
 // Otherwise returns an instance of `Type.AnyUnion`.
-export function createAnyUnion(unionedTypePairs: ReadonlyArray<Type.PowerQueryType>): Type.PowerQueryType {
-    const simplified: ReadonlyArray<Type.PowerQueryType> = simplify(unionedTypePairs);
+export function createAnyUnion(unionedTypePairs: ReadonlyArray<Type.TPowerQueryType>): Type.TPowerQueryType {
+    const simplified: ReadonlyArray<Type.TPowerQueryType> = simplify(unionedTypePairs);
     if (simplified.length === 1) {
         return simplified[0];
     }
@@ -25,7 +25,7 @@ export function createAnyUnion(unionedTypePairs: ReadonlyArray<Type.PowerQueryTy
     return {
         kind: Type.TypeKind.Any,
         maybeExtendedKind: Type.ExtendedTypeKind.AnyUnion,
-        isNullable: unionedTypePairs.find((ttype: Type.PowerQueryType) => ttype.isNullable === true) !== undefined,
+        isNullable: unionedTypePairs.find((ttype: Type.TPowerQueryType) => ttype.isNullable === true) !== undefined,
         unionedTypePairs: simplified,
     };
 }
@@ -33,7 +33,7 @@ export function createAnyUnion(unionedTypePairs: ReadonlyArray<Type.PowerQueryTy
 export function createDefinedFunction(
     isNullable: boolean,
     parameters: ReadonlyArray<Type.FunctionParameter>,
-    returnType: Type.PowerQueryType,
+    returnType: Type.TPowerQueryType,
 ): Type.DefinedFunction {
     return {
         kind: Type.TypeKind.Function,
@@ -44,7 +44,7 @@ export function createDefinedFunction(
     };
 }
 
-export function createDefinedList(isNullable: boolean, elements: ReadonlyArray<Type.PowerQueryType>): Type.DefinedList {
+export function createDefinedList(isNullable: boolean, elements: ReadonlyArray<Type.TPowerQueryType>): Type.DefinedList {
     return {
         kind: Type.TypeKind.List,
         maybeExtendedKind: Type.ExtendedTypeKind.DefinedList,
@@ -55,7 +55,7 @@ export function createDefinedList(isNullable: boolean, elements: ReadonlyArray<T
 
 export function createDefinedListType(
     isNullable: boolean,
-    itemTypes: ReadonlyArray<Type.PowerQueryType>,
+    itemTypes: ReadonlyArray<Type.TPowerQueryType>,
 ): Type.DefinedListType {
     return {
         kind: Type.TypeKind.Type,
@@ -67,7 +67,7 @@ export function createDefinedListType(
 
 export function createDefinedRecord(
     isNullable: boolean,
-    fields: Map<string, Type.PowerQueryType>,
+    fields: Map<string, Type.TPowerQueryType>,
     isOpen: boolean,
 ): Type.DefinedRecord {
     return {
@@ -81,7 +81,7 @@ export function createDefinedRecord(
 
 export function createDefinedTable(
     isNullable: boolean,
-    fields: Map<string, Type.PowerQueryType>,
+    fields: Map<string, Type.TPowerQueryType>,
     isOpen: boolean,
 ): Type.DefinedTable {
     return {
@@ -96,7 +96,7 @@ export function createDefinedTable(
 export function createFunctionType(
     isNullable: boolean,
     parameters: ReadonlyArray<Type.FunctionParameter>,
-    returnType: Type.PowerQueryType,
+    returnType: Type.TPowerQueryType,
 ): Type.FunctionType {
     return {
         kind: Type.TypeKind.Type,
@@ -117,7 +117,7 @@ export function createNumberLiteral(isNullable: boolean, literal: string): Type.
     };
 }
 
-export function createListType(isNullable: boolean, itemType: Type.PowerQueryType): Type.ListType {
+export function createListType(isNullable: boolean, itemType: Type.TPowerQueryType): Type.ListType {
     return {
         kind: Type.TypeKind.Type,
         maybeExtendedKind: Type.ExtendedTypeKind.ListType,
@@ -140,7 +140,7 @@ export function createPrimaryPrimitiveType(
 
 export function createRecordType(
     isNullable: boolean,
-    fields: Map<string, Type.PowerQueryType>,
+    fields: Map<string, Type.TPowerQueryType>,
     isOpen: boolean,
 ): Type.RecordType {
     return {
@@ -154,7 +154,7 @@ export function createRecordType(
 
 export function createTableType(
     isNullable: boolean,
-    fields: Map<string, Type.PowerQueryType>,
+    fields: Map<string, Type.TPowerQueryType>,
     isOpen: boolean,
 ): Type.TableType {
     return {
@@ -181,7 +181,7 @@ export function createTextLiteral(isNullable: boolean, literal: string): Type.Te
 
 export function createTableTypePrimary(
     isNullable: boolean,
-    primaryExpression: Type.PowerQueryType,
+    primaryExpression: Type.TPowerQueryType,
 ): Type.TableTypePrimaryExpression {
     return {
         kind: Type.TypeKind.Type,

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -11,7 +11,7 @@ import { isFieldSpecificationList, isFunctionSignature } from "./isType";
 // `Type.AnyInstance is compatible with Type.TextInstance` -> false
 // `Type.NullInstance is compatible with Type.AnyNonNull` -> false
 // `Type.TextInstance is compatible with Type.AnyUnion([Type.TextInstance, Type.NumberInstance])` -> true
-export function isCompatible(left: Type.PowerQueryType, right: Type.PowerQueryType): boolean | undefined {
+export function isCompatible(left: Type.TPowerQueryType, right: Type.TPowerQueryType): boolean | undefined {
     if (
         left.kind === Type.TypeKind.NotApplicable ||
         left.kind === Type.TypeKind.Unknown ||
@@ -68,8 +68,8 @@ export function isCompatible(left: Type.PowerQueryType, right: Type.PowerQueryTy
 }
 
 export function isCompatibleWithFunctionSignature(
-    left: Type.PowerQueryType,
-    right: Type.PowerQueryType & Type.FunctionSignature,
+    left: Type.TPowerQueryType,
+    right: Type.TPowerQueryType & Type.FunctionSignature,
 ): boolean {
     if (!isCompatibleWithNullable(left, right) || !isFunctionSignature(left)) {
         return false;
@@ -79,7 +79,7 @@ export function isCompatibleWithFunctionSignature(
 }
 
 export function isCompatibleWithFunctionParameter(
-    left: Type.PowerQueryType | undefined,
+    left: Type.TPowerQueryType | undefined,
     right: Type.FunctionParameter,
 ): boolean {
     if (left === undefined) {
@@ -93,7 +93,7 @@ export function isCompatibleWithFunctionParameter(
     }
 }
 
-function isCompatibleWithAny(left: Type.PowerQueryType, right: Type.TAny): boolean | undefined {
+function isCompatibleWithAny(left: Type.TPowerQueryType, right: Type.TAny): boolean | undefined {
     switch (right.maybeExtendedKind) {
         case undefined:
             return isCompatibleWithNullable(left, right);
@@ -106,7 +106,7 @@ function isCompatibleWithAny(left: Type.PowerQueryType, right: Type.TAny): boole
     }
 }
 
-function isCompatibleWithAnyUnion(left: Type.PowerQueryType, right: Type.AnyUnion): boolean | undefined {
+function isCompatibleWithAnyUnion(left: Type.TPowerQueryType, right: Type.AnyUnion): boolean | undefined {
     for (const subtype of right.unionedTypePairs) {
         if (isCompatible(left, subtype)) {
             return true;
@@ -116,7 +116,7 @@ function isCompatibleWithAnyUnion(left: Type.PowerQueryType, right: Type.AnyUnio
     return false;
 }
 
-function isCompatibleWithDefinedList(left: Type.PowerQueryType, right: Type.DefinedList): boolean {
+function isCompatibleWithDefinedList(left: Type.TPowerQueryType, right: Type.DefinedList): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -133,7 +133,7 @@ function isCompatibleWithDefinedList(left: Type.PowerQueryType, right: Type.Defi
     }
 }
 
-function isCompatibleWithDefinedListType(left: Type.PowerQueryType, right: Type.DefinedListType): boolean {
+function isCompatibleWithDefinedListType(left: Type.TPowerQueryType, right: Type.DefinedListType): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -160,7 +160,7 @@ function isCompatibleWithDefinedListType(left: Type.PowerQueryType, right: Type.
     }
 }
 
-function isCompatibleWithDefinedRecord(left: Type.PowerQueryType, right: Type.DefinedRecord): boolean {
+function isCompatibleWithDefinedRecord(left: Type.TPowerQueryType, right: Type.DefinedRecord): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -177,7 +177,7 @@ function isCompatibleWithDefinedRecord(left: Type.PowerQueryType, right: Type.De
     }
 }
 
-function isCompatibleWithDefinedTable(left: Type.PowerQueryType, right: Type.DefinedTable): boolean {
+function isCompatibleWithDefinedTable(left: Type.TPowerQueryType, right: Type.DefinedTable): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -197,8 +197,8 @@ function isCompatibleWithDefinedTable(left: Type.PowerQueryType, right: Type.Def
 
 // TODO: decide what a compatible FieldSpecificationList should look like
 function isCompatibleWithFieldSpecificationList(
-    left: Type.PowerQueryType,
-    right: Type.PowerQueryType & Type.FieldSpecificationList,
+    left: Type.TPowerQueryType,
+    right: Type.TPowerQueryType & Type.FieldSpecificationList,
 ): boolean {
     if (!isCompatibleWithNullable(left, right) || !isFieldSpecificationList(left)) {
         return false;
@@ -207,11 +207,11 @@ function isCompatibleWithFieldSpecificationList(
     return MapUtils.isSubsetMap(
         left.fields,
         right.fields,
-        (leftValue: Type.PowerQueryType, rightValue: Type.PowerQueryType) => isEqualType(leftValue, rightValue),
+        (leftValue: Type.TPowerQueryType, rightValue: Type.TPowerQueryType) => isEqualType(leftValue, rightValue),
     );
 }
 
-function isCompatibleWithFunction(left: Type.PowerQueryType, right: Type.TFunction): boolean {
+function isCompatibleWithFunction(left: Type.TPowerQueryType, right: Type.TFunction): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -228,7 +228,7 @@ function isCompatibleWithFunction(left: Type.PowerQueryType, right: Type.TFuncti
     }
 }
 
-function isCompatibleWithList(left: Type.PowerQueryType, right: Type.TList): boolean {
+function isCompatibleWithList(left: Type.TPowerQueryType, right: Type.TList): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -245,7 +245,7 @@ function isCompatibleWithList(left: Type.PowerQueryType, right: Type.TList): boo
     }
 }
 
-function isCompatibleWithListType(left: Type.PowerQueryType, right: Type.ListType): boolean {
+function isCompatibleWithListType(left: Type.TPowerQueryType, right: Type.ListType): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -272,7 +272,7 @@ function isCompatibleWithListType(left: Type.PowerQueryType, right: Type.ListTyp
     }
 }
 
-function isCompatibleWithPrimaryPrimitiveType(left: Type.PowerQueryType, right: Type.PrimaryPrimitiveType): boolean {
+function isCompatibleWithPrimaryPrimitiveType(left: Type.TPowerQueryType, right: Type.PrimaryPrimitiveType): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -297,11 +297,11 @@ function isCompatibleWithPrimaryPrimitiveType(left: Type.PowerQueryType, right: 
     }
 }
 
-function isCompatibleWithNullable(left: Type.PowerQueryType, right: Type.PowerQueryType): boolean {
+function isCompatibleWithNullable(left: Type.TPowerQueryType, right: Type.TPowerQueryType): boolean {
     return right.isNullable === true ? true : left.isNullable === false;
 }
 
-function isCompatibleWithNumber(left: Type.PowerQueryType, right: Type.TNumber): boolean {
+function isCompatibleWithNumber(left: Type.TPowerQueryType, right: Type.TNumber): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -318,7 +318,7 @@ function isCompatibleWithNumber(left: Type.PowerQueryType, right: Type.TNumber):
     }
 }
 
-function isCompatibleWithNumberLiteral(left: Type.PowerQueryType, right: Type.NumberLiteral): boolean {
+function isCompatibleWithNumberLiteral(left: Type.TPowerQueryType, right: Type.NumberLiteral): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -335,7 +335,7 @@ function isCompatibleWithNumberLiteral(left: Type.PowerQueryType, right: Type.Nu
     }
 }
 
-function isCompatibleWithRecord(left: Type.PowerQueryType, right: Type.TRecord): boolean {
+function isCompatibleWithRecord(left: Type.TPowerQueryType, right: Type.TRecord): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -352,7 +352,7 @@ function isCompatibleWithRecord(left: Type.PowerQueryType, right: Type.TRecord):
     }
 }
 
-function isCompatibleWithRecordType(left: Type.PowerQueryType, right: Type.RecordType): boolean {
+function isCompatibleWithRecordType(left: Type.TPowerQueryType, right: Type.RecordType): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -377,7 +377,7 @@ function isCompatibleWithRecordType(left: Type.PowerQueryType, right: Type.Recor
     }
 }
 
-function isCompatibleWithTable(left: Type.PowerQueryType, right: Type.TTable): boolean {
+function isCompatibleWithTable(left: Type.TPowerQueryType, right: Type.TTable): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -394,7 +394,7 @@ function isCompatibleWithTable(left: Type.PowerQueryType, right: Type.TTable): b
     }
 }
 
-function isCompatibleWithTableType(left: Type.PowerQueryType, right: Type.TableType): boolean {
+function isCompatibleWithTableType(left: Type.TPowerQueryType, right: Type.TableType): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -420,7 +420,7 @@ function isCompatibleWithTableType(left: Type.PowerQueryType, right: Type.TableT
 }
 
 function isCompatibleWithTableTypePrimaryExpression(
-    left: Type.PowerQueryType,
+    left: Type.TPowerQueryType,
     right: Type.TableTypePrimaryExpression,
 ): boolean | undefined {
     if (left.kind !== right.kind) {
@@ -447,7 +447,7 @@ function isCompatibleWithTableTypePrimaryExpression(
     }
 }
 
-function isCompatibleWithText(left: Type.PowerQueryType, right: Type.TText): boolean {
+function isCompatibleWithText(left: Type.TPowerQueryType, right: Type.TText): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -464,7 +464,7 @@ function isCompatibleWithText(left: Type.PowerQueryType, right: Type.TText): boo
     }
 }
 
-function isCompatibleWithTextLiteral(left: Type.PowerQueryType, right: Type.TextLiteral): boolean {
+function isCompatibleWithTextLiteral(left: Type.TPowerQueryType, right: Type.TextLiteral): boolean {
     if (left.kind !== right.kind) {
         return false;
     }
@@ -482,7 +482,7 @@ function isCompatibleWithTextLiteral(left: Type.PowerQueryType, right: Type.Text
 }
 
 function isCompatibleWithType(
-    left: Type.PowerQueryType,
+    left: Type.TPowerQueryType,
     right:
         | Type.DefinedListType
         | Type.FunctionType

--- a/src/powerquery-parser/language/type/typeUtils/isEqualType.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isEqualType.ts
@@ -5,7 +5,7 @@ import { Type } from "..";
 import { ArrayUtils, Assert, MapUtils } from "../../../common";
 import { isTypeInArray } from "./typeUtils";
 
-export function isEqualType(left: Type.PowerQueryType, right: Type.PowerQueryType): boolean {
+export function isEqualType(left: Type.TPowerQueryType, right: Type.TPowerQueryType): boolean {
     if (left === right) {
         return true;
     } else if (
@@ -30,8 +30,8 @@ export function isEqualFunctionParameter(left: Type.FunctionParameter, right: Ty
 }
 
 export function isEqualFunctionSignature(
-    left: Type.PowerQueryType & Type.FunctionSignature,
-    right: Type.PowerQueryType & Type.FunctionSignature,
+    left: Type.TPowerQueryType & Type.FunctionSignature,
+    right: Type.TPowerQueryType & Type.FunctionSignature,
 ): boolean {
     return (
         left === right ||
@@ -43,8 +43,8 @@ export function isEqualFunctionSignature(
 
 // Does not care about ordering.
 export function isEqualTypes(
-    leftTypes: ReadonlyArray<Type.PowerQueryType>,
-    rightTypes: ReadonlyArray<Type.PowerQueryType>,
+    leftTypes: ReadonlyArray<Type.TPowerQueryType>,
+    rightTypes: ReadonlyArray<Type.TPowerQueryType>,
 ): boolean {
     if (leftTypes === rightTypes) {
         return true;
@@ -138,9 +138,9 @@ export function isEqualDefinedList(left: Type.DefinedList, right: Type.DefinedLi
         return false;
     }
 
-    const rightElements: ReadonlyArray<Type.PowerQueryType> = right.elements;
+    const rightElements: ReadonlyArray<Type.TPowerQueryType> = right.elements;
     return ArrayUtils.all(
-        left.elements.map((leftType: Type.PowerQueryType, index: number) =>
+        left.elements.map((leftType: Type.TPowerQueryType, index: number) =>
             isEqualType(leftType, rightElements[index]),
         ),
     );
@@ -153,9 +153,9 @@ export function isEqualDefinedListType(left: Type.DefinedListType, right: Type.D
         return false;
     }
 
-    const rightElements: ReadonlyArray<Type.PowerQueryType> = right.itemTypes;
+    const rightElements: ReadonlyArray<Type.TPowerQueryType> = right.itemTypes;
     return ArrayUtils.all(
-        left.itemTypes.map((leftType: Type.PowerQueryType, index: number) =>
+        left.itemTypes.map((leftType: Type.TPowerQueryType, index: number) =>
             isEqualType(leftType, rightElements[index]),
         ),
     );
@@ -165,7 +165,7 @@ export function isEqualDefinedRecord(left: Type.DefinedRecord, right: Type.Defin
     return (
         left === right ||
         (left.isNullable === right.isNullable &&
-            MapUtils.isEqualMap<string, Type.PowerQueryType>(left.fields, right.fields, isEqualType))
+            MapUtils.isEqualMap<string, Type.TPowerQueryType>(left.fields, right.fields, isEqualType))
     );
 }
 
@@ -173,7 +173,7 @@ export function isEqualDefinedTable(left: Type.DefinedTable, right: Type.Defined
     return (
         left === right ||
         (left.isNullable === right.isNullable &&
-            MapUtils.isEqualMap<string, Type.PowerQueryType>(left.fields, right.fields, isEqualType))
+            MapUtils.isEqualMap<string, Type.TPowerQueryType>(left.fields, right.fields, isEqualType))
     );
 }
 
@@ -197,7 +197,7 @@ export function isEqualFieldSpecificationList(
     }
 
     for (const [key, leftValue] of left.fields.entries()) {
-        const maybeRightValue: Type.PowerQueryType | undefined = right.fields.get(key);
+        const maybeRightValue: Type.TPowerQueryType | undefined = right.fields.get(key);
         if (maybeRightValue === undefined || !isEqualType(leftValue, maybeRightValue)) {
             return false;
         }

--- a/src/powerquery-parser/language/type/typeUtils/isType.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isType.ts
@@ -4,65 +4,65 @@
 import { Type } from "..";
 import { Assert } from "../../../common";
 
-export function isAction(type: Type.PowerQueryType): type is Type.Action {
+export function isAction(type: Type.TPowerQueryType): type is Type.Action {
     return type.kind === Type.TypeKind.Action;
 }
 
-export function isAny(type: Type.PowerQueryType): type is Type.TAny {
+export function isAny(type: Type.TPowerQueryType): type is Type.TAny {
     return type.kind === Type.TypeKind.Any;
 }
 
-export function isAnyUnion(type: Type.PowerQueryType): type is Type.AnyUnion {
+export function isAnyUnion(type: Type.TPowerQueryType): type is Type.AnyUnion {
     return type.kind === Type.TypeKind.Any && type.maybeExtendedKind === Type.ExtendedTypeKind.AnyUnion;
 }
 
-export function isAnyNonNull(type: Type.PowerQueryType): type is Type.AnyNonNull {
+export function isAnyNonNull(type: Type.TPowerQueryType): type is Type.AnyNonNull {
     return type.kind === Type.TypeKind.AnyNonNull;
 }
 
-export function isBinary(type: Type.PowerQueryType): type is Type.Binary {
+export function isBinary(type: Type.TPowerQueryType): type is Type.Binary {
     return type.kind === Type.TypeKind.Binary;
 }
 
-export function isDate(type: Type.PowerQueryType): type is Type.Date {
+export function isDate(type: Type.TPowerQueryType): type is Type.Date {
     return type.kind === Type.TypeKind.Date;
 }
 
-export function isDateTime(type: Type.PowerQueryType): type is Type.DateTime {
+export function isDateTime(type: Type.TPowerQueryType): type is Type.DateTime {
     return type.kind === Type.TypeKind.DateTime;
 }
 
-export function isDateTimeZone(type: Type.PowerQueryType): type is Type.DateTimeZone {
+export function isDateTimeZone(type: Type.TPowerQueryType): type is Type.DateTimeZone {
     return type.kind === Type.TypeKind.DateTimeZone;
 }
 
-export function isDefinedFunction(type: Type.PowerQueryType): type is Type.DefinedFunction {
+export function isDefinedFunction(type: Type.TPowerQueryType): type is Type.DefinedFunction {
     return type.kind === Type.TypeKind.Function && type.maybeExtendedKind === Type.ExtendedTypeKind.DefinedFunction;
 }
 
-export function isDefinedList(type: Type.PowerQueryType): type is Type.DefinedList {
+export function isDefinedList(type: Type.TPowerQueryType): type is Type.DefinedList {
     return type.kind === Type.TypeKind.List && type.maybeExtendedKind === Type.ExtendedTypeKind.DefinedList;
 }
 
-export function isDefinedListType(type: Type.PowerQueryType): type is Type.DefinedListType {
+export function isDefinedListType(type: Type.TPowerQueryType): type is Type.DefinedListType {
     return type.kind === Type.TypeKind.Type && type.maybeExtendedKind === Type.ExtendedTypeKind.DefinedListType;
 }
 
-export function isDefinedRecord(type: Type.PowerQueryType): type is Type.DefinedRecord {
+export function isDefinedRecord(type: Type.TPowerQueryType): type is Type.DefinedRecord {
     return type.kind === Type.TypeKind.Record && type.maybeExtendedKind === Type.ExtendedTypeKind.DefinedRecord;
 }
 
-export function isDefinedTable(type: Type.PowerQueryType): type is Type.DefinedTable {
+export function isDefinedTable(type: Type.TPowerQueryType): type is Type.DefinedTable {
     return type.kind === Type.TypeKind.Table && type.maybeExtendedKind === Type.ExtendedTypeKind.DefinedTable;
 }
 
-export function isDuration(type: Type.PowerQueryType): type is Type.Duration {
+export function isDuration(type: Type.TPowerQueryType): type is Type.Duration {
     return type.kind === Type.TypeKind.Duration;
 }
 
 export function isFieldSpecificationList(
-    type: Type.PowerQueryType,
-): type is Type.PowerQueryType & Type.FieldSpecificationList {
+    type: Type.TPowerQueryType,
+): type is Type.TPowerQueryType & Type.FieldSpecificationList {
     return (
         (type.kind === Type.TypeKind.Record && type.maybeExtendedKind === Type.ExtendedTypeKind.DefinedRecord) ||
         (type.kind === Type.TypeKind.Table && type.maybeExtendedKind === Type.ExtendedTypeKind.DefinedTable) ||
@@ -71,99 +71,99 @@ export function isFieldSpecificationList(
     );
 }
 
-export function isFunction(type: Type.PowerQueryType): type is Type.TFunction {
+export function isFunction(type: Type.TPowerQueryType): type is Type.TFunction {
     return type.kind === Type.TypeKind.Function;
 }
 
-export function isFunctionSignature(type: Type.PowerQueryType): type is Type.PowerQueryType & Type.FunctionSignature {
+export function isFunctionSignature(type: Type.TPowerQueryType): type is Type.TPowerQueryType & Type.FunctionSignature {
     return (
         (type.kind === Type.TypeKind.Function && type.maybeExtendedKind === Type.ExtendedTypeKind.DefinedFunction) ||
         (type.kind === Type.TypeKind.Type && type.maybeExtendedKind === Type.ExtendedTypeKind.FunctionType)
     );
 }
 
-export function isFunctionType(type: Type.PowerQueryType): type is Type.FunctionType {
+export function isFunctionType(type: Type.TPowerQueryType): type is Type.FunctionType {
     return type.kind === Type.TypeKind.Type && type.maybeExtendedKind === Type.ExtendedTypeKind.FunctionType;
 }
 
-export function isList(type: Type.PowerQueryType): type is Type.TList {
+export function isList(type: Type.TPowerQueryType): type is Type.TList {
     return type.kind === Type.TypeKind.List;
 }
 
-export function isLiteral(type: Type.PowerQueryType): type is Type.TLiteral {
+export function isLiteral(type: Type.TPowerQueryType): type is Type.TLiteral {
     return (
         type.maybeExtendedKind === Type.ExtendedTypeKind.TextLiteral ||
         type.maybeExtendedKind === Type.ExtendedTypeKind.NumberLiteral
     );
 }
 
-export function isLogical(type: Type.PowerQueryType): type is Type.TLogical {
+export function isLogical(type: Type.TPowerQueryType): type is Type.TLogical {
     return type.kind === Type.TypeKind.Logical;
 }
 
-export function isLogicalLiteral(type: Type.PowerQueryType): type is Type.LogicalLiteral {
+export function isLogicalLiteral(type: Type.TPowerQueryType): type is Type.LogicalLiteral {
     return type.kind === Type.TypeKind.Logical && type.maybeExtendedKind === Type.ExtendedTypeKind.LogicalLiteral;
 }
 
-export function isNone(type: Type.PowerQueryType): type is Type.None {
+export function isNone(type: Type.TPowerQueryType): type is Type.None {
     return type.kind === Type.TypeKind.None;
 }
 
-export function isNotApplicable(type: Type.PowerQueryType): type is Type.NotApplicable {
+export function isNotApplicable(type: Type.TPowerQueryType): type is Type.NotApplicable {
     return type.kind === Type.TypeKind.NotApplicable;
 }
 
-export function isNull(type: Type.PowerQueryType): type is Type.Null {
+export function isNull(type: Type.TPowerQueryType): type is Type.Null {
     return type.kind === Type.TypeKind.Null;
 }
 
-export function isNumber(type: Type.PowerQueryType): type is Type.Number {
+export function isNumber(type: Type.TPowerQueryType): type is Type.Number {
     return type.kind === Type.TypeKind.Number;
 }
 
-export function isNumberLiteral(type: Type.PowerQueryType): type is Type.NumberLiteral {
+export function isNumberLiteral(type: Type.TPowerQueryType): type is Type.NumberLiteral {
     return type.kind === Type.TypeKind.Number && type.maybeExtendedKind === Type.ExtendedTypeKind.NumberLiteral;
 }
 
-export function isPrimaryPrimitiveType(type: Type.PowerQueryType): type is Type.PrimaryPrimitiveType {
+export function isPrimaryPrimitiveType(type: Type.TPowerQueryType): type is Type.PrimaryPrimitiveType {
     return type.kind === Type.TypeKind.Type && type.maybeExtendedKind === Type.ExtendedTypeKind.PrimaryPrimitiveType;
 }
 
-export function isRecord(type: Type.PowerQueryType): type is Type.TRecord {
+export function isRecord(type: Type.TPowerQueryType): type is Type.TRecord {
     return type.kind === Type.TypeKind.Record;
 }
 
-export function isRecordType(type: Type.PowerQueryType): type is Type.RecordType {
+export function isRecordType(type: Type.TPowerQueryType): type is Type.RecordType {
     return type.kind === Type.TypeKind.Type && type.maybeExtendedKind === Type.ExtendedTypeKind.RecordType;
 }
 
-export function isTable(type: Type.PowerQueryType): type is Type.TTable {
+export function isTable(type: Type.TPowerQueryType): type is Type.TTable {
     return type.kind === Type.TypeKind.Table;
 }
 
-export function isTableType(type: Type.PowerQueryType): type is Type.TableType {
+export function isTableType(type: Type.TPowerQueryType): type is Type.TableType {
     return type.kind === Type.TypeKind.Type && type.maybeExtendedKind === Type.ExtendedTypeKind.TableType;
 }
 
-export function isTableTypePrimaryExpression(type: Type.PowerQueryType): type is Type.TableTypePrimaryExpression {
+export function isTableTypePrimaryExpression(type: Type.TPowerQueryType): type is Type.TableTypePrimaryExpression {
     return (
         type.kind === Type.TypeKind.Type && type.maybeExtendedKind === Type.ExtendedTypeKind.TableTypePrimaryExpression
     );
 }
 
-export function isText(type: Type.PowerQueryType): type is Type.Text {
+export function isText(type: Type.TPowerQueryType): type is Type.Text {
     return type.kind === Type.TypeKind.Text;
 }
 
-export function isTextLiteral(type: Type.PowerQueryType): type is Type.TextLiteral {
+export function isTextLiteral(type: Type.TPowerQueryType): type is Type.TextLiteral {
     return type.kind === Type.TypeKind.Text && type.maybeExtendedKind === Type.ExtendedTypeKind.TextLiteral;
 }
 
-export function isTime(type: Type.PowerQueryType): type is Type.Time {
+export function isTime(type: Type.TPowerQueryType): type is Type.Time {
     return type.kind === Type.TypeKind.Time;
 }
 
-export function isTPrimitiveType(type: Type.PowerQueryType): type is Type.TPrimitiveType {
+export function isTPrimitiveType(type: Type.TPowerQueryType): type is Type.TPrimitiveType {
     switch (type.kind) {
         case Type.TypeKind.Action:
         case Type.TypeKind.Any:
@@ -195,10 +195,10 @@ export function isTPrimitiveType(type: Type.PowerQueryType): type is Type.TPrimi
     }
 }
 
-export function isType(type: Type.PowerQueryType): type is Type.Type {
+export function isType(type: Type.TPowerQueryType): type is Type.Type {
     return type.kind === Type.TypeKind.Type;
 }
 
-export function isUnknown(type: Type.PowerQueryType): type is Type.Unknown {
+export function isUnknown(type: Type.TPowerQueryType): type is Type.Unknown {
     return type.kind === Type.TypeKind.Unknown;
 }

--- a/src/powerquery-parser/language/type/typeUtils/nameOf.ts
+++ b/src/powerquery-parser/language/type/typeUtils/nameOf.ts
@@ -5,14 +5,14 @@ import { Type } from "..";
 import { Constant } from "../..";
 import { Assert } from "../../../common";
 
-export function nameOf(type: Type.PowerQueryType): string {
+export function nameOf(type: Type.TPowerQueryType): string {
     switch (type.maybeExtendedKind) {
         case Type.ExtendedTypeKind.NumberLiteral:
         case Type.ExtendedTypeKind.TextLiteral:
             return prefixNullableIfRequired(type, `${type.literal}`);
 
         case Type.ExtendedTypeKind.AnyUnion:
-            return type.unionedTypePairs.map((subtype: Type.PowerQueryType) => nameOf(subtype)).join(" | ");
+            return type.unionedTypePairs.map((subtype: Type.TPowerQueryType) => nameOf(subtype)).join(" | ");
 
         case Type.ExtendedTypeKind.DefinedFunction:
             return prefixNullableIfRequired(type, nameOfFunctionSignature(type, true));
@@ -104,10 +104,10 @@ function nameOfFieldSpecificationList(type: Type.FieldSpecificationList): string
     return `[${pairs}]`;
 }
 
-function nameOfIterable(collection: ReadonlyArray<Type.PowerQueryType>): string {
-    return collection.map((item: Type.PowerQueryType) => nameOf(item)).join(", ");
+function nameOfIterable(collection: ReadonlyArray<Type.TPowerQueryType>): string {
+    return collection.map((item: Type.TPowerQueryType) => nameOf(item)).join(", ");
 }
 
-function prefixNullableIfRequired(type: Type.PowerQueryType, name: string): string {
+function prefixNullableIfRequired(type: Type.TPowerQueryType, name: string): string {
     return type.isNullable ? `${Constant.LanguageConstantKind.Nullable} ${name}` : name;
 }

--- a/src/powerquery-parser/language/type/typeUtils/simplify.ts
+++ b/src/powerquery-parser/language/type/typeUtils/simplify.ts
@@ -18,7 +18,7 @@ import {
 } from "./categorize";
 import { isEqualType } from "./isEqualType";
 
-export function simplify(types: ReadonlyArray<Type.PowerQueryType>): ReadonlyArray<Type.PowerQueryType> {
+export function simplify(types: ReadonlyArray<Type.TPowerQueryType>): ReadonlyArray<Type.TPowerQueryType> {
     const categorized: CategorizedPowerQueryTypes = categorize(types);
 
     // If an `any` exists then that's as simplified as we can make it.
@@ -27,7 +27,7 @@ export function simplify(types: ReadonlyArray<Type.PowerQueryType>): ReadonlyArr
         return [maybeAny];
     }
 
-    const partial: Type.PowerQueryType[] = [
+    const partial: Type.TPowerQueryType[] = [
         ...(categorized.maybeAction?.primitives.values() ?? []),
         ...(categorized.maybeAnyNonNull?.primitives.values() ?? []),
         ...(categorized.maybeBinary?.primitives.values() ?? []),
@@ -62,7 +62,7 @@ export function simplify(types: ReadonlyArray<Type.PowerQueryType>): ReadonlyArr
 
 // Returns the first nullable instance if one exists,
 // otherwise returns the first element in the collection.
-function firstNullableElseFirst<T extends Type.PowerQueryType>(immutableSet: ImmutableSet<T>): T | undefined {
+function firstNullableElseFirst<T extends Type.TPowerQueryType>(immutableSet: ImmutableSet<T>): T | undefined {
     const setValues: ReadonlyArray<T> = [...immutableSet.values()];
 
     for (const item of setValues) {
@@ -83,7 +83,7 @@ function maybeFindAnyPrimitive(categorized: CategorizedPowerQueryTypes): Type.An
     return firstNullableElseFirst(maybeAnySet);
 }
 
-function simplifyAnyCategory(maybeCategory: AnyCategory | undefined): ReadonlyArray<Type.PowerQueryType> {
+function simplifyAnyCategory(maybeCategory: AnyCategory | undefined): ReadonlyArray<Type.TPowerQueryType> {
     if (!maybeCategory?.flattenedAnyUnions) {
         return [];
     } else {
@@ -155,7 +155,7 @@ function simplifyTextCategory(maybeCategory: TextCategory | undefined): Readonly
     return simplifyExtendedType(maybeCategory.primitives, maybeCategory.literals);
 }
 
-function simplifyTypeCategory(maybeCategory: TypeCategory | undefined): ReadonlyArray<Type.PowerQueryType> {
+function simplifyTypeCategory(maybeCategory: TypeCategory | undefined): ReadonlyArray<Type.TPowerQueryType> {
     if (maybeCategory === undefined) {
         return [];
     } else if (maybeCategory.primitives.size) {
@@ -174,7 +174,7 @@ function simplifyTypeCategory(maybeCategory: TypeCategory | undefined): Readonly
     }
 }
 
-function simplifyExtendedType<T extends Type.PowerQueryType, L extends Type.PowerQueryType>(
+function simplifyExtendedType<T extends Type.TPowerQueryType, L extends Type.TPowerQueryType>(
     primitives: ImmutableSet<T>,
     literals: ImmutableSet<L>,
 ): ReadonlyArray<T> | ReadonlyArray<L> {

--- a/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
@@ -44,8 +44,8 @@ export type TMismatch =
     | InvocationMismatch;
 
 export interface IMismatch<Actual, Expected> {
-    readonly expected: Expected;
     readonly actual: Actual;
+    readonly expected: Expected;
 }
 
 export type DefinedFunctionMismatch = IMismatch<Type.FunctionParameter, Type.FunctionParameter>;

--- a/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
@@ -11,38 +11,54 @@ export type TChecked =
     | CheckedDefinedList
     | CheckedDefinedRecord
     | CheckedDefinedTable
-    | CheckedFunctionSignature;
+    | CheckedFunctionSignature
+    | CheckedInvocation;
 
-export interface IChecked<
-    Key,
-    Actual extends Type.PowerQueryType | Type.FunctionParameter | undefined,
-    Expected extends Type.PowerQueryType | Type.FunctionParameter
-> {
+export interface IChecked<Key, Mismatch> {
     readonly valid: ReadonlyArray<Key>;
-    readonly invalid: ReadonlyArray<Mismatch<Key, Actual, Expected>>;
+    readonly invalid: Map<Key, Mismatch>;
     readonly extraneous: ReadonlyArray<Key>;
     readonly missing: ReadonlyArray<Key>;
 }
 
-export type CheckedDefinedList = IChecked<number, Type.PowerQueryType, Type.PowerQueryType>;
-
-export interface CheckedDefinedFunction extends IChecked<number, Type.FunctionParameter, Type.FunctionParameter> {
+export interface CheckedDefinedFunction extends IChecked<number, DefinedFunctionMismatch> {
     readonly isReturnTypeCompatible: boolean;
 }
 
-export type CheckedFunctionSignature = IChecked<number, Type.FunctionParameter, Type.FunctionParameter>;
+export type CheckedDefinedList = IChecked<number, DefinedListMismatch>;
 
-export type CheckedDefinedRecord = IChecked<string, Type.PowerQueryType, Type.PowerQueryType>;
+export type CheckedDefinedRecord = IChecked<string, DefinedRecordMismatch>;
 
-export type CheckedDefinedTable = IChecked<string, Type.PowerQueryType, Type.PowerQueryType>;
+export type CheckedDefinedTable = IChecked<string, DefinedTableMismatch>;
 
-export type CheckedInvocation = IChecked<number, Type.PowerQueryType | undefined, Type.FunctionParameter>;
+export type CheckedFunctionSignature = IChecked<number, FunctionSignatureMismatch>;
 
-export interface Mismatch<Key, Actual, Expected> {
-    readonly key: Key;
+export type CheckedInvocation = IChecked<number, InvocationMismatch>;
+
+export type TMismatch =
+    | DefinedFunctionMismatch
+    | DefinedListMismatch
+    | DefinedRecordMismatch
+    | DefinedTableMismatch
+    | FunctionSignatureMismatch
+    | InvocationMismatch;
+
+export interface IMismatch<Actual, Expected> {
     readonly expected: Expected;
     readonly actual: Actual;
 }
+
+export type DefinedFunctionMismatch = IMismatch<Type.FunctionParameter, Type.FunctionParameter>;
+
+export type DefinedListMismatch = IMismatch<Type.TPowerQueryType, Type.TPowerQueryType>;
+
+export type DefinedRecordMismatch = IMismatch<Type.TPowerQueryType, Type.TPowerQueryType>;
+
+export type DefinedTableMismatch = IMismatch<Type.TPowerQueryType, Type.TPowerQueryType>;
+
+export type FunctionSignatureMismatch = IMismatch<Type.FunctionParameter, Type.FunctionParameter>;
+
+export type InvocationMismatch = IMismatch<Type.TPowerQueryType | undefined, Type.FunctionParameter>;
 
 export function typeCheckFunction(
     valueType: Type.DefinedFunction,
@@ -66,7 +82,7 @@ export function typeCheckFunctionSignature(
 }
 
 export function typeCheckInvocation(
-    args: ReadonlyArray<Type.PowerQueryType>,
+    args: ReadonlyArray<Type.TPowerQueryType>,
     definedFunction: Type.DefinedFunction,
 ): CheckedInvocation {
     const parameters: ReadonlyArray<Type.FunctionParameter> = definedFunction.parameters;
@@ -78,16 +94,15 @@ export function typeCheckInvocation(
 
     const validArgs: number[] = [];
     const missingArgs: number[] = [];
-    const invalidArgs: Mismatch<number, Type.PowerQueryType | undefined, Type.FunctionParameter>[] = [];
+    const invalidArgs: Map<number, InvocationMismatch> = new Map();
     for (let index: number = 0; index < numParameters; index += 1) {
-        const maybeArg: Type.PowerQueryType | undefined = args[index];
+        const maybeArg: Type.TPowerQueryType | undefined = args[index];
         const parameter: Type.FunctionParameter = parameters[index];
 
         if (isCompatibleWithFunctionParameter(maybeArg, parameter)) {
             validArgs.push(index);
         } else if (maybeArg !== undefined) {
-            invalidArgs.push({
-                key: index,
+            invalidArgs.set(index, {
                 expected: parameter,
                 actual: maybeArg,
             });
@@ -105,19 +120,18 @@ export function typeCheckInvocation(
 }
 
 export function typeCheckListWithListType(valueType: Type.DefinedList, schemaType: Type.ListType): CheckedDefinedList {
-    const valid: number[] = [];
-    const invalid: Mismatch<number, Type.PowerQueryType, Type.PowerQueryType>[] = [];
-    const schemaItemType: Type.PowerQueryType = schemaType.itemType;
+    const validArgs: number[] = [];
+    const invalidArgs: Map<number, DefinedListMismatch> = new Map();
+    const schemaItemType: Type.TPowerQueryType = schemaType.itemType;
 
-    const valueElements: ReadonlyArray<Type.PowerQueryType> = valueType.elements;
+    const valueElements: ReadonlyArray<Type.TPowerQueryType> = valueType.elements;
     const numElements: number = valueElements.length;
     for (let index: number = 0; index < numElements; index += 1) {
-        const element: Type.PowerQueryType = valueElements[index];
+        const element: Type.TPowerQueryType = valueElements[index];
         if (isCompatible(element, schemaItemType)) {
-            valid.push(index);
+            validArgs.push(index);
         } else {
-            invalid.push({
-                key: index,
+            invalidArgs.set(index, {
                 expected: schemaType,
                 actual: element,
             });
@@ -125,8 +139,8 @@ export function typeCheckListWithListType(valueType: Type.DefinedList, schemaTyp
     }
 
     return {
-        valid,
-        invalid,
+        valid: validArgs,
+        invalid: invalidArgs,
         extraneous: [],
         missing: [],
     };
@@ -148,13 +162,13 @@ export function typeCheckTable(valueType: Type.DefinedTable, schemaType: Type.Ta
 }
 
 function typeCheckGenericNumber<
-    Value extends Type.PowerQueryType | Type.FunctionParameter | undefined,
-    Schema extends Type.PowerQueryType | Type.FunctionParameter
+    Value extends Type.TPowerQueryType | Type.FunctionParameter | undefined,
+    Schema extends Type.TPowerQueryType | Type.FunctionParameter
 >(
     valueElements: ReadonlyArray<Value>,
     schemaItemTypes: ReadonlyArray<Schema>,
     valueCmpFn: (left: Value, right: Schema) => boolean | undefined,
-): IChecked<number, Value, Schema> {
+): IChecked<number, IMismatch<Value, Schema>> {
     const numElements: number = valueElements.length;
     const numItemTypes: number = schemaItemTypes.length;
 
@@ -172,7 +186,7 @@ function typeCheckGenericNumber<
     }
 
     const validIndices: number[] = [];
-    const mismatches: Mismatch<number, Value, Schema>[] = [];
+    const mismatches: Map<number, IMismatch<Value, Schema>> = new Map();
     for (let index: number = 0; index < upperBound; index += 1) {
         const element: Value = valueElements[index];
         const schemaItemType: Schema = schemaItemTypes[index];
@@ -180,8 +194,7 @@ function typeCheckGenericNumber<
         if (valueCmpFn(element, schemaItemType)) {
             validIndices.push(index);
         } else {
-            mismatches.push({
-                key: index,
+            mismatches.set(index, {
                 expected: schemaItemType,
                 actual: element,
             });
@@ -197,27 +210,26 @@ function typeCheckGenericNumber<
 }
 
 function typeCheckRecordOrTable(
-    valueFields: Map<string, Type.PowerQueryType>,
-    schemaFields: Map<string, Type.PowerQueryType>,
+    valueFields: Map<string, Type.TPowerQueryType>,
+    schemaFields: Map<string, Type.TPowerQueryType>,
     schemaIsOpen: boolean,
-): IChecked<string, Type.PowerQueryType, Type.PowerQueryType> {
+): IChecked<string, IMismatch<Type.TPowerQueryType, Type.TPowerQueryType>> {
     const validFields: string[] = [];
-    const mismatches: Mismatch<string, Type.PowerQueryType, Type.PowerQueryType>[] = [];
+    const mismatches: Map<string, IMismatch<Type.TPowerQueryType, Type.TPowerQueryType>> = new Map();
     const extraneousFields: string[] = [];
     const missingFields: ReadonlyArray<string> = [...schemaFields.keys()].filter(
         (key: string) => !valueFields.has(key),
     );
 
     for (const [key, type] of valueFields.entries()) {
-        const maybeSchemaValueType: Type.PowerQueryType | undefined = schemaFields.get(key);
+        const maybeSchemaValueType: Type.TPowerQueryType | undefined = schemaFields.get(key);
         if (maybeSchemaValueType !== undefined) {
-            const schemaValueType: Type.PowerQueryType = maybeSchemaValueType;
+            const schemaValueType: Type.TPowerQueryType = maybeSchemaValueType;
 
             if (isCompatible(type, schemaValueType)) {
                 validFields.push(key);
             } else {
-                mismatches.push({
-                    key,
+                mismatches.set(key, {
                     expected: schemaValueType,
                     actual: type,
                 });

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -35,11 +35,11 @@ export function typeKindFromLiteralKind(literalKind: Ast.LiteralKind): Type.Type
     }
 }
 
-export function isTypeInArray(collection: ReadonlyArray<Type.PowerQueryType>, item: Type.PowerQueryType): boolean {
+export function isTypeInArray(collection: ReadonlyArray<Type.TPowerQueryType>, item: Type.TPowerQueryType): boolean {
     // Fast comparison then deep comparison
     return (
         collection.includes(item) ||
-        collection.find((type: Type.PowerQueryType) => isEqualType(item, type)) !== undefined
+        collection.find((type: Type.TPowerQueryType) => isEqualType(item, type)) !== undefined
     );
 }
 
@@ -74,7 +74,7 @@ export function isTypeKind(text: string): text is Type.TypeKind {
 
 export function isValidInvocation(
     functionType: Type.DefinedFunction,
-    args: ReadonlyArray<Type.PowerQueryType>,
+    args: ReadonlyArray<Type.TPowerQueryType>,
 ): boolean {
     // You can't provide more arguments than are on the function signature.
     if (args.length > functionType.parameters.length) {
@@ -86,11 +86,11 @@ export function isValidInvocation(
 
     for (let index: number = 1; index < numParameters; index += 1) {
         const parameter: Type.FunctionParameter = Assert.asDefined(parameters[index]);
-        const maybeArgType: Type.PowerQueryType | undefined = args[index];
+        const maybeArgType: Type.TPowerQueryType | undefined = args[index];
 
         if (maybeArgType !== undefined) {
-            const argType: Type.PowerQueryType = maybeArgType;
-            const parameterType: Type.PowerQueryType = createPrimitiveType(
+            const argType: Type.TPowerQueryType = maybeArgType;
+            const parameterType: Type.TPowerQueryType = createPrimitiveType(
                 parameter.isNullable,
                 Assert.asDefined(parameter.maybeType),
             );

--- a/src/test/libraryTest/type/typeUtils/nameOf.ts
+++ b/src/test/libraryTest/type/typeUtils/nameOf.ts
@@ -182,11 +182,11 @@ describe(`TypeUtils.nameOf`, () => {
     describe(`extended`, () => {
         describe(`${Type.ExtendedTypeKind.AnyUnion}`, () => {
             it(`primitives`, () => {
-                const type: Type.PowerQueryType = TypeUtils.createAnyUnion([Type.NumberInstance, Type.ListInstance]);
+                const type: Type.TPowerQueryType = TypeUtils.createAnyUnion([Type.NumberInstance, Type.ListInstance]);
                 expect(TypeUtils.nameOf(type)).to.equal(`list | number`);
             });
             it(`complex`, () => {
-                const type: Type.PowerQueryType = TypeUtils.createAnyUnion([
+                const type: Type.TPowerQueryType = TypeUtils.createAnyUnion([
                     TypeUtils.createDefinedRecord(false, new Map([[`foo`, Type.NumberInstance]]), false),
                     TypeUtils.createDefinedList(false, [Type.TextInstance]),
                     TypeUtils.createDefinedTable(false, new Map([[`bar`, Type.TextInstance]]), true),
@@ -340,7 +340,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`[foo = number, bar = nullable text]`, () => {
                 const type: Type.DefinedRecord = TypeUtils.createDefinedRecord(
                     false,
-                    new Map<string, Type.PowerQueryType>([
+                    new Map<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`bar`, Type.NullableTextInstance],
                     ]),
@@ -354,7 +354,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`[foo = number, bar = nullable text, ...]`, () => {
                 const type: Type.DefinedRecord = TypeUtils.createDefinedRecord(
                     false,
-                    new Map<string, Type.PowerQueryType>([
+                    new Map<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`bar`, Type.NullableTextInstance],
                     ]),
@@ -382,7 +382,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`table [foo = number, bar = nullable text]`, () => {
                 const type: Type.DefinedTable = TypeUtils.createDefinedTable(
                     false,
-                    new Map<string, Type.PowerQueryType>([
+                    new Map<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`bar`, Type.NullableTextInstance],
                     ]),
@@ -396,7 +396,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`table [foo = number, bar = nullable text, ...]`, () => {
                 const type: Type.DefinedTable = TypeUtils.createDefinedTable(
                     false,
-                    new Map<string, Type.PowerQueryType>([
+                    new Map<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`bar`, Type.NullableTextInstance],
                     ]),
@@ -410,7 +410,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`table [#"foo" = number, #"space space"]`, () => {
                 const type: Type.DefinedTable = TypeUtils.createDefinedTable(
                     false,
-                    new Map<string, Type.PowerQueryType>([
+                    new Map<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`#"space space"`, Type.NullableTextInstance],
                     ]),
@@ -505,7 +505,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`type [foo = number, bar = nullable text]`, () => {
                 const type: Type.RecordType = TypeUtils.createRecordType(
                     false,
-                    new Map<string, Type.PowerQueryType>([
+                    new Map<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`bar`, Type.NullableTextInstance],
                     ]),
@@ -519,7 +519,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`type [foo = number, bar = nullable text, ...]`, () => {
                 const type: Type.RecordType = TypeUtils.createRecordType(
                     false,
-                    new Map<string, Type.PowerQueryType>([
+                    new Map<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`bar`, Type.NullableTextInstance],
                     ]),
@@ -551,7 +551,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`type table [foo = number, bar = nullable text]`, () => {
                 const type: Type.TableType = TypeUtils.createTableType(
                     false,
-                    new Map<string, Type.PowerQueryType>([
+                    new Map<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`bar`, Type.NullableTextInstance],
                     ]),
@@ -565,7 +565,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`type table [foo = number, bar = nullable text, ...]`, () => {
                 const type: Type.TableType = TypeUtils.createTableType(
                     false,
-                    new Map<string, Type.PowerQueryType>([
+                    new Map<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`bar`, Type.NullableTextInstance],
                     ]),

--- a/src/test/libraryTest/type/typeUtils/typeUtils.ts
+++ b/src/test/libraryTest/type/typeUtils/typeUtils.ts
@@ -20,7 +20,7 @@ function abridgedPrimitiveType(kind: Type.TypeKind, isNullable: boolean): Abridg
     };
 }
 
-function typeToAbridged(type: Type.PowerQueryType): AbridgedType {
+function typeToAbridged(type: Type.TPowerQueryType): AbridgedType {
     return {
         kind: type.kind,
         maybeExtendedKind: type.maybeExtendedKind,
@@ -28,7 +28,7 @@ function typeToAbridged(type: Type.PowerQueryType): AbridgedType {
     };
 }
 
-function createAbridgedTypes(types: ReadonlyArray<Type.PowerQueryType>): ReadonlyArray<AbridgedType> {
+function createAbridgedTypes(types: ReadonlyArray<Type.TPowerQueryType>): ReadonlyArray<AbridgedType> {
     return types.map(typeToAbridged);
 }
 
@@ -109,7 +109,7 @@ describe(`TypeUtils`, () => {
         });
 
         it(`${Type.ExtendedTypeKind.AnyUnion}, combine into a single primitive type`, () => {
-            const simplified: ReadonlyArray<Type.PowerQueryType> = TypeUtils.simplify([
+            const simplified: ReadonlyArray<Type.TPowerQueryType> = TypeUtils.simplify([
                 TypeUtils.createAnyUnion([Type.RecordInstance, Type.RecordInstance]),
                 TypeUtils.createAnyUnion([Type.RecordInstance, Type.RecordInstance]),
             ]);
@@ -121,7 +121,7 @@ describe(`TypeUtils`, () => {
         });
 
         it(`${Type.ExtendedTypeKind.AnyUnion}, dedupe primitive types across AnyUnion`, () => {
-            const simplified: ReadonlyArray<Type.PowerQueryType> = TypeUtils.simplify([
+            const simplified: ReadonlyArray<Type.TPowerQueryType> = TypeUtils.simplify([
                 TypeUtils.createAnyUnion([Type.RecordInstance, Type.NullableTableInstance]),
                 TypeUtils.createAnyUnion([Type.RecordInstance, Type.NullableTableInstance]),
             ]);
@@ -136,7 +136,7 @@ describe(`TypeUtils`, () => {
         });
 
         it(`${Type.ExtendedTypeKind.AnyUnion}, mixed nullability`, () => {
-            const simplified: ReadonlyArray<Type.PowerQueryType> = TypeUtils.simplify([
+            const simplified: ReadonlyArray<Type.TPowerQueryType> = TypeUtils.simplify([
                 TypeUtils.createAnyUnion([Type.NullableRecordInstance, Type.NullableTableInstance]),
                 TypeUtils.createAnyUnion([Type.RecordInstance, Type.TableInstance]),
             ]);
@@ -153,7 +153,7 @@ describe(`TypeUtils`, () => {
         });
 
         it(`${Type.ExtendedTypeKind.AnyUnion}, dedupe across multi level AnyUnion`, () => {
-            const simplified: ReadonlyArray<Type.PowerQueryType> = TypeUtils.simplify([
+            const simplified: ReadonlyArray<Type.TPowerQueryType> = TypeUtils.simplify([
                 TypeUtils.createAnyUnion([
                     Type.RecordInstance,
                     TypeUtils.createAnyUnion([Type.RecordInstance, Type.NumberInstance]),
@@ -171,7 +171,7 @@ describe(`TypeUtils`, () => {
         });
 
         it(`${Type.ExtendedTypeKind.AnyUnion}, short circuit with Any primitive in AnyUnion`, () => {
-            const simplified: ReadonlyArray<Type.PowerQueryType> = TypeUtils.simplify([
+            const simplified: ReadonlyArray<Type.TPowerQueryType> = TypeUtils.simplify([
                 TypeUtils.createAnyUnion([
                     Type.RecordInstance,
                     TypeUtils.createAnyUnion([Type.AnyInstance, Type.NumberInstance]),
@@ -360,14 +360,14 @@ describe(`TypeUtils`, () => {
         describe(`extended`, () => {
             describe(`${Type.ExtendedTypeKind.AnyUnion}`, () => {
                 it(`primitives`, () => {
-                    const type: Type.PowerQueryType = TypeUtils.createAnyUnion([
+                    const type: Type.TPowerQueryType = TypeUtils.createAnyUnion([
                         Type.NumberInstance,
                         Type.ListInstance,
                     ]);
                     expect(TypeUtils.nameOf(type)).to.equal(`list | number`);
                 });
                 it(`complex`, () => {
-                    const type: Type.PowerQueryType = TypeUtils.createAnyUnion([
+                    const type: Type.TPowerQueryType = TypeUtils.createAnyUnion([
                         TypeUtils.createDefinedRecord(false, new Map([["foo", Type.NumberInstance]]), false),
                         TypeUtils.createDefinedList(false, [Type.TextInstance]),
                         TypeUtils.createDefinedTable(false, new Map([["bar", Type.TextInstance]]), true),
@@ -500,7 +500,7 @@ describe(`TypeUtils`, () => {
                 it(`[foo = number, bar = nullable text]`, () => {
                     const type: Type.DefinedRecord = TypeUtils.createDefinedRecord(
                         false,
-                        new Map<string, Type.PowerQueryType>([
+                        new Map<string, Type.TPowerQueryType>([
                             ["foo", Type.NumberInstance],
                             ["bar", Type.NullableTextInstance],
                         ]),
@@ -514,7 +514,7 @@ describe(`TypeUtils`, () => {
                 it(`[foo = number, bar = nullable text, ...]`, () => {
                     const type: Type.DefinedRecord = TypeUtils.createDefinedRecord(
                         false,
-                        new Map<string, Type.PowerQueryType>([
+                        new Map<string, Type.TPowerQueryType>([
                             ["foo", Type.NumberInstance],
                             ["bar", Type.NullableTextInstance],
                         ]),
@@ -542,7 +542,7 @@ describe(`TypeUtils`, () => {
                 it(`table [foo = number, bar = nullable text]`, () => {
                     const type: Type.DefinedTable = TypeUtils.createDefinedTable(
                         false,
-                        new Map<string, Type.PowerQueryType>([
+                        new Map<string, Type.TPowerQueryType>([
                             ["foo", Type.NumberInstance],
                             ["bar", Type.NullableTextInstance],
                         ]),
@@ -556,7 +556,7 @@ describe(`TypeUtils`, () => {
                 it(`table [foo = number, bar = nullable text, ...]`, () => {
                     const type: Type.DefinedTable = TypeUtils.createDefinedTable(
                         false,
-                        new Map<string, Type.PowerQueryType>([
+                        new Map<string, Type.TPowerQueryType>([
                             ["foo", Type.NumberInstance],
                             ["bar", Type.NullableTextInstance],
                         ]),
@@ -653,7 +653,7 @@ describe(`TypeUtils`, () => {
                 it(`type [foo = number, bar = nullable text]`, () => {
                     const type: Type.RecordType = TypeUtils.createRecordType(
                         false,
-                        new Map<string, Type.PowerQueryType>([
+                        new Map<string, Type.TPowerQueryType>([
                             ["foo", Type.NumberInstance],
                             ["bar", Type.NullableTextInstance],
                         ]),
@@ -667,7 +667,7 @@ describe(`TypeUtils`, () => {
                 it(`type [foo = number, bar = nullable text, ...]`, () => {
                     const type: Type.RecordType = TypeUtils.createRecordType(
                         false,
-                        new Map<string, Type.PowerQueryType>([
+                        new Map<string, Type.TPowerQueryType>([
                             ["foo", Type.NumberInstance],
                             ["bar", Type.NullableTextInstance],
                         ]),
@@ -699,7 +699,7 @@ describe(`TypeUtils`, () => {
                 it(`type table [foo = number, bar = nullable text]`, () => {
                     const type: Type.TableType = TypeUtils.createTableType(
                         false,
-                        new Map<string, Type.PowerQueryType>([
+                        new Map<string, Type.TPowerQueryType>([
                             ["foo", Type.NumberInstance],
                             ["bar", Type.NullableTextInstance],
                         ]),
@@ -713,7 +713,7 @@ describe(`TypeUtils`, () => {
                 it(`type table [foo = number, bar = nullable text, ...]`, () => {
                     const type: Type.TableType = TypeUtils.createTableType(
                         false,
-                        new Map<string, Type.PowerQueryType>([
+                        new Map<string, Type.TPowerQueryType>([
                             ["foo", Type.NumberInstance],
                             ["bar", Type.NullableTextInstance],
                         ]),


### PR DESCRIPTION
Type checking use to return `ReadonlyArray<Mismatch<Key, Actual, Expected>>`, where Mismatch was:

```
export interface Mismatch<Key, Actual, Expected> {
    readonly key: Key;
    readonly expected: Expected;
    readonly actual: Actual;
}
```

I can't think of a reason why I initially did it that way, and to make things easier downstream I'm converting it to `Map<Key, Mismatch<Actual, Expected>` and stripping out key from the Mismatch interface.

The second change is to rename PowerQueryType to TPowerQueryType. This follows the existing naming standards where a T prefix is placed on type aliases that are a union of tagged union types.