### PR TITLE
Fixes for TypeUtils.isCompatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1340,9 +1340,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "tslint-config-prettier": "^1.18.0",
         "tslint-microsoft-contrib": "^6.2.0",
         "tslint-plugin-prettier": "^2.3.0",
-        "typescript": "^3.8.3"
+        "typescript": "^4.3.5"
     },
     "files": [
         "lib/powerquery-parser/**/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/orderedMap.ts
+++ b/src/powerquery-parser/common/orderedMap.ts
@@ -10,18 +10,23 @@ export class OrderedMap<K, V> implements Map<K, V> {
     private readonly map: Map<K, V>;
     private order: ReadonlyArray<K>;
 
-    constructor(entries?: readonly (readonly [K, V])[] | null | undefined) {
+    constructor(entries?: readonly (readonly [K, V])[] | null | undefined | Map<K, V>) {
         if (!entries) {
             this.map = new Map();
             this.order = [];
             this.size = 0;
         } else {
             this.map = new Map(entries);
-            this.order = entries.map(pair => pair[0]);
-            this.size = entries.length;
+            if (entries instanceof Map) {
+                this.order = [...entries.keys()];
+                this.size = entries.size;
+            } else {
+                this.order = entries.map(pair => pair[0]);
+                this.size = entries.length;
+            }
         }
     }
-    
+
     public [Symbol.iterator](): IterableIterator<[K, V]> {
         return this.entries();
     }

--- a/src/powerquery-parser/language/type/type.ts
+++ b/src/powerquery-parser/language/type/type.ts
@@ -207,8 +207,9 @@ export interface IExtendedType extends IType {
     readonly maybeExtendedKind: ExtendedTypeKind;
 }
 
-export interface IPrimitiveLiteral extends IExtendedType {
+export interface IPrimitiveLiteral<T> extends IExtendedType {
     readonly literal: string;
+    readonly normalizedLiteral: T;
 }
 
 export interface IPrimitiveType<T extends TypeKind = TypeKind> extends IType<T> {
@@ -297,16 +298,14 @@ export interface ListType extends IExtendedType {
     readonly itemType: TPowerQueryType;
 }
 
-export interface LogicalLiteral extends IPrimitiveLiteral {
+export interface LogicalLiteral extends IPrimitiveLiteral<boolean> {
     readonly kind: TypeKind.Logical;
     readonly maybeExtendedKind: ExtendedTypeKind.LogicalLiteral;
-    readonly normalizedLiteral: boolean;
 }
 
-export interface NumberLiteral extends IPrimitiveLiteral {
+export interface NumberLiteral extends IPrimitiveLiteral<number> {
     readonly kind: TypeKind.Number;
     readonly maybeExtendedKind: ExtendedTypeKind.NumberLiteral;
-    readonly normalizedLiteral: number;
 }
 
 export interface PrimaryPrimitiveType extends IExtendedType {
@@ -333,7 +332,7 @@ export interface TableTypePrimaryExpression extends IExtendedType {
     readonly primaryExpression: TPowerQueryType;
 }
 
-export interface TextLiteral extends IPrimitiveLiteral {
+export interface TextLiteral extends IPrimitiveLiteral<string> {
     readonly kind: TypeKind.Text;
     readonly maybeExtendedKind: ExtendedTypeKind.TextLiteral;
 }

--- a/src/powerquery-parser/language/type/typeUtils/factories.ts
+++ b/src/powerquery-parser/language/type/typeUtils/factories.ts
@@ -110,13 +110,22 @@ export function createFunctionType(
     };
 }
 
-export function createNumberLiteral(isNullable: boolean, literal: string): Type.NumberLiteral {
+export function createLogicalLiteral(isNullable: boolean, literal: string): Type.LogicalLiteral {
+    let normalizedLiteral: boolean;
+    if (literal === "true") {
+        normalizedLiteral = true;
+    } else if (literal === "false") {
+        normalizedLiteral = false;
+    } else {
+        throw new CommonError.InvariantError(`invalid boolean string`);
+    }
+
     return {
         isNullable,
-        kind: Type.TypeKind.Number,
-        maybeExtendedKind: Type.ExtendedTypeKind.NumberLiteral,
+        kind: Type.TypeKind.Logical,
+        maybeExtendedKind: Type.ExtendedTypeKind.LogicalLiteral,
         literal,
-        normalizedLiteral: Number.parseFloat(Assert.asDefined(StringUtils.maybeNormalizeNumber(literal))),
+        normalizedLiteral,
     };
 }
 
@@ -126,6 +135,16 @@ export function createListType(isNullable: boolean, itemType: Type.TPowerQueryTy
         maybeExtendedKind: Type.ExtendedTypeKind.ListType,
         isNullable,
         itemType,
+    };
+}
+
+export function createNumberLiteral(isNullable: boolean, literal: string): Type.NumberLiteral {
+    return {
+        isNullable,
+        kind: Type.TypeKind.Number,
+        maybeExtendedKind: Type.ExtendedTypeKind.NumberLiteral,
+        literal,
+        normalizedLiteral: Number.parseFloat(Assert.asDefined(StringUtils.maybeNormalizeNumber(literal))),
     };
 }
 

--- a/src/powerquery-parser/language/type/typeUtils/factories.ts
+++ b/src/powerquery-parser/language/type/typeUtils/factories.ts
@@ -114,17 +114,11 @@ export function createLogicalLiteral(isNullable: boolean, literal: string | bool
     let parsedLiteral: string;
     let normalizedLiteral: boolean;
 
-    if (literal === true) {
+    if (literal === true || literal === "true") {
         parsedLiteral = "true";
         normalizedLiteral = true;
-    } else if (literal === false) {
+    } else if (literal === false || literal === "false") {
         parsedLiteral = "false";
-        normalizedLiteral = false;
-    } else if (literal === "true") {
-        parsedLiteral = literal;
-        normalizedLiteral = true;
-    } else if (literal === "false") {
-        parsedLiteral = literal;
         normalizedLiteral = false;
     } else {
         throw new CommonError.InvariantError(`invalid boolean string`);

--- a/src/powerquery-parser/language/type/typeUtils/factories.ts
+++ b/src/powerquery-parser/language/type/typeUtils/factories.ts
@@ -110,11 +110,21 @@ export function createFunctionType(
     };
 }
 
-export function createLogicalLiteral(isNullable: boolean, literal: string): Type.LogicalLiteral {
+export function createLogicalLiteral(isNullable: boolean, literal: string | boolean): Type.LogicalLiteral {
+    let parsedLiteral: string;
     let normalizedLiteral: boolean;
-    if (literal === "true") {
+
+    if (literal === true) {
+        parsedLiteral = "true";
+        normalizedLiteral = true;
+    } else if (literal === false) {
+        parsedLiteral = "false";
+        normalizedLiteral = false;
+    } else if (literal === "true") {
+        parsedLiteral = literal;
         normalizedLiteral = true;
     } else if (literal === "false") {
+        parsedLiteral = literal;
         normalizedLiteral = false;
     } else {
         throw new CommonError.InvariantError(`invalid boolean string`);
@@ -124,7 +134,7 @@ export function createLogicalLiteral(isNullable: boolean, literal: string): Type
         isNullable,
         kind: Type.TypeKind.Logical,
         maybeExtendedKind: Type.ExtendedTypeKind.LogicalLiteral,
-        literal,
+        literal: parsedLiteral,
         normalizedLiteral,
     };
 }
@@ -138,13 +148,24 @@ export function createListType(isNullable: boolean, itemType: Type.TPowerQueryTy
     };
 }
 
-export function createNumberLiteral(isNullable: boolean, literal: string): Type.NumberLiteral {
+export function createNumberLiteral(isNullable: boolean, literal: string | number): Type.NumberLiteral {
+    let parsedLiteral: string;
+    let normalizedLiteral: number;
+
+    if (typeof literal === "number") {
+        parsedLiteral = literal.toString();
+        normalizedLiteral = literal;
+    } else {
+        parsedLiteral = literal;
+        normalizedLiteral = Number.parseFloat(Assert.asDefined(StringUtils.maybeNormalizeNumber(literal)));
+    }
+
     return {
         isNullable,
         kind: Type.TypeKind.Number,
         maybeExtendedKind: Type.ExtendedTypeKind.NumberLiteral,
-        literal,
-        normalizedLiteral: Number.parseFloat(Assert.asDefined(StringUtils.maybeNormalizeNumber(literal))),
+        literal: parsedLiteral,
+        normalizedLiteral,
     };
 }
 

--- a/src/powerquery-parser/language/type/typeUtils/factories.ts
+++ b/src/powerquery-parser/language/type/typeUtils/factories.ts
@@ -219,6 +219,7 @@ export function createTextLiteral(isNullable: boolean, literal: string): Type.Te
         kind: Type.TypeKind.Text,
         maybeExtendedKind: Type.ExtendedTypeKind.TextLiteral,
         literal,
+        normalizedLiteral: literal,
     };
 }
 

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -52,10 +52,10 @@ export function isCompatible(left: Type.TPowerQueryType, right: Type.TPowerQuery
             return isCompatibleWithList(left, right);
 
         case Type.TypeKind.Logical:
-            return isCompatibleWithPrimitiveOrLiteralPrimitive(left, right);
+            return isCompatibleWithPrimitiveOrLiteral(left, right);
 
         case Type.TypeKind.Number:
-            return isCompatibleWithPrimitiveOrLiteralPrimitive(left, right);
+            return isCompatibleWithPrimitiveOrLiteral(left, right);
 
         case Type.TypeKind.Null:
             return left.kind === Type.TypeKind.Null;
@@ -67,7 +67,7 @@ export function isCompatible(left: Type.TPowerQueryType, right: Type.TPowerQuery
             return isCompatibleWithTable(left, right);
 
         case Type.TypeKind.Text:
-            return isCompatibleWithPrimitiveOrLiteralPrimitive(left, right);
+            return isCompatibleWithPrimitiveOrLiteral(left, right);
 
         case Type.TypeKind.Type:
             return isCompatibleWithType(left, right);
@@ -431,19 +431,19 @@ function isCompatibleWithTableTypePrimaryExpression(
     }
 }
 
-function isCompatibleWithPrimitiveOrLiteralPrimitive(
-    left: Type.TPowerQueryType,
-    right: Type.TLogical | Type.TText | Type.TNumber,
-): boolean {
-    return left.kind === right.kind && (!right.maybeExtendedKind || isCompatibleWithLiteral(left, right));
-}
-
 function isCompatibleWithLiteral<T extends Type.TLiteral>(left: Type.TPowerQueryType, right: T): boolean {
     if (left.kind !== right.kind || !left.maybeExtendedKind || left.maybeExtendedKind !== right.maybeExtendedKind) {
         return false;
     } else {
         return left.normalizedLiteral === right.normalizedLiteral;
     }
+}
+
+function isCompatibleWithPrimitiveOrLiteral(
+    left: Type.TPowerQueryType,
+    right: Type.TLogical | Type.TText | Type.TNumber,
+): boolean {
+    return left.kind === right.kind && (!right.maybeExtendedKind || isCompatibleWithLiteral(left, right));
 }
 
 function isCompatibleWithType(

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -43,7 +43,7 @@ export function isCompatible(left: Type.TPowerQueryType, right: Type.TPowerQuery
             return isCompatibleWithAny(left, right);
 
         case Type.TypeKind.AnyNonNull:
-            return left.kind !== right.kind;
+            return left.kind !== Type.TypeKind.Null && !left.isNullable;
 
         case Type.TypeKind.Function:
             return isCompatibleWithFunction(left, right);
@@ -522,6 +522,6 @@ function isDefinedListTypeCompatibleWithListType(definedList: Type.DefinedListTy
     const itemTypeCompatabilities: ReadonlyArray<boolean | undefined> = definedList.itemTypes.map(itemType =>
         isCompatible(itemType, listType.itemType),
     );
-    // !itemTypeCompatabilities.includes(undefined) && !itemTypeCompatabilities.includes(false);
+
     return itemTypeCompatabilities.find(value => value === undefined || value === false) !== undefined;
 }

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -125,8 +125,20 @@ function isCompatibleWithDefinedList(left: Type.TPowerQueryType, right: Type.Def
         case undefined:
             return false;
 
-        case Type.ExtendedTypeKind.DefinedList:
-            return isEqualType(left, right);
+        case Type.ExtendedTypeKind.DefinedList: {
+            if (left.elements.length !== right.elements.length) {
+                return false;
+            }
+
+            const numElements: number = left.elements.length;
+            for (let index: number = 0; index < numElements; index += 1) {
+                if (!isCompatible(left.elements[index], right.elements[index])) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
 
         default:
             throw Assert.isNever(left);
@@ -298,7 +310,7 @@ function isCompatibleWithPrimaryPrimitiveType(left: Type.TPowerQueryType, right:
 }
 
 function isCompatibleWithNullable(left: Type.TPowerQueryType, right: Type.TPowerQueryType): boolean {
-    return right.isNullable === true ? true : left.isNullable === false;
+    return right.isNullable ? true : !left.isNullable;
 }
 
 function isCompatibleWithNumber(left: Type.TPowerQueryType, right: Type.TNumber): boolean {

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -161,15 +161,13 @@ function isCompatibleWithDefinedListType(left: Type.TPowerQueryType, right: Type
     }
 
     switch (left.maybeExtendedKind) {
-        case undefined:
-            return false;
-
         case Type.ExtendedTypeKind.DefinedListType:
             return isEqualType(left, right);
 
         case Type.ExtendedTypeKind.ListType:
             return isDefinedListTypeCompatibleWithListType(right, left);
 
+        case undefined:
         case Type.ExtendedTypeKind.FunctionType:
         case Type.ExtendedTypeKind.PrimaryPrimitiveType:
         case Type.ExtendedTypeKind.RecordType:
@@ -273,15 +271,13 @@ function isCompatibleWithListType(left: Type.TPowerQueryType, right: Type.ListTy
     }
 
     switch (left.maybeExtendedKind) {
-        case undefined:
-            return false;
-
         case Type.ExtendedTypeKind.DefinedListType:
             return isDefinedListTypeCompatibleWithListType(left, right);
 
         case Type.ExtendedTypeKind.ListType:
             return isEqualType(left.itemType, right.itemType);
 
+        case undefined:
         case Type.ExtendedTypeKind.FunctionType:
         case Type.ExtendedTypeKind.PrimaryPrimitiveType:
         case Type.ExtendedTypeKind.RecordType:
@@ -300,12 +296,10 @@ function isCompatibleWithPrimaryPrimitiveType(left: Type.TPowerQueryType, right:
     }
 
     switch (left.maybeExtendedKind) {
-        case undefined:
-            return false;
-
         case Type.ExtendedTypeKind.PrimaryPrimitiveType:
             return left.primitiveType === right.primitiveType;
 
+        case undefined:
         case Type.ExtendedTypeKind.DefinedListType:
         case Type.ExtendedTypeKind.ListType:
         case Type.ExtendedTypeKind.FunctionType:
@@ -342,12 +336,10 @@ function isCompatibleWithRecordType(left: Type.TPowerQueryType, right: Type.Reco
     }
 
     switch (left.maybeExtendedKind) {
-        case undefined:
-            return false;
-
         case Type.ExtendedTypeKind.RecordType:
             return isCompatibleWithFieldSpecificationList(left, right);
 
+        case undefined:
         case Type.ExtendedTypeKind.DefinedListType:
         case Type.ExtendedTypeKind.PrimaryPrimitiveType:
         case Type.ExtendedTypeKind.ListType:

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -227,7 +227,10 @@ function isCompatibleWithFieldSpecificationList(
     return MapUtils.isSubsetMap(
         left.fields,
         right.fields,
-        (leftValue: Type.TPowerQueryType, rightValue: Type.TPowerQueryType) => isEqualType(leftValue, rightValue),
+        (leftValue: Type.TPowerQueryType, rightValue: Type.TPowerQueryType) => {
+            const result: boolean | undefined = isCompatible(leftValue, rightValue);
+            return result !== undefined && result;
+        },
     );
 }
 

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -52,10 +52,10 @@ export function isCompatible(left: Type.TPowerQueryType, right: Type.TPowerQuery
             return isCompatibleWithList(left, right);
 
         case Type.TypeKind.Logical:
-            return isCompatibleWitLogical(left, right);
+            return isCompatibleWithPrimitiveOrLiteralPrimitive(left, right);
 
         case Type.TypeKind.Number:
-            return isCompatibleWithNumber(left, right);
+            return isCompatibleWithPrimitiveOrLiteralPrimitive(left, right);
 
         case Type.TypeKind.Null:
             return left.kind === Type.TypeKind.Null;
@@ -67,7 +67,7 @@ export function isCompatible(left: Type.TPowerQueryType, right: Type.TPowerQuery
             return isCompatibleWithTable(left, right);
 
         case Type.TypeKind.Text:
-            return isCompatibleWithText(left, right);
+            return isCompatibleWithPrimitiveOrLiteralPrimitive(left, right);
 
         case Type.TypeKind.Type:
             return isCompatibleWithType(left, right);
@@ -319,74 +319,6 @@ function isCompatibleWithPrimaryPrimitiveType(left: Type.TPowerQueryType, right:
     }
 }
 
-function isCompatibleWitLogical(left: Type.TPowerQueryType, right: Type.TLogical): boolean {
-    if (left.kind !== right.kind) {
-        return false;
-    }
-
-    switch (right.maybeExtendedKind) {
-        case undefined:
-            return true;
-
-        case Type.ExtendedTypeKind.LogicalLiteral:
-            return isCompatibleWithLogicalLiteral(left, right);
-
-        default:
-            throw Assert.isNever(right);
-    }
-}
-
-function isCompatibleWithLogicalLiteral(left: Type.TPowerQueryType, right: Type.LogicalLiteral): boolean {
-    if (left.kind !== right.kind) {
-        return false;
-    }
-
-    switch (left.maybeExtendedKind) {
-        case undefined:
-            return false;
-
-        case Type.ExtendedTypeKind.LogicalLiteral:
-            return isEqualType(left, right);
-
-        default:
-            throw Assert.isNever(left);
-    }
-}
-
-function isCompatibleWithNumber(left: Type.TPowerQueryType, right: Type.TNumber): boolean {
-    if (left.kind !== right.kind) {
-        return false;
-    }
-
-    switch (right.maybeExtendedKind) {
-        case undefined:
-            return true;
-
-        case Type.ExtendedTypeKind.NumberLiteral:
-            return isCompatibleWithNumberLiteral(left, right);
-
-        default:
-            throw Assert.isNever(right);
-    }
-}
-
-function isCompatibleWithNumberLiteral(left: Type.TPowerQueryType, right: Type.NumberLiteral): boolean {
-    if (left.kind !== right.kind) {
-        return false;
-    }
-
-    switch (left.maybeExtendedKind) {
-        case undefined:
-            return false;
-
-        case Type.ExtendedTypeKind.NumberLiteral:
-            return left.normalizedLiteral === right.normalizedLiteral;
-
-        default:
-            throw Assert.isNever(left);
-    }
-}
-
 function isCompatibleWithRecord(left: Type.TPowerQueryType, right: Type.TRecord): boolean {
     if (left.kind !== right.kind) {
         return false;
@@ -499,37 +431,18 @@ function isCompatibleWithTableTypePrimaryExpression(
     }
 }
 
-function isCompatibleWithText(left: Type.TPowerQueryType, right: Type.TText): boolean {
-    if (left.kind !== right.kind) {
-        return false;
-    }
-
-    switch (right.maybeExtendedKind) {
-        case undefined:
-            return true;
-
-        case Type.ExtendedTypeKind.TextLiteral:
-            return isCompatibleWithTextLiteral(left, right);
-
-        default:
-            throw Assert.isNever(right);
-    }
+function isCompatibleWithPrimitiveOrLiteralPrimitive(
+    left: Type.TPowerQueryType,
+    right: Type.TLogical | Type.TText | Type.TNumber,
+): boolean {
+    return left.kind === right.kind && (!right.maybeExtendedKind || isCompatibleWithLiteral(left, right));
 }
 
-function isCompatibleWithTextLiteral(left: Type.TPowerQueryType, right: Type.TextLiteral): boolean {
-    if (left.kind !== right.kind) {
+function isCompatibleWithLiteral<T extends Type.TLiteral>(left: Type.TPowerQueryType, right: T): boolean {
+    if (left.kind !== right.kind || !left.maybeExtendedKind || left.maybeExtendedKind !== right.maybeExtendedKind) {
         return false;
-    }
-
-    switch (left.maybeExtendedKind) {
-        case undefined:
-            return false;
-
-        case Type.ExtendedTypeKind.TextLiteral:
-            return isEqualType(left, right);
-
-        default:
-            throw Assert.isNever(left);
+    } else {
+        return left.normalizedLiteral === right.normalizedLiteral;
     }
 }
 

--- a/src/powerquery-parser/language/type/typeUtils/isType.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isType.ts
@@ -92,6 +92,7 @@ export function isList(type: Type.TPowerQueryType): type is Type.TList {
 
 export function isLiteral(type: Type.TPowerQueryType): type is Type.TLiteral {
     return (
+        type.maybeExtendedKind === Type.ExtendedTypeKind.LogicalLiteral ||
         type.maybeExtendedKind === Type.ExtendedTypeKind.TextLiteral ||
         type.maybeExtendedKind === Type.ExtendedTypeKind.NumberLiteral
     );

--- a/src/test/libraryTest/type/typeUtils/isCompatible.ts
+++ b/src/test/libraryTest/type/typeUtils/isCompatible.ts
@@ -83,7 +83,7 @@ describe(`TypeUtils.isCompatible`, () => {
         describe(`literal element is compatible with parent type`, () => {
             it(`${Type.ExtendedTypeKind.LogicalLiteral}`, () => {
                 const left: Type.DefinedList = TypeUtils.createDefinedList(false, [
-                    TypeUtils.createLogicalLiteral(false, "true"),
+                    TypeUtils.createLogicalLiteral(false, true),
                 ]);
                 const right: Type.DefinedList = TypeUtils.createDefinedList(false, [Type.LogicalInstance]);
 

--- a/src/test/libraryTest/type/typeUtils/isCompatible.ts
+++ b/src/test/libraryTest/type/typeUtils/isCompatible.ts
@@ -3,141 +3,158 @@
 
 import { expect } from "chai";
 import "mocha";
-import { Language } from "../../../..";
+import { Type, TypeUtils } from "../../../../powerquery-parser/language";
 
 describe(`TypeUtils.isCompatible`, () => {
-    it(`${Language.Type.TypeKind.NotApplicable} should return undefined`, () => {
-        const actual: boolean | undefined = Language.TypeUtils.isCompatible(
-            Language.Type.NotApplicableInstance,
-            Language.Type.AnyInstance,
-        );
+    it(`${Type.TypeKind.NotApplicable} should return undefined`, () => {
+        const actual: boolean | undefined = TypeUtils.isCompatible(Type.NotApplicableInstance, Type.AnyInstance);
         expect(actual).to.equal(undefined, undefined);
     });
 
-    it(`${Language.Type.TypeKind.Unknown} should return undefined`, () => {
-        const actual: boolean | undefined = Language.TypeUtils.isCompatible(
-            Language.Type.UnknownInstance,
-            Language.Type.AnyInstance,
-        );
+    it(`${Type.TypeKind.Unknown} should return undefined`, () => {
+        const actual: boolean | undefined = TypeUtils.isCompatible(Type.UnknownInstance, Type.AnyInstance);
         expect(actual).to.equal(undefined, undefined);
     });
 
     describe(`any`, () => {
         it(`primitives compatible with any`, () => {
-            const typeKinds: ReadonlyArray<Language.Type.TypeKind> = [
-                Language.Type.TypeKind.Action,
-                Language.Type.TypeKind.Any,
-                Language.Type.TypeKind.AnyNonNull,
-                Language.Type.TypeKind.Binary,
-                Language.Type.TypeKind.Date,
-                Language.Type.TypeKind.DateTime,
-                Language.Type.TypeKind.DateTimeZone,
-                Language.Type.TypeKind.Duration,
-                Language.Type.TypeKind.Function,
-                Language.Type.TypeKind.List,
-                Language.Type.TypeKind.Logical,
-                Language.Type.TypeKind.Null,
-                Language.Type.TypeKind.Number,
-                Language.Type.TypeKind.Record,
-                Language.Type.TypeKind.Table,
-                Language.Type.TypeKind.Text,
-                Language.Type.TypeKind.Time,
-                Language.Type.TypeKind.Type,
+            const typeKinds: ReadonlyArray<Type.TypeKind> = [
+                Type.TypeKind.Action,
+                Type.TypeKind.Any,
+                Type.TypeKind.AnyNonNull,
+                Type.TypeKind.Binary,
+                Type.TypeKind.Date,
+                Type.TypeKind.DateTime,
+                Type.TypeKind.DateTimeZone,
+                Type.TypeKind.Duration,
+                Type.TypeKind.Function,
+                Type.TypeKind.List,
+                Type.TypeKind.Logical,
+                Type.TypeKind.Null,
+                Type.TypeKind.Number,
+                Type.TypeKind.Record,
+                Type.TypeKind.Table,
+                Type.TypeKind.Text,
+                Type.TypeKind.Time,
+                Type.TypeKind.Type,
             ];
-            const expected: ReadonlyArray<[Language.Type.TypeKind, boolean]> = typeKinds.map(typeKind => [
+            const expected: ReadonlyArray<[Type.TypeKind, boolean]> = typeKinds.map(typeKind => [typeKind, true]);
+            const actual: ReadonlyArray<[Type.TypeKind, boolean | undefined]> = typeKinds.map(typeKind => [
                 typeKind,
-                true,
-            ]);
-            const actual: ReadonlyArray<[Language.Type.TypeKind, boolean | undefined]> = typeKinds.map(typeKind => [
-                typeKind,
-                Language.TypeUtils.isCompatible(
-                    Language.TypeUtils.createPrimitiveType(false, typeKind),
-                    Language.Type.AnyInstance,
-                ),
+                TypeUtils.isCompatible(TypeUtils.createPrimitiveType(false, typeKind), Type.AnyInstance),
             ]);
             expect(actual).deep.equal(expected);
         });
 
-        it(`${Language.Type.TypeKind.None} not compatible with any`, () => {
-            const actual: boolean | undefined = Language.TypeUtils.isCompatible(
-                Language.TypeUtils.createPrimitiveType(false, Language.Type.TypeKind.None),
-                Language.Type.AnyInstance,
+        it(`${Type.TypeKind.None} not compatible with any`, () => {
+            const actual: boolean | undefined = TypeUtils.isCompatible(
+                TypeUtils.createPrimitiveType(false, Type.TypeKind.None),
+                Type.AnyInstance,
             );
             expect(actual).to.equal(false, undefined);
         });
 
         it(`AnyUnion, basic`, () => {
-            const actual: boolean | undefined = Language.TypeUtils.isCompatible(
-                Language.Type.TextInstance,
-                Language.TypeUtils.createAnyUnion([Language.Type.TextInstance, Language.Type.NumberInstance]),
+            const actual: boolean | undefined = TypeUtils.isCompatible(
+                Type.TextInstance,
+                TypeUtils.createAnyUnion([Type.TextInstance, Type.NumberInstance]),
             );
             expect(actual).to.equal(true, undefined);
         });
 
         it(`AnyUnion, contains any`, () => {
-            const actual: boolean | undefined = Language.TypeUtils.isCompatible(
-                Language.Type.TextInstance,
-                Language.TypeUtils.createAnyUnion([Language.Type.TextInstance, Language.Type.NumberInstance]),
+            const actual: boolean | undefined = TypeUtils.isCompatible(
+                Type.TextInstance,
+                TypeUtils.createAnyUnion([Type.TextInstance, Type.NumberInstance]),
             );
             expect(actual).to.equal(true, undefined);
         });
     });
 
+    describe(`${Type.ExtendedTypeKind.DefinedList}`, () => {
+        it(`identical`, () => {
+            const definedList: Type.DefinedList = TypeUtils.createDefinedList(false, [
+                Type.TextInstance,
+                Type.NumberInstance,
+            ]);
+            expect(TypeUtils.isCompatible(definedList, definedList)).to.equal(true, undefined);
+        });
+
+        describe(`literal element is compatible with parent type`, () => {
+            it(`${Type.ExtendedTypeKind.LogicalLiteral}`, () => {
+                const left: Type.DefinedList = TypeUtils.createDefinedList(false, [
+                    TypeUtils.createLogicalLiteral(false, "true"),
+                ]);
+                const right: Type.DefinedList = TypeUtils.createDefinedList(false, [Type.LogicalInstance]);
+
+                expect(TypeUtils.isCompatible(left, right)).to.equal(true, undefined);
+            });
+
+            it(`${Type.ExtendedTypeKind.NumberLiteral}`, () => {
+                const left: Type.DefinedList = TypeUtils.createDefinedList(false, [
+                    TypeUtils.createNumberLiteral(false, `1`),
+                ]);
+                const right: Type.DefinedList = TypeUtils.createDefinedList(false, [Type.NumberInstance]);
+
+                expect(TypeUtils.isCompatible(left, right)).to.equal(true, undefined);
+            });
+
+            it(`${Type.ExtendedTypeKind.TextLiteral}`, () => {
+                const left: Type.DefinedList = TypeUtils.createDefinedList(false, [
+                    TypeUtils.createTextLiteral(false, `"foo"`),
+                ]);
+                const right: Type.DefinedList = TypeUtils.createDefinedList(false, [Type.TextInstance]);
+
+                expect(TypeUtils.isCompatible(left, right)).to.equal(true, undefined);
+            });
+        });
+    });
+
     describe(`literals are compatible with parent type`, () => {
-        describe(`${Language.Type.ExtendedTypeKind.NumberLiteral}`, () => {
+        describe(`${Type.ExtendedTypeKind.NumberLiteral}`, () => {
             it(`1`, () => {
-                expect(
-                    Language.TypeUtils.isCompatible(
-                        Language.TypeUtils.createNumberLiteral(false, `1`),
-                        Language.Type.NumberInstance,
-                    ),
-                ).to.equal(true, undefined);
+                expect(TypeUtils.isCompatible(TypeUtils.createNumberLiteral(false, `1`), Type.NumberInstance)).to.equal(
+                    true,
+                    undefined,
+                );
             });
 
             it(`--1`, () => {
                 expect(
-                    Language.TypeUtils.isCompatible(
-                        Language.TypeUtils.createNumberLiteral(false, `--1`),
-                        Language.Type.NumberInstance,
-                    ),
+                    TypeUtils.isCompatible(TypeUtils.createNumberLiteral(false, `--1`), Type.NumberInstance),
                 ).to.equal(true, undefined);
             });
 
             it(`+1`, () => {
                 expect(
-                    Language.TypeUtils.isCompatible(
-                        Language.TypeUtils.createNumberLiteral(false, `+1`),
-                        Language.Type.NumberInstance,
-                    ),
+                    TypeUtils.isCompatible(TypeUtils.createNumberLiteral(false, `+1`), Type.NumberInstance),
                 ).to.equal(true, undefined);
             });
         });
 
         it(`"foo"`, () => {
-            expect(
-                Language.TypeUtils.isCompatible(
-                    Language.TypeUtils.createTextLiteral(false, `"foo"`),
-                    Language.Type.TextInstance,
-                ),
-            ).to.equal(true, undefined);
+            expect(TypeUtils.isCompatible(TypeUtils.createTextLiteral(false, `"foo"`), Type.TextInstance)).to.equal(
+                true,
+                undefined,
+            );
         });
     });
 
     describe(`literals are compatible with literals`, () => {
         it(`1`, () => {
             expect(
-                Language.TypeUtils.isCompatible(
-                    Language.TypeUtils.createNumberLiteral(false, `1`),
-                    Language.TypeUtils.createNumberLiteral(false, `1`),
+                TypeUtils.isCompatible(
+                    TypeUtils.createNumberLiteral(false, `1`),
+                    TypeUtils.createNumberLiteral(false, `1`),
                 ),
             ).to.equal(true, undefined);
         });
 
         it(`"foo"`, () => {
             expect(
-                Language.TypeUtils.isCompatible(
-                    Language.TypeUtils.createTextLiteral(false, `"foo"`),
-                    Language.TypeUtils.createTextLiteral(false, `"foo"`),
+                TypeUtils.isCompatible(
+                    TypeUtils.createTextLiteral(false, `"foo"`),
+                    TypeUtils.createTextLiteral(false, `"foo"`),
                 ),
             ).to.equal(true, undefined);
         });

--- a/src/test/libraryTest/type/typeUtils/isCompatible.ts
+++ b/src/test/libraryTest/type/typeUtils/isCompatible.ts
@@ -3,6 +3,7 @@
 
 import { expect } from "chai";
 import "mocha";
+import { OrderedMap } from "../../../../powerquery-parser";
 import { Type, TypeUtils } from "../../../../powerquery-parser/language";
 
 describe(`TypeUtils.isCompatible`, () => {
@@ -134,7 +135,179 @@ describe(`TypeUtils.isCompatible`, () => {
         });
     });
 
+    describe(`${Type.ExtendedTypeKind.DefinedRecord}`, () => {
+        describe(`identity`, () => {
+            it(`empty`, () => {
+                const definedRecord: Type.DefinedRecord = TypeUtils.createDefinedRecord(false, new Map(), false);
+                expect(TypeUtils.isCompatible(definedRecord, definedRecord)).to.equal(true, undefined);
+            });
+
+            it(`non-empty`, () => {
+                const definedRecord: Type.DefinedRecord = TypeUtils.createDefinedRecord(
+                    false,
+                    new Map([["number", Type.NumberInstance]]),
+                    false,
+                );
+                expect(TypeUtils.isCompatible(definedRecord, definedRecord)).to.equal(true, undefined);
+            });
+        });
+
+        describe(`field member literal is compatible with parent type`, () => {
+            it(`${Type.ExtendedTypeKind.LogicalLiteral}`, () => {
+                const left: Type.DefinedRecord = TypeUtils.createDefinedRecord(
+                    false,
+                    new Map([["logical", TypeUtils.createLogicalLiteral(false, true)]]),
+                    false,
+                );
+                const right: Type.DefinedRecord = TypeUtils.createDefinedRecord(
+                    false,
+                    new Map([["logical", Type.LogicalInstance]]),
+                    false,
+                );
+
+                expect(TypeUtils.isCompatible(left, right)).to.equal(true, undefined);
+            });
+
+            it(`${Type.ExtendedTypeKind.NumberLiteral}`, () => {
+                const left: Type.DefinedRecord = TypeUtils.createDefinedRecord(
+                    false,
+                    new Map([["number", TypeUtils.createNumberLiteral(false, 1)]]),
+                    false,
+                );
+                const right: Type.DefinedRecord = TypeUtils.createDefinedRecord(
+                    false,
+                    new Map([["number", Type.NumberInstance]]),
+                    false,
+                );
+
+                expect(TypeUtils.isCompatible(left, right)).to.equal(true, undefined);
+            });
+
+            it(`${Type.ExtendedTypeKind.TextLiteral}`, () => {
+                const left: Type.DefinedRecord = TypeUtils.createDefinedRecord(
+                    false,
+                    new Map([["text", TypeUtils.createTextLiteral(false, `""`)]]),
+                    false,
+                );
+                const right: Type.DefinedRecord = TypeUtils.createDefinedRecord(
+                    false,
+                    new Map([["text", Type.TextInstance]]),
+                    false,
+                );
+
+                expect(TypeUtils.isCompatible(left, right)).to.equal(true, undefined);
+            });
+        });
+
+        describe(`null`, () => {
+            it(`null is not compatible with non-nullable`, () => {
+                const definedRecord: Type.DefinedRecord = TypeUtils.createDefinedRecord(false, new Map(), false);
+                expect(TypeUtils.isCompatible(Type.NullInstance, definedRecord)).to.equal(false, undefined);
+            });
+
+            it(`non-nullable is not compatible with null`, () => {
+                const definedRecord: Type.DefinedRecord = TypeUtils.createDefinedRecord(false, new Map(), false);
+                expect(TypeUtils.isCompatible(definedRecord, Type.NullInstance)).to.equal(false, undefined);
+            });
+
+            it(`null is compatible with nullable`, () => {
+                const definedRecord: Type.DefinedRecord = TypeUtils.createDefinedRecord(true, new Map(), false);
+                expect(TypeUtils.isCompatible(Type.NullInstance, definedRecord)).to.equal(true, undefined);
+            });
+        });
+    });
+
+    describe(`${Type.ExtendedTypeKind.DefinedTable}`, () => {
+        describe(`identity`, () => {
+            it(`empty`, () => {
+                const definedTable: Type.DefinedTable = TypeUtils.createDefinedTable(false, new OrderedMap(), false);
+                expect(TypeUtils.isCompatible(definedTable, definedTable)).to.equal(true, undefined);
+            });
+
+            it(`non-empty`, () => {
+                const definedTable: Type.DefinedTable = TypeUtils.createDefinedTable(
+                    false,
+                    new OrderedMap([["number", Type.NumberInstance]]),
+                    false,
+                );
+                expect(TypeUtils.isCompatible(definedTable, definedTable)).to.equal(true, undefined);
+            });
+        });
+
+        describe(`field member literal is compatible with parent type`, () => {
+            it(`${Type.ExtendedTypeKind.LogicalLiteral}`, () => {
+                const left: Type.DefinedTable = TypeUtils.createDefinedTable(
+                    false,
+                    new OrderedMap([["logical", TypeUtils.createLogicalLiteral(false, true)]]),
+                    false,
+                );
+                const right: Type.DefinedTable = TypeUtils.createDefinedTable(
+                    false,
+                    new OrderedMap([["logical", Type.LogicalInstance]]),
+                    false,
+                );
+
+                expect(TypeUtils.isCompatible(left, right)).to.equal(true, undefined);
+            });
+
+            it(`${Type.ExtendedTypeKind.NumberLiteral}`, () => {
+                const left: Type.DefinedTable = TypeUtils.createDefinedTable(
+                    false,
+                    new OrderedMap([["number", TypeUtils.createNumberLiteral(false, 1)]]),
+                    false,
+                );
+                const right: Type.DefinedTable = TypeUtils.createDefinedTable(
+                    false,
+                    new OrderedMap([["number", Type.NumberInstance]]),
+                    false,
+                );
+
+                expect(TypeUtils.isCompatible(left, right)).to.equal(true, undefined);
+            });
+
+            it(`${Type.ExtendedTypeKind.TextLiteral}`, () => {
+                const left: Type.DefinedTable = TypeUtils.createDefinedTable(
+                    false,
+                    new OrderedMap([["text", TypeUtils.createTextLiteral(false, `""`)]]),
+                    false,
+                );
+                const right: Type.DefinedTable = TypeUtils.createDefinedTable(
+                    false,
+                    new OrderedMap([["text", Type.TextInstance]]),
+                    false,
+                );
+
+                expect(TypeUtils.isCompatible(left, right)).to.equal(true, undefined);
+            });
+        });
+
+        describe(`null`, () => {
+            it(`null is not compatible with non-nullable`, () => {
+                const definedTable: Type.DefinedTable = TypeUtils.createDefinedTable(false, new OrderedMap(), false);
+                expect(TypeUtils.isCompatible(Type.NullInstance, definedTable)).to.equal(false, undefined);
+            });
+
+            it(`non-nullable is not compatible with null`, () => {
+                const definedTable: Type.DefinedTable = TypeUtils.createDefinedTable(false, new OrderedMap(), false);
+                expect(TypeUtils.isCompatible(definedTable, Type.NullInstance)).to.equal(false, undefined);
+            });
+
+            it(`null is compatible with nullable`, () => {
+                const definedTable: Type.DefinedTable = TypeUtils.createDefinedTable(true, new OrderedMap(), false);
+                expect(TypeUtils.isCompatible(Type.NullInstance, definedTable)).to.equal(true, undefined);
+            });
+        });
+    });
+
     describe(`literals are compatible with parent type`, () => {
+        describe(`${Type.ExtendedTypeKind.LogicalLiteral}`, () => {
+            it(`true`, () =>
+                expect(TypeUtils.isCompatible(Type.TrueInstance, Type.LogicalInstance)).to.equal(true, undefined));
+
+            it(`false`, () =>
+                expect(TypeUtils.isCompatible(Type.FalseInstance, Type.LogicalInstance)).to.equal(true, undefined));
+        });
+
         describe(`${Type.ExtendedTypeKind.NumberLiteral}`, () => {
             it(`1`, () => {
                 expect(TypeUtils.isCompatible(TypeUtils.createNumberLiteral(false, `1`), Type.NumberInstance)).to.equal(
@@ -156,7 +329,7 @@ describe(`TypeUtils.isCompatible`, () => {
             });
         });
 
-        it(`"foo"`, () => {
+        it(`${Type.ExtendedTypeKind.TextLiteral}`, () => {
             expect(TypeUtils.isCompatible(TypeUtils.createTextLiteral(false, `"foo"`), Type.TextInstance)).to.equal(
                 true,
                 undefined,

--- a/src/test/libraryTest/type/typeUtils/isCompatible.ts
+++ b/src/test/libraryTest/type/typeUtils/isCompatible.ts
@@ -72,15 +72,22 @@ describe(`TypeUtils.isCompatible`, () => {
     });
 
     describe(`${Type.ExtendedTypeKind.DefinedList}`, () => {
-        it(`identical`, () => {
-            const definedList: Type.DefinedList = TypeUtils.createDefinedList(false, [
-                Type.TextInstance,
-                Type.NumberInstance,
-            ]);
-            expect(TypeUtils.isCompatible(definedList, definedList)).to.equal(true, undefined);
+        describe(`identity`, () => {
+            it(`empty`, () => {
+                const definedList: Type.DefinedList = TypeUtils.createDefinedList(false, []);
+                expect(TypeUtils.isCompatible(definedList, definedList)).to.equal(true, undefined);
+            });
+
+            it(`non-empty`, () => {
+                const definedList: Type.DefinedList = TypeUtils.createDefinedList(false, [
+                    Type.TextInstance,
+                    Type.NumberInstance,
+                ]);
+                expect(TypeUtils.isCompatible(definedList, definedList)).to.equal(true, undefined);
+            });
         });
 
-        describe(`literal element is compatible with parent type`, () => {
+        describe(`list item literal is compatible with parent type`, () => {
             it(`${Type.ExtendedTypeKind.LogicalLiteral}`, () => {
                 const left: Type.DefinedList = TypeUtils.createDefinedList(false, [
                     TypeUtils.createLogicalLiteral(false, true),
@@ -106,6 +113,23 @@ describe(`TypeUtils.isCompatible`, () => {
                 const right: Type.DefinedList = TypeUtils.createDefinedList(false, [Type.TextInstance]);
 
                 expect(TypeUtils.isCompatible(left, right)).to.equal(true, undefined);
+            });
+        });
+
+        describe(`null`, () => {
+            it(`null is not compatible with non-nullable`, () => {
+                const definedList: Type.DefinedList = TypeUtils.createDefinedList(false, []);
+                expect(TypeUtils.isCompatible(Type.NullInstance, definedList)).to.equal(false, undefined);
+            });
+
+            it(`non-nullable is not compatible with null`, () => {
+                const definedList: Type.DefinedList = TypeUtils.createDefinedList(false, []);
+                expect(TypeUtils.isCompatible(definedList, Type.NullInstance)).to.equal(false, undefined);
+            });
+
+            it(`null is compatible with nullable`, () => {
+                const definedList: Type.DefinedList = TypeUtils.createDefinedList(true, []);
+                expect(TypeUtils.isCompatible(Type.NullInstance, definedList)).to.equal(true, undefined);
             });
         });
     });

--- a/src/test/libraryTest/type/typeUtils/isCompatible.ts
+++ b/src/test/libraryTest/type/typeUtils/isCompatible.ts
@@ -7,6 +7,20 @@ import { OrderedMap } from "../../../../powerquery-parser";
 import { Type, TypeUtils } from "../../../../powerquery-parser/language";
 
 describe(`TypeUtils.isCompatible`, () => {
+    describe(`${Type.TypeKind.AnyNonNull}`, () => {
+        it(`null is not compatible`, () => {
+            expect(TypeUtils.isCompatible(Type.NullInstance, Type.AnyNonNullInstance)).to.equal(false);
+        });
+
+        it(`nullable is not compatible`, () => {
+            expect(TypeUtils.isCompatible(Type.NullableTextInstance, Type.AnyNonNullInstance)).to.equal(false);
+        });
+
+        it(`text is compatible`, () => {
+            expect(TypeUtils.isCompatible(Type.TextInstance, Type.AnyNonNullInstance)).to.equal(true);
+        });
+    });
+
     it(`${Type.TypeKind.NotApplicable} should return undefined`, () => {
         const actual: boolean | undefined = TypeUtils.isCompatible(Type.NotApplicableInstance, Type.AnyInstance);
         expect(actual).to.equal(undefined, undefined);

--- a/src/test/libraryTest/type/typeUtils/nameOf.ts
+++ b/src/test/libraryTest/type/typeUtils/nameOf.ts
@@ -62,7 +62,7 @@ describe(`TypeUtils.nameOf`, () => {
                 expect(TypeUtils.nameOf(Type.NumberInstance)).to.equal("number");
             });
             it(`${Type.NumberInstance.kind} literal`, () => {
-                expect(TypeUtils.nameOf(TypeUtils.createNumberLiteral(false, "1"))).to.equal("1");
+                expect(TypeUtils.nameOf(TypeUtils.createNumberLiteral(false, 1))).to.equal("1");
             });
             it(`${Type.RecordInstance.kind}`, () => {
                 expect(TypeUtils.nameOf(Type.RecordInstance)).to.equal("record");
@@ -228,7 +228,7 @@ describe(`TypeUtils.nameOf`, () => {
                             nameLiteral: "y",
                         },
                     ],
-                    TypeUtils.createNumberLiteral(false, "1"),
+                    TypeUtils.createNumberLiteral(false, 1),
                 );
                 const actual: string = TypeUtils.nameOf(type);
 

--- a/src/test/libraryTest/type/typeUtils/typeCheck.ts
+++ b/src/test/libraryTest/type/typeUtils/typeCheck.ts
@@ -110,7 +110,7 @@ describe(`TypeUtils.typeCheck`, () => {
 
         it(`valid parameter`, () => {
             const args: ReadonlyArray<Language.Type.TPowerQueryType> = [
-                Language.TypeUtils.createNumberLiteral(false, "1"),
+                Language.TypeUtils.createNumberLiteral(false, 1),
             ];
             const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.createDefinedFunction(
                 false,
@@ -140,7 +140,7 @@ describe(`TypeUtils.typeCheck`, () => {
 
         it(`valid multiple parameters`, () => {
             const args: ReadonlyArray<Language.Type.TPowerQueryType> = [
-                Language.TypeUtils.createNumberLiteral(false, "1"),
+                Language.TypeUtils.createNumberLiteral(false, 1),
                 Language.TypeUtils.createTextLiteral(false, `"cat"`),
             ];
             const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.createDefinedFunction(

--- a/src/test/libraryTest/type/typeUtils/typeCheck.ts
+++ b/src/test/libraryTest/type/typeUtils/typeCheck.ts
@@ -23,10 +23,7 @@ function createAbridgedChecked(actual: Language.TypeUtils.TChecked): AbridgedChe
 }
 
 function assertAbridgedEqual(actual: AbridgedChecked, expected: AbridgedChecked): void {
-    expect(actual.valid).to.have.members(expected.valid, "mismatch on valid");
-    expect(actual.invalid).to.have.members(expected.invalid, "mismatch on invalid");
-    expect(actual.extraneous).to.have.members(expected.extraneous, "mismatch on extraneous");
-    expect(actual.missing).to.have.members(expected.missing, "mismatch on missing");
+    expect(actual).to.deep.equal(expected);
 }
 
 describe(`TypeUtils.typeCheck`, () => {

--- a/src/test/libraryTest/type/typeUtils/typeUtils.ts
+++ b/src/test/libraryTest/type/typeUtils/typeUtils.ts
@@ -65,7 +65,7 @@ describe(`TypeUtils`, () => {
 
         it(`simplify literal and primitive to primitive`, () => {
             const actual: ReadonlyArray<AbridgedType> = createAbridgedTypes(
-                TypeUtils.simplify([Type.NumberInstance, TypeUtils.createNumberLiteral(false, "1")]),
+                TypeUtils.simplify([Type.NumberInstance, TypeUtils.createNumberLiteral(false, 1)]),
             );
             const expected: ReadonlyArray<AbridgedType> = [Type.NumberInstance];
             expect(actual).deep.equal(expected);
@@ -73,12 +73,12 @@ describe(`TypeUtils`, () => {
 
         it(`retain multiple unique literals`, () => {
             const actual: ReadonlyArray<AbridgedType> = TypeUtils.simplify([
-                TypeUtils.createNumberLiteral(false, "1"),
-                TypeUtils.createNumberLiteral(false, "2"),
+                TypeUtils.createNumberLiteral(false, 1),
+                TypeUtils.createNumberLiteral(false, 2),
             ]);
             const expected: ReadonlyArray<AbridgedType> = [
-                TypeUtils.createNumberLiteral(false, "1"),
-                TypeUtils.createNumberLiteral(false, "2"),
+                TypeUtils.createNumberLiteral(false, 1),
+                TypeUtils.createNumberLiteral(false, 2),
             ];
             expect(actual).deep.equal(expected);
         });
@@ -102,10 +102,10 @@ describe(`TypeUtils`, () => {
 
         it(`dedupe duplicate literals`, () => {
             const actual: ReadonlyArray<AbridgedType> = TypeUtils.simplify([
-                TypeUtils.createNumberLiteral(false, "1"),
-                TypeUtils.createNumberLiteral(false, "1"),
+                TypeUtils.createNumberLiteral(false, 1),
+                TypeUtils.createNumberLiteral(false, 1),
             ]);
-            const expected: ReadonlyArray<AbridgedType> = [TypeUtils.createNumberLiteral(false, "1")];
+            const expected: ReadonlyArray<AbridgedType> = [TypeUtils.createNumberLiteral(false, 1)];
             expect(actual).deep.equal(expected);
         });
 


### PR DESCRIPTION
* Several bug fixes to isCompatible
* Added missing helper utilities for logical literal types
* Constructors for number and boolean literals accept number and boolean values respectively instead of requiring a string
* Lots of new tests