### PR TITLE
Add OrderedMap for Table type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/index.ts
+++ b/src/powerquery-parser/common/index.ts
@@ -13,5 +13,6 @@ export * as TypeScriptUtils from "./typeScriptTypeUtils";
 
 export * from "./cancellationToken";
 export * from "./immutableSet";
+export * from "./orderedMap";
 export * from "./partialResult";
 export * from "./result";

--- a/src/powerquery-parser/common/orderedMap.ts
+++ b/src/powerquery-parser/common/orderedMap.ts
@@ -21,6 +21,7 @@ export class OrderedMap<K, V> implements Map<K, V> {
             this.size = entries.length;
         }
     }
+    
     public [Symbol.iterator](): IterableIterator<[K, V]> {
         return this.entries();
     }

--- a/src/powerquery-parser/common/orderedMap.ts
+++ b/src/powerquery-parser/common/orderedMap.ts
@@ -2,16 +2,15 @@
 // Licensed under the MIT license.
 
 import { ArrayUtils, Assert } from ".";
-import { TPowerQueryType } from "../language/type/type";
 
-export class OrderedMap implements Map<string, TPowerQueryType> {
+export class OrderedMap<K, V> implements Map<K, V> {
     public size: number;
     public [Symbol.toStringTag]: string;
 
-    private readonly map: Map<string, TPowerQueryType>;
-    private order: ReadonlyArray<string>;
+    private readonly map: Map<K, V>;
+    private order: ReadonlyArray<K>;
 
-    constructor(entries?: readonly (readonly [string, TPowerQueryType])[] | null | undefined) {
+    constructor(entries?: readonly (readonly [K, V])[] | null | undefined) {
         if (!entries) {
             this.map = new Map();
             this.order = [];
@@ -22,7 +21,7 @@ export class OrderedMap implements Map<string, TPowerQueryType> {
             this.size = entries.length;
         }
     }
-    public [Symbol.iterator](): IterableIterator<[string, TPowerQueryType]> {
+    public [Symbol.iterator](): IterableIterator<[K, V]> {
         return this.entries();
     }
 
@@ -31,7 +30,7 @@ export class OrderedMap implements Map<string, TPowerQueryType> {
         this.order = [];
     }
 
-    public delete(key: string): boolean {
+    public delete(key: K): boolean {
         if (this.map.delete(key)) {
             this.order = ArrayUtils.removeFirstInstance(this.order, key);
             return true;
@@ -40,31 +39,31 @@ export class OrderedMap implements Map<string, TPowerQueryType> {
         }
     }
 
-    public *entries(): IterableIterator<[string, TPowerQueryType]> {
+    public *entries(): IterableIterator<[K, V]> {
         for (const key of this.order) {
             yield [key, Assert.asDefined(this.map.get(key))];
         }
     }
 
-    public forEach(callbackfn: (value: TPowerQueryType, key: string, map: Map<string, TPowerQueryType>) => void): void {
+    public forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void): void {
         for (const [key, value] of this.entries()) {
             callbackfn(value, key, this.map);
         }
     }
 
-    public get(key: string): TPowerQueryType | undefined {
+    public get(key: K): V | undefined {
         return this.map.get(key);
     }
 
-    public has(key: string): boolean {
+    public has(key: K): boolean {
         return this.map.has(key);
     }
 
-    public keys(): IterableIterator<string> {
+    public keys(): IterableIterator<K> {
         return this.map.keys();
     }
 
-    public set(key: string, value: TPowerQueryType, maintainIndex?: boolean): this {
+    public set(key: K, value: V, maintainIndex?: boolean): this {
         if (this.has(key)) {
             if (!maintainIndex) {
                 this.order = [...ArrayUtils.removeFirstInstance(this.order, key), key];
@@ -77,7 +76,7 @@ export class OrderedMap implements Map<string, TPowerQueryType> {
         return this;
     }
 
-    public values(): IterableIterator<TPowerQueryType> {
+    public values(): IterableIterator<V> {
         return this.map.values();
     }
 }

--- a/src/powerquery-parser/common/orderedMap.ts
+++ b/src/powerquery-parser/common/orderedMap.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ArrayUtils, Assert } from ".";
+import { TPowerQueryType } from "../language/type/type";
+
+export class OrderedMap implements Map<string, TPowerQueryType> {
+    public size: number;
+    public [Symbol.toStringTag]: string;
+
+    private readonly map: Map<string, TPowerQueryType>;
+    private order: ReadonlyArray<string>;
+
+    constructor(entries?: readonly (readonly [string, TPowerQueryType])[] | null | undefined) {
+        if (!entries) {
+            this.map = new Map();
+            this.order = [];
+            this.size = 0;
+        } else {
+            this.map = new Map(entries);
+            this.order = entries.map(pair => pair[0]);
+            this.size = entries.length;
+        }
+    }
+    public [Symbol.iterator](): IterableIterator<[string, TPowerQueryType]> {
+        return this.entries();
+    }
+
+    public clear(): void {
+        this.map.clear();
+        this.order = [];
+    }
+
+    public delete(key: string): boolean {
+        if (this.map.delete(key)) {
+            this.order = ArrayUtils.removeFirstInstance(this.order, key);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public *entries(): IterableIterator<[string, TPowerQueryType]> {
+        for (const key of this.order) {
+            yield [key, Assert.asDefined(this.map.get(key))];
+        }
+    }
+
+    public forEach(callbackfn: (value: TPowerQueryType, key: string, map: Map<string, TPowerQueryType>) => void): void {
+        for (const [key, value] of this.entries()) {
+            callbackfn(value, key, this.map);
+        }
+    }
+
+    public get(key: string): TPowerQueryType | undefined {
+        return this.map.get(key);
+    }
+
+    public has(key: string): boolean {
+        return this.map.has(key);
+    }
+
+    public keys(): IterableIterator<string> {
+        return this.map.keys();
+    }
+
+    public set(key: string, value: TPowerQueryType, maintainIndex?: boolean): this {
+        if (this.has(key)) {
+            if (!maintainIndex) {
+                this.order = [...ArrayUtils.removeFirstInstance(this.order, key), key];
+            }
+        } else {
+            this.order = [...this.order, key];
+        }
+
+        this.map.set(key, value);
+        return this;
+    }
+
+    public values(): IterableIterator<TPowerQueryType> {
+        return this.map.values();
+    }
+}

--- a/src/powerquery-parser/language/type/type.ts
+++ b/src/powerquery-parser/language/type/type.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { OrderedMap } from "../../common";
+
 // A representation of a type can be either an extended type, or a non-extended type.
 // Non-extended types are the types you traditionally find in Power Query, eg. `number`, `text`, etc.
 //
@@ -102,6 +104,13 @@ export type TPrimitiveType =
     | Time
     | Type
     | Unknown;
+
+// Key value pairs for Records and Tables,
+// where tables have ordered pairs and records have unordered pairs.
+export type TFieldSpecificationList = FieldSpecificationList<TFields>;
+export type TFields = OrderedFields | UnorderedFields;
+export type OrderedFields = OrderedMap<string, TPowerQueryType>;
+export type UnorderedFields = Map<string, TPowerQueryType>;
 
 export const enum TypeKind {
     Any = "Any",
@@ -210,8 +219,8 @@ export interface IPrimitiveType<T extends TypeKind = TypeKind> extends IType<T> 
 // ---------- Non-IType Interfaces ----------
 // ------------------------------------------
 
-export interface FieldSpecificationList {
-    readonly fields: Map<string, TPowerQueryType>;
+export interface FieldSpecificationList<T extends TFields> {
+    readonly fields: T;
     readonly isOpen: boolean;
 }
 
@@ -265,13 +274,13 @@ export interface DefinedListType extends IExtendedType {
 }
 
 export type DefinedRecord = IExtendedType &
-    FieldSpecificationList & {
+    FieldSpecificationList<UnorderedFields> & {
         readonly kind: TypeKind.Record;
         readonly maybeExtendedKind: ExtendedTypeKind.DefinedRecord;
     };
 
 export type DefinedTable = IExtendedType &
-    FieldSpecificationList & {
+    FieldSpecificationList<OrderedFields> & {
         readonly kind: TypeKind.Table;
         readonly maybeExtendedKind: ExtendedTypeKind.DefinedTable;
     };
@@ -307,13 +316,13 @@ export interface PrimaryPrimitiveType extends IExtendedType {
 }
 
 export type RecordType = IExtendedType &
-    FieldSpecificationList & {
+    FieldSpecificationList<UnorderedFields> & {
         readonly kind: TypeKind.Type;
         readonly maybeExtendedKind: ExtendedTypeKind.RecordType;
     };
 
 export type TableType = IExtendedType &
-    FieldSpecificationList & {
+    FieldSpecificationList<UnorderedFields> & {
         readonly kind: TypeKind.Type;
         readonly maybeExtendedKind: ExtendedTypeKind.TableType;
     };

--- a/src/powerquery-parser/language/type/typeUtils/assert.ts
+++ b/src/powerquery-parser/language/type/typeUtils/assert.ts
@@ -660,8 +660,8 @@ export function assertIsUnknown(type: Type.TPowerQueryType): asserts type is Typ
 }
 
 interface AssertErrorDetails {
-    givenTypeKind: Type.TypeKind;
-    givenExtendedTypeKind: Type.ExtendedTypeKind | undefined;
-    expectedTypeKind: Type.TypeKind | ReadonlyArray<Type.TypeKind>;
-    expectedExtendedTypeKind: undefined | ReadonlyArray<Type.ExtendedTypeKind | undefined>;
+    readonly givenTypeKind: Type.TypeKind;
+    readonly givenExtendedTypeKind: Type.ExtendedTypeKind | undefined;
+    readonly expectedTypeKind: Type.TypeKind | ReadonlyArray<Type.TypeKind>;
+    readonly expectedExtendedTypeKind: undefined | ReadonlyArray<Type.ExtendedTypeKind | undefined>;
 }

--- a/src/powerquery-parser/language/type/typeUtils/factories.ts
+++ b/src/powerquery-parser/language/type/typeUtils/factories.ts
@@ -84,7 +84,7 @@ export function createDefinedRecord(
 
 export function createDefinedTable(
     isNullable: boolean,
-    fields: Map<string, Type.TPowerQueryType>,
+    fields: Type.OrderedFields,
     isOpen: boolean,
 ): Type.DefinedTable {
     return {

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -198,7 +198,7 @@ function isCompatibleWithDefinedTable(left: Type.TPowerQueryType, right: Type.De
 // TODO: decide what a compatible FieldSpecificationList should look like
 function isCompatibleWithFieldSpecificationList(
     left: Type.TPowerQueryType,
-    right: Type.TPowerQueryType & Type.FieldSpecificationList,
+    right: Type.TPowerQueryType & Type.TFieldSpecificationList,
 ): boolean {
     if (!isCompatibleWithNullable(left, right) || !isFieldSpecificationList(left)) {
         return false;

--- a/src/powerquery-parser/language/type/typeUtils/isEqualType.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isEqualType.ts
@@ -187,8 +187,8 @@ export function isEqualPrimaryPrimitiveType(
 }
 
 export function isEqualFieldSpecificationList(
-    left: Type.FieldSpecificationList,
-    right: Type.FieldSpecificationList,
+    left: Type.TFieldSpecificationList,
+    right: Type.TFieldSpecificationList,
 ): boolean {
     if (left === right) {
         return true;

--- a/src/powerquery-parser/language/type/typeUtils/isType.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isType.ts
@@ -62,7 +62,7 @@ export function isDuration(type: Type.TPowerQueryType): type is Type.Duration {
 
 export function isFieldSpecificationList(
     type: Type.TPowerQueryType,
-): type is Type.TPowerQueryType & Type.FieldSpecificationList {
+): type is Type.TPowerQueryType & Type.TFieldSpecificationList {
     return (
         (type.kind === Type.TypeKind.Record && type.maybeExtendedKind === Type.ExtendedTypeKind.DefinedRecord) ||
         (type.kind === Type.TypeKind.Table && type.maybeExtendedKind === Type.ExtendedTypeKind.DefinedTable) ||

--- a/src/powerquery-parser/language/type/typeUtils/nameOf.ts
+++ b/src/powerquery-parser/language/type/typeUtils/nameOf.ts
@@ -88,7 +88,7 @@ export function nameOfTypeKind(kind: Type.TypeKind): string {
     return kind === Type.TypeKind.NotApplicable ? "not applicable" : kind.toLowerCase();
 }
 
-function nameOfFieldSpecificationList(type: Type.FieldSpecificationList): string {
+function nameOfFieldSpecificationList(type: Type.TFieldSpecificationList): string {
     const chunks: string[] = [];
 
     for (const [key, value] of type.fields.entries()) {

--- a/src/test/libraryTest/type/typeUtils/nameOf.ts
+++ b/src/test/libraryTest/type/typeUtils/nameOf.ts
@@ -3,6 +3,7 @@
 
 import { expect } from "chai";
 import "mocha";
+import { OrderedMap } from "../../../../powerquery-parser";
 
 import { Type, TypeUtils } from "../../../../powerquery-parser/language";
 
@@ -189,7 +190,7 @@ describe(`TypeUtils.nameOf`, () => {
                 const type: Type.TPowerQueryType = TypeUtils.createAnyUnion([
                     TypeUtils.createDefinedRecord(false, new Map([[`foo`, Type.NumberInstance]]), false),
                     TypeUtils.createDefinedList(false, [Type.TextInstance]),
-                    TypeUtils.createDefinedTable(false, new Map([[`bar`, Type.TextInstance]]), true),
+                    TypeUtils.createDefinedTable(false, new OrderedMap([[`bar`, Type.TextInstance]]), true),
                 ]);
                 const actual: string = TypeUtils.nameOf(type);
                 expect(actual).to.equal(`{text} | [foo: number] | table [bar: text, ...]`);
@@ -368,13 +369,13 @@ describe(`TypeUtils.nameOf`, () => {
 
         describe(`${Type.ExtendedTypeKind.DefinedTable}`, () => {
             it(`table []`, () => {
-                const type: Type.DefinedTable = TypeUtils.createDefinedTable(false, new Map(), false);
+                const type: Type.DefinedTable = TypeUtils.createDefinedTable(false, new OrderedMap(), false);
                 const actual: string = TypeUtils.nameOf(type);
                 expect(actual).to.equal(`table []`);
             });
 
             it(`table [...]`, () => {
-                const type: Type.DefinedTable = TypeUtils.createDefinedTable(false, new Map(), true);
+                const type: Type.DefinedTable = TypeUtils.createDefinedTable(false, new OrderedMap(), true);
                 const actual: string = TypeUtils.nameOf(type);
                 expect(actual).to.equal(`table [...]`);
             });
@@ -382,7 +383,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`table [foo = number, bar = nullable text]`, () => {
                 const type: Type.DefinedTable = TypeUtils.createDefinedTable(
                     false,
-                    new Map<string, Type.TPowerQueryType>([
+                    new OrderedMap<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`bar`, Type.NullableTextInstance],
                     ]),
@@ -396,7 +397,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`table [foo = number, bar = nullable text, ...]`, () => {
                 const type: Type.DefinedTable = TypeUtils.createDefinedTable(
                     false,
-                    new Map<string, Type.TPowerQueryType>([
+                    new OrderedMap<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`bar`, Type.NullableTextInstance],
                     ]),
@@ -410,7 +411,7 @@ describe(`TypeUtils.nameOf`, () => {
             it(`table [#"foo" = number, #"space space"]`, () => {
                 const type: Type.DefinedTable = TypeUtils.createDefinedTable(
                     false,
-                    new Map<string, Type.TPowerQueryType>([
+                    new OrderedMap<string, Type.TPowerQueryType>([
                         [`foo`, Type.NumberInstance],
                         [`#"space space"`, Type.NullableTextInstance],
                     ]),

--- a/src/test/libraryTest/type/typeUtils/typeCheck.ts
+++ b/src/test/libraryTest/type/typeUtils/typeCheck.ts
@@ -4,6 +4,7 @@
 import { expect } from "chai";
 import "mocha";
 import { Language } from "../../../..";
+import { OrderedMap } from "../../../../powerquery-parser";
 
 interface AbridgedChecked<K = number | string> {
     readonly valid: ReadonlyArray<K>;
@@ -657,7 +658,7 @@ describe(`TypeUtils.typeCheck`, () => {
         it(`${Language.Type.ExtendedTypeKind.DefinedTable}`, () => {
             const valueType: Language.Type.DefinedTable = Language.TypeUtils.createDefinedTable(
                 false,
-                new Map<string, Language.Type.TPowerQueryType>([
+                new OrderedMap<string, Language.Type.TPowerQueryType>([
                     ["number", Language.Type.NullableNumberInstance],
                     ["nullableNumber", Language.Type.NullableNumberInstance],
                     ["table", Language.Type.TableInstance],

--- a/src/test/libraryTest/type/typeUtils/typeUtils.ts
+++ b/src/test/libraryTest/type/typeUtils/typeUtils.ts
@@ -3,6 +3,7 @@
 
 import { expect } from "chai";
 import "mocha";
+import { OrderedMap } from "../../../../powerquery-parser";
 
 import { Type, TypeUtils } from "../../../../powerquery-parser/language";
 
@@ -370,7 +371,7 @@ describe(`TypeUtils`, () => {
                     const type: Type.TPowerQueryType = TypeUtils.createAnyUnion([
                         TypeUtils.createDefinedRecord(false, new Map([["foo", Type.NumberInstance]]), false),
                         TypeUtils.createDefinedList(false, [Type.TextInstance]),
-                        TypeUtils.createDefinedTable(false, new Map([["bar", Type.TextInstance]]), true),
+                        TypeUtils.createDefinedTable(false, new OrderedMap([["bar", Type.TextInstance]]), true),
                     ]);
                     const actual: string = TypeUtils.nameOf(type);
                     expect(actual).to.equal(`{text} | [foo: number] | table [bar: text, ...]`);
@@ -528,13 +529,13 @@ describe(`TypeUtils`, () => {
 
             describe(`${Type.ExtendedTypeKind.DefinedTable}`, () => {
                 it(`table []`, () => {
-                    const type: Type.DefinedTable = TypeUtils.createDefinedTable(false, new Map(), false);
+                    const type: Type.DefinedTable = TypeUtils.createDefinedTable(false, new OrderedMap(), false);
                     const actual: string = TypeUtils.nameOf(type);
                     expect(actual).to.equal(`table []`);
                 });
 
                 it(`table [...]`, () => {
-                    const type: Type.DefinedTable = TypeUtils.createDefinedTable(false, new Map(), true);
+                    const type: Type.DefinedTable = TypeUtils.createDefinedTable(false, new OrderedMap(), true);
                     const actual: string = TypeUtils.nameOf(type);
                     expect(actual).to.equal(`table [...]`);
                 });
@@ -542,7 +543,7 @@ describe(`TypeUtils`, () => {
                 it(`table [foo = number, bar = nullable text]`, () => {
                     const type: Type.DefinedTable = TypeUtils.createDefinedTable(
                         false,
-                        new Map<string, Type.TPowerQueryType>([
+                        new OrderedMap<string, Type.TPowerQueryType>([
                             ["foo", Type.NumberInstance],
                             ["bar", Type.NullableTextInstance],
                         ]),
@@ -556,7 +557,7 @@ describe(`TypeUtils`, () => {
                 it(`table [foo = number, bar = nullable text, ...]`, () => {
                     const type: Type.DefinedTable = TypeUtils.createDefinedTable(
                         false,
-                        new Map<string, Type.TPowerQueryType>([
+                        new OrderedMap<string, Type.TPowerQueryType>([
                             ["foo", Type.NumberInstance],
                             ["bar", Type.NullableTextInstance],
                         ]),


### PR DESCRIPTION
I started working on some more smart function type resolvers and realized table types need ordering in order to support certain functions like Table.ReorderColumns