### PR TITLE
Bugfix type checking on invocation validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/language/type/type.ts
+++ b/src/powerquery-parser/language/type/type.ts
@@ -360,7 +360,7 @@ export const NotApplicableInstance: IPrimitiveType<TypeKind.NotApplicable> = cre
     TypeKind.NotApplicable,
     false,
 );
-export const NullInstance: IPrimitiveType<TypeKind.Null> = createPrimitiveType(TypeKind.Null, false);
+export const NullInstance: IPrimitiveType<TypeKind.Null> = createPrimitiveType(TypeKind.Null, true);
 export const NumberInstance: IPrimitiveType<TypeKind.Number> = createPrimitiveType(TypeKind.Number, false);
 export const RecordInstance: IPrimitiveType<TypeKind.Record> = createPrimitiveType(TypeKind.Record, false);
 export const TableInstance: IPrimitiveType<TypeKind.Table> = createPrimitiveType(TypeKind.Table, false);
@@ -391,7 +391,6 @@ export const NullableNotApplicableInstance: IPrimitiveType<TypeKind.NotApplicabl
     TypeKind.NotApplicable,
     true,
 );
-export const NullableNullInstance: IPrimitiveType<TypeKind.Null> = createPrimitiveType(TypeKind.Null, true);
 export const NullableNumberInstance: IPrimitiveType<TypeKind.Number> = createPrimitiveType(TypeKind.Number, true);
 export const NullableRecordInstance: IPrimitiveType<TypeKind.Record> = createPrimitiveType(TypeKind.Record, true);
 export const NullableTableInstance: IPrimitiveType<TypeKind.Table> = createPrimitiveType(TypeKind.Table, true);
@@ -454,7 +453,6 @@ export const NullablePrimitiveInstance: AnyUnion = {
         NullableLogicalInstance,
         NullableNoneInstance,
         NullableNotApplicableInstance,
-        NullableNullInstance,
         NullableNumberInstance,
         NullableRecordInstance,
         NullableTableInstance,

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -96,10 +96,8 @@ export function isCompatibleWithFunctionParameter(
         return right.isOptional;
     } else if (left.isNullable && !right.isNullable) {
         return false;
-    } else if (right.maybeType) {
-        return left.kind === right.maybeType;
     } else {
-        return true;
+        return !right.maybeType || right.maybeType === Type.TypeKind.Any || left.kind === right.maybeType;
     }
 }
 

--- a/src/powerquery-parser/language/type/typeUtils/nameOf.ts
+++ b/src/powerquery-parser/language/type/typeUtils/nameOf.ts
@@ -6,6 +6,10 @@ import { Constant } from "../..";
 import { Assert } from "../../../common";
 
 export function nameOf(type: Type.TPowerQueryType): string {
+    if (type.kind === Type.TypeKind.Null) {
+        return "null";
+    }
+
     switch (type.maybeExtendedKind) {
         case Type.ExtendedTypeKind.NumberLiteral:
         case Type.ExtendedTypeKind.TextLiteral:

--- a/src/powerquery-parser/language/type/typeUtils/primitive.ts
+++ b/src/powerquery-parser/language/type/typeUtils/primitive.ts
@@ -219,10 +219,6 @@ export const PrimitiveTypeConstantMap: ReadonlyMap<string, Type.TPrimitiveType> 
         Type.NullableNotApplicableInstance,
     ],
     [
-        primitiveTypeMapKey(Type.NullableNullInstance.isNullable, Type.NullableNullInstance.kind),
-        Type.NullableNullInstance,
-    ],
-    [
         primitiveTypeMapKey(Type.NullableNumberInstance.isNullable, Type.NullableNumberInstance.kind),
         Type.NullableNumberInstance,
     ],

--- a/src/test/libraryTest/type/typeUtils/isCompatible.ts
+++ b/src/test/libraryTest/type/typeUtils/isCompatible.ts
@@ -48,7 +48,6 @@ describe(`TypeUtils.isCompatible`, () => {
                 Type.TypeKind.Function,
                 Type.TypeKind.List,
                 Type.TypeKind.Logical,
-                Type.TypeKind.Null,
                 Type.TypeKind.Number,
                 Type.TypeKind.Record,
                 Type.TypeKind.Table,

--- a/src/test/libraryTest/type/typeUtils/nameOf.ts
+++ b/src/test/libraryTest/type/typeUtils/nameOf.ts
@@ -137,10 +137,6 @@ describe(`TypeUtils.nameOf`, () => {
                 const actual: string = TypeUtils.nameOf(Type.NullableNotApplicableInstance);
                 expect(actual).to.equal("nullable not applicable", undefined);
             });
-            it(`${Type.NullableNullInstance.kind}`, () => {
-                const actual: string = TypeUtils.nameOf(Type.NullableNullInstance);
-                expect(actual).to.equal("nullable null", undefined);
-            });
             it(`${Type.NullableNumberInstance.kind}`, () => {
                 const actual: string = TypeUtils.nameOf(Type.NullableNumberInstance);
                 expect(actual).to.equal("nullable number", undefined);

--- a/src/test/libraryTest/type/typeUtils/typeCheck.ts
+++ b/src/test/libraryTest/type/typeUtils/typeCheck.ts
@@ -105,6 +105,62 @@ describe(`TypeUtils.typeCheck`, () => {
             expect(actual).to.deep.equal(expected);
         });
 
+        it(`maybeType === null translates to any`, () => {
+            const args: ReadonlyArray<Language.Type.TPowerQueryType> = [Language.Type.NumberInstance];
+            const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.createDefinedFunction(
+                false,
+                [
+                    {
+                        isNullable: true,
+                        isOptional: false,
+                        maybeType: undefined,
+                        nameLiteral: "foo",
+                    },
+                ],
+                Language.Type.ActionInstance,
+            );
+            const actual: Language.TypeUtils.CheckedInvocation = Language.TypeUtils.typeCheckInvocation(
+                args,
+                definedFunction,
+            );
+            const expected: Language.TypeUtils.CheckedInvocation = {
+                valid: [0],
+                invalid: new Map(),
+                extraneous: [],
+                missing: [],
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`maybeType === any allows any type`, () => {
+            const args: ReadonlyArray<Language.Type.TPowerQueryType> = [Language.Type.NumberInstance];
+            const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.createDefinedFunction(
+                false,
+                [
+                    {
+                        isNullable: false,
+                        isOptional: false,
+                        maybeType: Language.Type.TypeKind.Any,
+                        nameLiteral: "foo",
+                    },
+                ],
+                Language.Type.ActionInstance,
+            );
+            const actual: Language.TypeUtils.CheckedInvocation = Language.TypeUtils.typeCheckInvocation(
+                args,
+                definedFunction,
+            );
+            const expected: Language.TypeUtils.CheckedInvocation = {
+                valid: [0],
+                invalid: new Map(),
+                extraneous: [],
+                missing: [],
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
         it(`valid parameter`, () => {
             const args: ReadonlyArray<Language.Type.TPowerQueryType> = [
                 Language.TypeUtils.createNumberLiteral(false, 1),

--- a/src/test/libraryTest/type/typeUtils/typeUtils.ts
+++ b/src/test/libraryTest/type/typeUtils/typeUtils.ts
@@ -308,11 +308,6 @@ describe(`TypeUtils`, () => {
                     // tslint:disable-next-line: chai-vague-errors
                     expect(actual).to.equal("nullable none");
                 });
-                it(`${Type.NullableNullInstance.kind}`, () => {
-                    const actual: string = TypeUtils.nameOf(Type.NullableNullInstance);
-                    // tslint:disable-next-line: chai-vague-errors
-                    expect(actual).to.equal("nullable null");
-                });
                 it(`${Type.NullableNumberInstance.kind}`, () => {
                     const actual: string = TypeUtils.nameOf(Type.NullableNumberInstance);
                     // tslint:disable-next-line: chai-vague-errors


### PR DESCRIPTION
A validation on `Json.Document("foo")` would fail with: `'Json.Document expected the argument for 'jsonText' to be 'any', but got 'text' instead`.