### PR TITLE
Bugfix for arguments with `any` type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.4.10",
+    "version": "0.4.11",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -97,7 +97,12 @@ export function isCompatibleWithFunctionParameter(
     } else if (left.isNullable && !right.isNullable) {
         return false;
     } else {
-        return !right.maybeType || right.maybeType === Type.TypeKind.Any || left.kind === right.maybeType;
+        return (
+            !right.maybeType ||
+            right.maybeType === Type.TypeKind.Any ||
+            left.kind === Type.TypeKind.Any ||
+            left.kind === right.maybeType
+        );
     }
 }
 

--- a/src/test/libraryTest/type/typeUtils/typeCheck.ts
+++ b/src/test/libraryTest/type/typeUtils/typeCheck.ts
@@ -133,7 +133,7 @@ describe(`TypeUtils.typeCheck`, () => {
             expect(actual).to.deep.equal(expected);
         });
 
-        it(`maybeType === any allows any type`, () => {
+        it(`paramter.maybeType === any allows any type`, () => {
             const args: ReadonlyArray<Language.Type.TPowerQueryType> = [Language.Type.NumberInstance];
             const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.createDefinedFunction(
                 false,
@@ -142,6 +142,34 @@ describe(`TypeUtils.typeCheck`, () => {
                         isNullable: false,
                         isOptional: false,
                         maybeType: Language.Type.TypeKind.Any,
+                        nameLiteral: "foo",
+                    },
+                ],
+                Language.Type.ActionInstance,
+            );
+            const actual: Language.TypeUtils.CheckedInvocation = Language.TypeUtils.typeCheckInvocation(
+                args,
+                definedFunction,
+            );
+            const expected: Language.TypeUtils.CheckedInvocation = {
+                valid: [0],
+                invalid: new Map(),
+                extraneous: [],
+                missing: [],
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`an any argument allowed for non-any parameters`, () => {
+            const args: ReadonlyArray<Language.Type.TPowerQueryType> = [Language.Type.AnyInstance];
+            const definedFunction: Language.Type.DefinedFunction = Language.TypeUtils.createDefinedFunction(
+                false,
+                [
+                    {
+                        isNullable: false,
+                        isOptional: false,
+                        maybeType: Language.Type.TypeKind.Text,
                         nameLiteral: "foo",
                     },
                 ],


### PR DESCRIPTION
A fix for cases like `Table.FirstN(1 as any)` which would consider the first argument as an invalid type as it's not the expected type `table`.