### PR TITLE
Better XorNode API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.4.12",
+    "version": "0.4.13",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/traversal.ts
+++ b/src/powerquery-parser/common/traversal.ts
@@ -136,7 +136,7 @@ export function assertGetAllXorChildren<State extends ITraversalState<ResultType
         }
         case XorNodeKind.Context: {
             const result: TXorNode[] = [];
-            const contextNode: ParseContext.Node = xorNode.node;
+            const contextNode: ParseContext.TNode = xorNode.node;
             const maybeChildIds: ReadonlyArray<number> | undefined = nodeIdMapCollection.childIdsById.get(
                 contextNode.id,
             );

--- a/src/powerquery-parser/common/traversal.ts
+++ b/src/powerquery-parser/common/traversal.ts
@@ -117,7 +117,7 @@ export function assertGetAllAstChildren<State extends ITraversalState<ResultType
 
     if (maybeChildIds) {
         const childIds: ReadonlyArray<number> = maybeChildIds;
-        return childIds.map(nodeId => NodeIdMapUtils.assertGetAst(nodeIdMapCollection.astNodeById, nodeId));
+        return childIds.map(nodeId => NodeIdMapUtils.assertUnwrapAst(nodeIdMapCollection.astNodeById, nodeId));
     } else {
         return [];
     }

--- a/src/powerquery-parser/common/traversal.ts
+++ b/src/powerquery-parser/common/traversal.ts
@@ -117,7 +117,7 @@ export function assertGetAllAstChildren<State extends ITraversalState<ResultType
 
     if (maybeChildIds) {
         const childIds: ReadonlyArray<number> = maybeChildIds;
-        return childIds.map(nodeId => NodeIdMapUtils.assertUnwrapAst(nodeIdMapCollection.astNodeById, nodeId));
+        return childIds.map(nodeId => NodeIdMapUtils.assertAst(nodeIdMapCollection.astNodeById, nodeId));
     } else {
         return [];
     }

--- a/src/powerquery-parser/common/traversal.ts
+++ b/src/powerquery-parser/common/traversal.ts
@@ -117,7 +117,7 @@ export function assertGetAllAstChildren<State extends ITraversalState<ResultType
 
     if (maybeChildIds) {
         const childIds: ReadonlyArray<number> = maybeChildIds;
-        return childIds.map(nodeId => NodeIdMapUtils.assertAst(nodeIdMapCollection.astNodeById, nodeId));
+        return childIds.map(nodeId => NodeIdMapUtils.assertGetAst(nodeIdMapCollection.astNodeById, nodeId));
     } else {
         return [];
     }

--- a/src/powerquery-parser/language/ast/astUtils/assert.ts
+++ b/src/powerquery-parser/language/ast/astUtils/assert.ts
@@ -273,7 +273,7 @@ export function assertHasAnyNodeKind<T extends Ast.TNode>(
     node: Ast.TNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]>,
 ): asserts node is T {
-    if (!TypeGuards.isAnyNodeKind(node, expectedNodeKinds)) {
+    if (!TypeGuards.isNodeKind(node, expectedNodeKinds)) {
         throw new CommonError.InvariantError(`assert failed, expected a different nodeKind`, {
             nodeId: node.id,
             nodeKind: node.kind,

--- a/src/powerquery-parser/language/ast/astUtils/assert.ts
+++ b/src/powerquery-parser/language/ast/astUtils/assert.ts
@@ -263,29 +263,6 @@ export function assertAsUnaryExpression(node: Ast.TNode): Ast.UnaryExpression {
     return assertAs(TypeGuards.isUnaryExpression, node, [Ast.NodeKind.UnaryExpression]);
 }
 
-export function assertHasNodeKind<T extends Ast.TNode>(node: Ast.TNode, expectedNodeKind: T["kind"]): void {
-    if (!TypeGuards.isNodeKind(node, expectedNodeKind)) {
-        throw new CommonError.InvariantError(`assert failed, expected a different nodeKind`, {
-            nodeId: node.id,
-            nodeKind: node.kind,
-            expectedNodeKind,
-        });
-    }
-}
-
-export function assertHasAnyNodeKind<T extends Ast.TNode>(
-    node: Ast.TNode,
-    expectedNodeKinds: ReadonlyArray<T["kind"]>,
-): asserts node is T {
-    if (!TypeGuards.isNodeKind(node, expectedNodeKinds)) {
-        throw new CommonError.InvariantError(`assert failed, expected a different nodeKind`, {
-            nodeId: node.id,
-            nodeKind: node.kind,
-            expectedNodeKinds,
-        });
-    }
-}
-
 export function assertIsArithmeticExpression(node: Ast.TNode): asserts node is Ast.ArithmeticExpression {
     assertIs(TypeGuards.isArithmeticExpression, node, [Ast.NodeKind.ArithmeticExpression]);
 }

--- a/src/powerquery-parser/language/ast/astUtils/assert.ts
+++ b/src/powerquery-parser/language/ast/astUtils/assert.ts
@@ -256,77 +256,77 @@ export function assertAsTPairedConstant(node: Ast.TNode): Ast.TPairedConstant {
 }
 
 export function assertAsTypePrimaryType(node: Ast.TNode): Ast.TypePrimaryType {
-    return assertAs(TypeGuards.isTypePrimaryType, node, [Ast.NodeKind.TypePrimaryType]);
+    return assertAs(TypeGuards.isTypePrimaryType, node, Ast.NodeKind.TypePrimaryType);
 }
 
 export function assertAsUnaryExpression(node: Ast.TNode): Ast.UnaryExpression {
-    return assertAs(TypeGuards.isUnaryExpression, node, [Ast.NodeKind.UnaryExpression]);
+    return assertAs(TypeGuards.isUnaryExpression, node, Ast.NodeKind.UnaryExpression);
 }
 
 export function assertIsArithmeticExpression(node: Ast.TNode): asserts node is Ast.ArithmeticExpression {
-    assertIs(TypeGuards.isArithmeticExpression, node, [Ast.NodeKind.ArithmeticExpression]);
+    assertIsNodeKind(TypeGuards.isArithmeticExpression, node, Ast.NodeKind.ArithmeticExpression);
 }
 
 export function assertIsAsExpression(node: Ast.TNode): asserts node is Ast.AsExpression {
-    assertIs(TypeGuards.isAsExpression, node, [Ast.NodeKind.AsExpression]);
+    assertIsNodeKind(TypeGuards.isAsExpression, node, Ast.NodeKind.AsExpression);
 }
 
 export function assertIsAsNullablePrimitiveType(node: Ast.TNode): asserts node is Ast.AsNullablePrimitiveType {
-    assertIs(TypeGuards.isAsNullablePrimitiveType, node, [Ast.NodeKind.AsNullablePrimitiveType]);
+    assertIsNodeKind(TypeGuards.isAsNullablePrimitiveType, node, Ast.NodeKind.AsNullablePrimitiveType);
 }
 
 export function assertIsEachExpression(node: Ast.TNode): asserts node is Ast.EachExpression {
-    assertIs(TypeGuards.isEachExpression, node, [Ast.NodeKind.EachExpression]);
+    assertIsNodeKind(TypeGuards.isEachExpression, node, Ast.NodeKind.EachExpression);
 }
 
 export function assertIsEqualityExpression(node: Ast.TNode): asserts node is Ast.EqualityExpression {
-    assertIs(TypeGuards.isEqualityExpression, node, [Ast.NodeKind.EqualityExpression]);
+    assertIsNodeKind(TypeGuards.isEqualityExpression, node, Ast.NodeKind.EqualityExpression);
 }
 
 export function assertIsErrorHandlingExpression(node: Ast.TNode): asserts node is Ast.ErrorHandlingExpression {
-    assertIs(TypeGuards.isErrorHandlingExpression, node, [Ast.NodeKind.ErrorHandlingExpression]);
+    assertIsNodeKind(TypeGuards.isErrorHandlingExpression, node, Ast.NodeKind.ErrorHandlingExpression);
 }
 
 export function assertIsErrorRaisingExpression(node: Ast.TNode): asserts node is Ast.ErrorRaisingExpression {
-    assertIs(TypeGuards.isErrorRaisingExpression, node, [Ast.NodeKind.ErrorRaisingExpression]);
+    assertIsNodeKind(TypeGuards.isErrorRaisingExpression, node, Ast.NodeKind.ErrorRaisingExpression);
 }
 
 export function assertIsFieldProjection(node: Ast.TNode): asserts node is Ast.FieldProjection {
-    assertIs(TypeGuards.isFieldProjection, node, [Ast.NodeKind.FieldProjection]);
+    assertIsNodeKind(TypeGuards.isFieldProjection, node, Ast.NodeKind.FieldProjection);
 }
 
 export function assertIsFieldSelector(node: Ast.TNode): asserts node is Ast.FieldSelector {
-    assertIs(TypeGuards.isFieldSelector, node, [Ast.NodeKind.FieldSelector]);
+    assertIsNodeKind(TypeGuards.isFieldSelector, node, Ast.NodeKind.FieldSelector);
 }
 
 export function assertIsFieldSpecification(node: Ast.TNode): asserts node is Ast.FieldSpecification {
-    assertIs(TypeGuards.isFieldSpecification, node, [Ast.NodeKind.FieldSpecification]);
+    assertIsNodeKind(TypeGuards.isFieldSpecification, node, Ast.NodeKind.FieldSpecification);
 }
 
 export function assertIsFieldSpecificationList(node: Ast.TNode): asserts node is Ast.FieldSpecificationList {
-    assertIs(TypeGuards.isFieldSpecificationList, node, [Ast.NodeKind.FieldSpecificationList]);
+    assertIsNodeKind(TypeGuards.isFieldSpecificationList, node, Ast.NodeKind.FieldSpecificationList);
 }
 
 export function assertIsFieldTypeSpecification(node: Ast.TNode): asserts node is Ast.FieldTypeSpecification {
-    assertIs(TypeGuards.isFieldTypeSpecification, node, [Ast.NodeKind.FieldTypeSpecification]);
+    assertIsNodeKind(TypeGuards.isFieldTypeSpecification, node, Ast.NodeKind.FieldTypeSpecification);
 }
 
 export function assertIsFunctionExpression(node: Ast.TNode): asserts node is Ast.FunctionExpression {
-    assertIs(TypeGuards.isFunctionExpression, node, [Ast.NodeKind.FunctionExpression]);
+    assertIsNodeKind(TypeGuards.isFunctionExpression, node, Ast.NodeKind.FunctionExpression);
 }
 
 export function assertIsFunctionType(node: Ast.TNode): asserts node is Ast.FunctionType {
-    assertIs(TypeGuards.isFunctionType, node, [Ast.NodeKind.FunctionType]);
+    assertIsNodeKind(TypeGuards.isFunctionType, node, Ast.NodeKind.FunctionType);
 }
 
 export function assertIsGeneralizedIdentifier(node: Ast.TNode): asserts node is Ast.GeneralizedIdentifier {
-    assertIs(TypeGuards.isGeneralizedIdentifier, node, [Ast.NodeKind.GeneralizedIdentifier]);
+    assertIsNodeKind(TypeGuards.isGeneralizedIdentifier, node, Ast.NodeKind.GeneralizedIdentifier);
 }
 
 export function assertIsGeneralizedIdentifierPairedAnyLiteral(
     node: Ast.TNode,
 ): asserts node is Ast.GeneralizedIdentifierPairedAnyLiteral {
-    assertIs(TypeGuards.isGeneralizedIdentifierPairedAnyLiteral, node, [
+    assertIsNodeKind(TypeGuards.isGeneralizedIdentifierPairedAnyLiteral, node, [
         Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
     ]);
 }
@@ -334,141 +334,159 @@ export function assertIsGeneralizedIdentifierPairedAnyLiteral(
 export function assertIsGeneralizedIdentifierPairedExpression(
     node: Ast.TNode,
 ): asserts node is Ast.GeneralizedIdentifierPairedExpression {
-    assertIs(TypeGuards.isGeneralizedIdentifierPairedExpression, node, [
+    assertIsNodeKind(TypeGuards.isGeneralizedIdentifierPairedExpression, node, [
         Ast.NodeKind.GeneralizedIdentifierPairedExpression,
     ]);
 }
 
 export function assertIsIdentifier(node: Ast.TNode): asserts node is Ast.Identifier {
-    assertIs(TypeGuards.isIdentifier, node, [Ast.NodeKind.Identifier]);
+    assertIsNodeKind(TypeGuards.isIdentifier, node, Ast.NodeKind.Identifier);
 }
 
 export function assertIsIdentifierExpression(node: Ast.TNode): asserts node is Ast.IdentifierExpression {
-    assertIs(TypeGuards.isIdentifierExpression, node, [Ast.NodeKind.IdentifierExpression]);
+    assertIsNodeKind(TypeGuards.isIdentifierExpression, node, Ast.NodeKind.IdentifierExpression);
 }
 
 export function assertIsIdentifierPairedExpression(node: Ast.TNode): asserts node is Ast.IdentifierPairedExpression {
-    assertIs(TypeGuards.isIdentifierPairedExpression, node, [Ast.NodeKind.IdentifierPairedExpression]);
+    assertIsNodeKind(TypeGuards.isIdentifierPairedExpression, node, Ast.NodeKind.IdentifierPairedExpression);
 }
 
 export function assertIsIfExpression(node: Ast.TNode): asserts node is Ast.IfExpression {
-    assertIs(TypeGuards.isIfExpression, node, [Ast.NodeKind.IfExpression]);
+    assertIsNodeKind(TypeGuards.isIfExpression, node, Ast.NodeKind.IfExpression);
 }
 
 export function assertIsInvokeExpression(node: Ast.TNode): asserts node is Ast.InvokeExpression {
-    assertIs(TypeGuards.isInvokeExpression, node, [Ast.NodeKind.InvokeExpression]);
+    assertIsNodeKind(TypeGuards.isInvokeExpression, node, Ast.NodeKind.InvokeExpression);
 }
 
 export function assertIsIsExpression(node: Ast.TNode): asserts node is Ast.IsExpression {
-    assertIs(TypeGuards.isIsExpression, node, [Ast.NodeKind.IsExpression]);
+    assertIsNodeKind(TypeGuards.isIsExpression, node, Ast.NodeKind.IsExpression);
 }
 
 export function assertIsIsNullablePrimitiveType(node: Ast.TNode): asserts node is Ast.IsNullablePrimitiveType {
-    assertIs(TypeGuards.isIsNullablePrimitiveType, node, [Ast.NodeKind.IsNullablePrimitiveType]);
+    assertIsNodeKind(TypeGuards.isIsNullablePrimitiveType, node, Ast.NodeKind.IsNullablePrimitiveType);
 }
 
 export function assertIsItemAccessExpression(node: Ast.TNode): asserts node is Ast.ItemAccessExpression {
-    assertIs(TypeGuards.isItemAccessExpression, node, [Ast.NodeKind.ItemAccessExpression]);
+    assertIsNodeKind(TypeGuards.isItemAccessExpression, node, Ast.NodeKind.ItemAccessExpression);
 }
 
 export function assertIsLetExpression(node: Ast.TNode): asserts node is Ast.LetExpression {
-    assertIs(TypeGuards.isLetExpression, node, [Ast.NodeKind.LetExpression]);
+    assertIsNodeKind(TypeGuards.isLetExpression, node, Ast.NodeKind.LetExpression);
 }
 
 export function assertIsListExpression(node: Ast.TNode): asserts node is Ast.ListExpression {
-    assertIs(TypeGuards.isListExpression, node, [Ast.NodeKind.ListExpression]);
+    assertIsNodeKind(TypeGuards.isListExpression, node, Ast.NodeKind.ListExpression);
 }
 
 export function assertIsListLiteral(node: Ast.TNode): asserts node is Ast.ListLiteral {
-    assertIs(TypeGuards.isListLiteral, node, [Ast.NodeKind.ListLiteral]);
+    assertIsNodeKind(TypeGuards.isListLiteral, node, Ast.NodeKind.ListLiteral);
 }
 
 export function assertIsListType(node: Ast.TNode): asserts node is Ast.ListType {
-    assertIs(TypeGuards.isListType, node, [Ast.NodeKind.ListType]);
+    assertIsNodeKind(TypeGuards.isListType, node, Ast.NodeKind.ListType);
 }
 
 export function assertIsLiteralExpression(node: Ast.TNode): asserts node is Ast.LiteralExpression {
-    assertIs(TypeGuards.isLiteralExpression, node, [Ast.NodeKind.LiteralExpression]);
+    assertIsNodeKind(TypeGuards.isLiteralExpression, node, Ast.NodeKind.LiteralExpression);
 }
 
 export function assertIsLogicalExpression(node: Ast.TNode): asserts node is Ast.LogicalExpression {
-    assertIs(TypeGuards.isLogicalExpression, node, [Ast.NodeKind.LogicalExpression]);
+    assertIsNodeKind(TypeGuards.isLogicalExpression, node, Ast.NodeKind.LogicalExpression);
 }
 
 export function assertIsMetadataExpression(node: Ast.TNode): asserts node is Ast.MetadataExpression {
-    assertIs(TypeGuards.isMetadataExpression, node, [Ast.NodeKind.MetadataExpression]);
+    assertIsNodeKind(TypeGuards.isMetadataExpression, node, Ast.NodeKind.MetadataExpression);
+}
+
+export function assertIsNodeKind<T extends Ast.TNode>(
+    predicateFn: (node: Ast.TNode, expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"]) => node is T,
+    node: Ast.TNode,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
+): asserts node is T {
+    if (!predicateFn(node, expectedNodeKinds)) {
+        throw new CommonError.InvariantError(`unexpected node kind`, {
+            nodeId: node.id,
+            nodeKind: node.kind,
+            expectedNodeKinds,
+        });
+    }
 }
 
 export function assertIsNotImplementedExpression(node: Ast.TNode): asserts node is Ast.NotImplementedExpression {
-    assertIs(TypeGuards.isNotImplementedExpression, node, [Ast.NodeKind.NotImplementedExpression]);
+    assertIsNodeKind<Ast.NotImplementedExpression>(
+        TypeGuards.isNotImplementedExpression,
+        node,
+        Ast.NodeKind.NotImplementedExpression,
+    );
 }
 
 export function assertIsNullCoalescingExpression(node: Ast.TNode): asserts node is Ast.NullCoalescingExpression {
-    assertIs(TypeGuards.isNullCoalescingExpression, node, [Ast.NodeKind.NullCoalescingExpression]);
+    assertIsNodeKind(TypeGuards.isNullCoalescingExpression, node, Ast.NodeKind.NullCoalescingExpression);
 }
 
 export function assertIsNullablePrimitiveType(node: Ast.TNode): asserts node is Ast.NullablePrimitiveType {
-    assertIs(TypeGuards.isNullablePrimitiveType, node, [Ast.NodeKind.NullablePrimitiveType]);
+    assertIsNodeKind(TypeGuards.isNullablePrimitiveType, node, Ast.NodeKind.NullablePrimitiveType);
 }
 
 export function assertIsNullableType(node: Ast.TNode): asserts node is Ast.NullableType {
-    assertIs(TypeGuards.isNullableType, node, [Ast.NodeKind.NullableType]);
+    assertIsNodeKind(TypeGuards.isNullableType, node, Ast.NodeKind.NullableType);
 }
 
 export function assertIsOtherwiseExpression(node: Ast.TNode): asserts node is Ast.OtherwiseExpression {
-    assertIs(TypeGuards.isOtherwiseExpression, node, [Ast.NodeKind.OtherwiseExpression]);
+    assertIsNodeKind(TypeGuards.isOtherwiseExpression, node, Ast.NodeKind.OtherwiseExpression);
 }
 
 export function assertIsParenthesizedExpression(node: Ast.TNode): asserts node is Ast.ParenthesizedExpression {
-    assertIs(TypeGuards.isParenthesizedExpression, node, [Ast.NodeKind.ParenthesizedExpression]);
+    assertIsNodeKind(TypeGuards.isParenthesizedExpression, node, Ast.NodeKind.ParenthesizedExpression);
 }
 
 export function assertIsPrimitiveType(node: Ast.TNode): asserts node is Ast.PrimitiveType {
-    assertIs(TypeGuards.isPrimitiveType, node, [Ast.NodeKind.PrimitiveType]);
+    assertIsNodeKind(TypeGuards.isPrimitiveType, node, Ast.NodeKind.PrimitiveType);
 }
 
 export function assertIsRangeExpression(node: Ast.TNode): asserts node is Ast.RangeExpression {
-    assertIs(TypeGuards.isRangeExpression, node, [Ast.NodeKind.RangeExpression]);
+    assertIsNodeKind(TypeGuards.isRangeExpression, node, Ast.NodeKind.RangeExpression);
 }
 
 export function assertIsRecordExpression(node: Ast.TNode): asserts node is Ast.RecordExpression {
-    assertIs(TypeGuards.isRecordExpression, node, [Ast.NodeKind.RecordExpression]);
+    assertIsNodeKind(TypeGuards.isRecordExpression, node, Ast.NodeKind.RecordExpression);
 }
 
 export function assertIsRecordLiteral(node: Ast.TNode): asserts node is Ast.RecordLiteral {
-    assertIs(TypeGuards.isRecordLiteral, node, [Ast.NodeKind.RecordLiteral]);
+    assertIsNodeKind(TypeGuards.isRecordLiteral, node, Ast.NodeKind.RecordLiteral);
 }
 
 export function assertIsRecordType(node: Ast.TNode): asserts node is Ast.RecordType {
-    assertIs(TypeGuards.isRecordType, node, [Ast.NodeKind.RecordType]);
+    assertIsNodeKind(TypeGuards.isRecordType, node, Ast.NodeKind.RecordType);
 }
 
 export function assertIsRecursivePrimaryExpression(node: Ast.TNode): asserts node is Ast.RecursivePrimaryExpression {
-    assertIs(TypeGuards.isRecursivePrimaryExpression, node, [Ast.NodeKind.RecursivePrimaryExpression]);
+    assertIsNodeKind(TypeGuards.isRecursivePrimaryExpression, node, Ast.NodeKind.RecursivePrimaryExpression);
 }
 
 export function assertIsRelationalExpression(node: Ast.TNode): asserts node is Ast.RelationalExpression {
-    assertIs(TypeGuards.isRelationalExpression, node, [Ast.NodeKind.RelationalExpression]);
+    assertIsNodeKind(TypeGuards.isRelationalExpression, node, Ast.NodeKind.RelationalExpression);
 }
 
 export function assertIsSection(node: Ast.TNode): asserts node is Ast.Section {
-    assertIs(TypeGuards.isSection, node, [Ast.NodeKind.Section]);
+    assertIsNodeKind(TypeGuards.isSection, node, Ast.NodeKind.Section);
 }
 
 export function assertIsSectionMember(node: Ast.TNode): asserts node is Ast.SectionMember {
-    assertIs(TypeGuards.isSectionMember, node, [Ast.NodeKind.SectionMember]);
+    assertIsNodeKind(TypeGuards.isSectionMember, node, Ast.NodeKind.SectionMember);
 }
 
 export function assertIsTableType(node: Ast.TNode): asserts node is Ast.TableType {
-    assertIs(TypeGuards.isTableType, node, [Ast.NodeKind.TableType]);
+    assertIsNodeKind(TypeGuards.isTableType, node, Ast.NodeKind.TableType);
 }
 
 export function assertIsTArrayWrapper(node: Ast.TNode): asserts node is Ast.TArrayWrapper {
-    assertIs(TypeGuards.isTArrayWrapper, node, [Ast.NodeKind.ArrayWrapper]);
+    assertIsNodeKind(TypeGuards.isTArrayWrapper, node, Ast.NodeKind.ArrayWrapper);
 }
 
 export function assertIsTBinOpExpression(node: Ast.TNode): asserts node is Ast.TBinOpExpression {
-    assertIs(TypeGuards.isTBinOpExpression, node, [
+    assertIsNodeKind(TypeGuards.isTBinOpExpression, node, [
         Ast.NodeKind.ArithmeticExpression,
         Ast.NodeKind.AsExpression,
         Ast.NodeKind.EqualityExpression,
@@ -480,15 +498,15 @@ export function assertIsTBinOpExpression(node: Ast.TNode): asserts node is Ast.T
 }
 
 export function assertIsTConstant(node: Ast.TNode): asserts node is Ast.TConstant {
-    assertIs(TypeGuards.isTConstant, node, [Ast.NodeKind.Constant]);
+    assertIsNodeKind(TypeGuards.isTConstant, node, Ast.NodeKind.Constant);
 }
 
 export function assertIsTCsv(node: Ast.TNode): asserts node is Ast.TCsv {
-    assertIs(TypeGuards.isTCsv, node, [Ast.NodeKind.Csv]);
+    assertIsNodeKind(TypeGuards.isTCsv, node, [Ast.NodeKind.Csv]);
 }
 
 export function assertIsTKeyValuePair(node: Ast.TNode): asserts node is Ast.TKeyValuePair {
-    assertIs(TypeGuards.isTKeyValuePair, node, [
+    assertIsNodeKind(TypeGuards.isTKeyValuePair, node, [
         Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
         Ast.NodeKind.GeneralizedIdentifierPairedExpression,
         Ast.NodeKind.IdentifierPairedExpression,
@@ -496,7 +514,7 @@ export function assertIsTKeyValuePair(node: Ast.TNode): asserts node is Ast.TKey
 }
 
 export function assertIsTPairedConstant(node: Ast.TNode): asserts node is Ast.TPairedConstant {
-    assertIs(TypeGuards.isTPairedConstant, node, [
+    assertIsNodeKind(TypeGuards.isTPairedConstant, node, [
         Ast.NodeKind.AsNullablePrimitiveType,
         Ast.NodeKind.AsType,
         Ast.NodeKind.ErrorRaisingExpression,
@@ -509,33 +527,19 @@ export function assertIsTPairedConstant(node: Ast.TNode): asserts node is Ast.TP
 }
 
 export function assertIsTypePrimaryType(node: Ast.TNode): asserts node is Ast.TypePrimaryType {
-    assertIs(TypeGuards.isTypePrimaryType, node, [Ast.NodeKind.TypePrimaryType]);
+    assertIsNodeKind(TypeGuards.isTypePrimaryType, node, Ast.NodeKind.TypePrimaryType);
 }
 
 export function assertIsUnaryExpression(node: Ast.TNode): asserts node is Ast.UnaryExpression {
-    assertIs(TypeGuards.isUnaryExpression, node, [Ast.NodeKind.UnaryExpression]);
+    assertIsNodeKind(TypeGuards.isUnaryExpression, node, Ast.NodeKind.UnaryExpression);
 }
 
 function assertAs<T extends Ast.TNode>(
     predicateFn: (node: Ast.TNode) => node is T,
     node: Ast.TNode,
-    expectedNodeKinds: ReadonlyArray<Ast.NodeKind>,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): T {
-    assertIs<T>(predicateFn, node, expectedNodeKinds);
+    assertIsNodeKind<T>(predicateFn, node, expectedNodeKinds);
 
     return node;
-}
-
-function assertIs<T extends Ast.TNode>(
-    predicateFn: (node: Ast.TNode) => node is T,
-    node: Ast.TNode,
-    expectedNodeKinds: ReadonlyArray<Ast.NodeKind>,
-): asserts node is T {
-    if (!predicateFn(node)) {
-        throw new CommonError.InvariantError(`assert failed, expected a different nodeKind`, {
-            nodeId: node.id,
-            nodeKind: node.kind,
-            expectedNodeKinds,
-        });
-    }
 }

--- a/src/powerquery-parser/language/ast/astUtils/assert.ts
+++ b/src/powerquery-parser/language/ast/astUtils/assert.ts
@@ -272,7 +272,7 @@ export function assertHasNodeKind<T extends Ast.TNode>(node: Ast.TNode, expected
 export function assertHasAnyNodeKind<T extends Ast.TNode>(
     node: Ast.TNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]>,
-): void {
+): asserts node is T {
     if (!TypeGuards.isAnyNodeKind(node, expectedNodeKinds)) {
         throw new CommonError.InvariantError(`assert failed, expected a different nodeKind`, {
             nodeId: node.id,

--- a/src/powerquery-parser/language/ast/astUtils/assert.ts
+++ b/src/powerquery-parser/language/ast/astUtils/assert.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Ast } from "..";
-import { ArrayUtils, CommonError } from "../../../common";
 import * as TypeGuards from "./typeGuards";
+
+import { Ast } from "..";
+import { CommonError } from "../../../common";
 
 export function assertAsArithmeticExpression(node: Ast.TNode): Ast.ArithmeticExpression {
     return assertAs(TypeGuards.isArithmeticExpression, node, [Ast.NodeKind.ArithmeticExpression]);
@@ -258,12 +259,27 @@ export function assertAsUnaryExpression(node: Ast.TNode): Ast.UnaryExpression {
     return assertAs(TypeGuards.isUnaryExpression, node, [Ast.NodeKind.UnaryExpression]);
 }
 
-export function assertIsAnyNodeKind(node: Ast.TNode, allowedNodeKinds: ReadonlyArray<Ast.NodeKind>): void {
-    ArrayUtils.assertIn(allowedNodeKinds, node.kind, "assert failed, given nodeKind wasn't in allowedNodeKinds", {
-        allowedNodeKinds,
-        actualNodeKind: node.kind,
-        actualNodeId: node.id,
-    });
+export function assertHasNodeKind<T extends Ast.TNode>(node: Ast.TNode, expectedNodeKind: T["kind"]): void {
+    if (!TypeGuards.isNodeKind(node, expectedNodeKind)) {
+        throw new CommonError.InvariantError(`assert failed, expected a different nodeKind`, {
+            nodeId: node.id,
+            nodeKind: node.kind,
+            expectedNodeKind,
+        });
+    }
+}
+
+export function assertHasAnyNodeKind<T extends Ast.TNode>(
+    node: Ast.TNode,
+    expectedNodeKinds: ReadonlyArray<T["kind"]>,
+): void {
+    if (!TypeGuards.isAnyNodeKind(node, expectedNodeKinds)) {
+        throw new CommonError.InvariantError(`assert failed, expected a different nodeKind`, {
+            nodeId: node.id,
+            nodeKind: node.kind,
+            expectedNodeKinds,
+        });
+    }
 }
 
 export function assertIsArithmeticExpression(node: Ast.TNode): asserts node is Ast.ArithmeticExpression {

--- a/src/powerquery-parser/language/ast/astUtils/assert.ts
+++ b/src/powerquery-parser/language/ast/astUtils/assert.ts
@@ -7,215 +7,211 @@ import { Ast } from "..";
 import { CommonError } from "../../../common";
 
 export function assertAsArithmeticExpression(node: Ast.TNode): Ast.ArithmeticExpression {
-    return assertAs(TypeGuards.isArithmeticExpression, node, [Ast.NodeKind.ArithmeticExpression]);
+    return assertAs(node, [Ast.NodeKind.ArithmeticExpression]);
 }
 
 export function assertAsAsExpression(node: Ast.TNode): Ast.AsExpression {
-    return assertAs(TypeGuards.isAsExpression, node, [Ast.NodeKind.AsExpression]);
+    return assertAs(node, [Ast.NodeKind.AsExpression]);
 }
 
 export function assertAsAsNullablePrimitiveType(node: Ast.TNode): Ast.AsNullablePrimitiveType {
-    return assertAs(TypeGuards.isAsNullablePrimitiveType, node, [Ast.NodeKind.AsNullablePrimitiveType]);
+    return assertAs(node, [Ast.NodeKind.AsNullablePrimitiveType]);
 }
 
 export function assertAsEachExpression(node: Ast.TNode): Ast.EachExpression {
-    return assertAs(TypeGuards.isEachExpression, node, [Ast.NodeKind.EachExpression]);
+    return assertAs(node, [Ast.NodeKind.EachExpression]);
 }
 
 export function assertAsEqualityExpression(node: Ast.TNode): Ast.EqualityExpression {
-    return assertAs(TypeGuards.isEqualityExpression, node, [Ast.NodeKind.EqualityExpression]);
+    return assertAs(node, [Ast.NodeKind.EqualityExpression]);
 }
 
 export function assertAsErrorHandlingExpression(node: Ast.TNode): Ast.ErrorHandlingExpression {
-    return assertAs(TypeGuards.isErrorHandlingExpression, node, [Ast.NodeKind.ErrorHandlingExpression]);
+    return assertAs(node, [Ast.NodeKind.ErrorHandlingExpression]);
 }
 
 export function assertAsErrorRaisingExpression(node: Ast.TNode): Ast.ErrorRaisingExpression {
-    return assertAs(TypeGuards.isErrorRaisingExpression, node, [Ast.NodeKind.ErrorRaisingExpression]);
+    return assertAs(node, [Ast.NodeKind.ErrorRaisingExpression]);
 }
 
 export function assertAsFieldProjection(node: Ast.TNode): Ast.FieldProjection {
-    return assertAs(TypeGuards.isFieldProjection, node, [Ast.NodeKind.FieldProjection]);
+    return assertAs(node, [Ast.NodeKind.FieldProjection]);
 }
 
 export function assertAsFieldSelector(node: Ast.TNode): Ast.FieldSelector {
-    return assertAs(TypeGuards.isFieldSelector, node, [Ast.NodeKind.FieldSelector]);
+    return assertAs(node, [Ast.NodeKind.FieldSelector]);
 }
 
 export function assertAsFieldSpecification(node: Ast.TNode): Ast.FieldSpecification {
-    return assertAs(TypeGuards.isFieldSpecification, node, [Ast.NodeKind.FieldSpecification]);
+    return assertAs(node, [Ast.NodeKind.FieldSpecification]);
 }
 
 export function assertAsFieldSpecificationList(node: Ast.TNode): Ast.FieldSpecificationList {
-    return assertAs(TypeGuards.isFieldSpecificationList, node, [Ast.NodeKind.FieldSpecificationList]);
+    return assertAs(node, [Ast.NodeKind.FieldSpecificationList]);
 }
 
 export function assertAsFieldTypeSpecification(node: Ast.TNode): Ast.FieldTypeSpecification {
-    return assertAs(TypeGuards.isFieldTypeSpecification, node, [Ast.NodeKind.FieldTypeSpecification]);
+    return assertAs(node, [Ast.NodeKind.FieldTypeSpecification]);
 }
 
 export function assertAsFunctionExpression(node: Ast.TNode): Ast.FunctionExpression {
-    return assertAs(TypeGuards.isFunctionExpression, node, [Ast.NodeKind.FunctionExpression]);
+    return assertAs(node, [Ast.NodeKind.FunctionExpression]);
 }
 
 export function assertAsFunctionType(node: Ast.TNode): Ast.FunctionType {
-    return assertAs(TypeGuards.isFunctionType, node, [Ast.NodeKind.FunctionType]);
+    return assertAs(node, [Ast.NodeKind.FunctionType]);
 }
 
 export function assertAsGeneralizedIdentifier(node: Ast.TNode): Ast.GeneralizedIdentifier {
-    return assertAs(TypeGuards.isGeneralizedIdentifier, node, [Ast.NodeKind.GeneralizedIdentifier]);
+    return assertAs(node, [Ast.NodeKind.GeneralizedIdentifier]);
 }
 
 export function assertAsGeneralizedIdentifierPairedAnyLiteral(
     node: Ast.TNode,
 ): Ast.GeneralizedIdentifierPairedAnyLiteral {
-    return assertAs(TypeGuards.isGeneralizedIdentifierPairedAnyLiteral, node, [
-        Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
-    ]);
+    return assertAs(node, [Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral]);
 }
 
 export function assertAsGeneralizedIdentifierPairedExpression(
     node: Ast.TNode,
 ): Ast.GeneralizedIdentifierPairedExpression {
-    return assertAs(TypeGuards.isGeneralizedIdentifierPairedExpression, node, [
-        Ast.NodeKind.GeneralizedIdentifierPairedExpression,
-    ]);
+    return assertAs(node, [Ast.NodeKind.GeneralizedIdentifierPairedExpression]);
 }
 
 export function assertAsIdentifier(node: Ast.TNode): Ast.Identifier {
-    return assertAs(TypeGuards.isIdentifier, node, [Ast.NodeKind.Identifier]);
+    return assertAs(node, [Ast.NodeKind.Identifier]);
 }
 
 export function assertAsIdentifierExpression(node: Ast.TNode): Ast.IdentifierExpression {
-    return assertAs(TypeGuards.isIdentifierExpression, node, [Ast.NodeKind.IdentifierExpression]);
+    return assertAs(node, [Ast.NodeKind.IdentifierExpression]);
 }
 
 export function assertAsIdentifierPairedExpression(node: Ast.TNode): Ast.IdentifierPairedExpression {
-    return assertAs(TypeGuards.isIdentifierPairedExpression, node, [Ast.NodeKind.IdentifierPairedExpression]);
+    return assertAs(node, [Ast.NodeKind.IdentifierPairedExpression]);
 }
 
 export function assertAsIfExpression(node: Ast.TNode): Ast.IfExpression {
-    return assertAs(TypeGuards.isIfExpression, node, [Ast.NodeKind.IfExpression]);
+    return assertAs(node, [Ast.NodeKind.IfExpression]);
 }
 
 export function assertAsInvokeExpression(node: Ast.TNode): Ast.InvokeExpression {
-    return assertAs(TypeGuards.isInvokeExpression, node, [Ast.NodeKind.InvokeExpression]);
+    return assertAs(node, [Ast.NodeKind.InvokeExpression]);
 }
 
 export function assertAsIsExpression(node: Ast.TNode): Ast.IsExpression {
-    return assertAs(TypeGuards.isIsExpression, node, [Ast.NodeKind.IsExpression]);
+    return assertAs(node, [Ast.NodeKind.IsExpression]);
 }
 
 export function assertAsIsNullablePrimitiveType(node: Ast.TNode): Ast.IsNullablePrimitiveType {
-    return assertAs(TypeGuards.isIsNullablePrimitiveType, node, [Ast.NodeKind.IsNullablePrimitiveType]);
+    return assertAs(node, [Ast.NodeKind.IsNullablePrimitiveType]);
 }
 
 export function assertAsItemAccessExpression(node: Ast.TNode): Ast.ItemAccessExpression {
-    return assertAs(TypeGuards.isItemAccessExpression, node, [Ast.NodeKind.ItemAccessExpression]);
+    return assertAs(node, [Ast.NodeKind.ItemAccessExpression]);
 }
 
 export function assertAsLetExpression(node: Ast.TNode): Ast.LetExpression {
-    return assertAs(TypeGuards.isLetExpression, node, [Ast.NodeKind.LetExpression]);
+    return assertAs(node, [Ast.NodeKind.LetExpression]);
 }
 
 export function assertAsListExpression(node: Ast.TNode): Ast.ListExpression {
-    return assertAs(TypeGuards.isListExpression, node, [Ast.NodeKind.ListExpression]);
+    return assertAs(node, [Ast.NodeKind.ListExpression]);
 }
 
 export function assertAsListLiteral(node: Ast.TNode): Ast.ListLiteral {
-    return assertAs(TypeGuards.isListLiteral, node, [Ast.NodeKind.ListLiteral]);
+    return assertAs(node, [Ast.NodeKind.ListLiteral]);
 }
 
 export function assertAsListType(node: Ast.TNode): Ast.ListType {
-    return assertAs(TypeGuards.isListType, node, [Ast.NodeKind.ListType]);
+    return assertAs(node, [Ast.NodeKind.ListType]);
 }
 
 export function assertAsLiteralExpression(node: Ast.TNode): Ast.LiteralExpression {
-    return assertAs(TypeGuards.isLiteralExpression, node, [Ast.NodeKind.LiteralExpression]);
+    return assertAs(node, [Ast.NodeKind.LiteralExpression]);
 }
 
 export function assertAsLogicalExpression(node: Ast.TNode): Ast.LogicalExpression {
-    return assertAs(TypeGuards.isLogicalExpression, node, [Ast.NodeKind.LogicalExpression]);
+    return assertAs(node, [Ast.NodeKind.LogicalExpression]);
 }
 
 export function assertAsMetadataExpression(node: Ast.TNode): Ast.MetadataExpression {
-    return assertAs(TypeGuards.isMetadataExpression, node, [Ast.NodeKind.MetadataExpression]);
+    return assertAs(node, [Ast.NodeKind.MetadataExpression]);
 }
 
 export function assertAsNotImplementedExpression(node: Ast.TNode): Ast.NotImplementedExpression {
-    return assertAs(TypeGuards.isNotImplementedExpression, node, [Ast.NodeKind.NotImplementedExpression]);
+    return assertAs(node, [Ast.NodeKind.NotImplementedExpression]);
 }
 
 export function assertAsNullCoalescingExpression(node: Ast.TNode): Ast.NullCoalescingExpression {
-    return assertAs(TypeGuards.isNullCoalescingExpression, node, [Ast.NodeKind.NullCoalescingExpression]);
+    return assertAs(node, [Ast.NodeKind.NullCoalescingExpression]);
 }
 
 export function assertAsNullablePrimitiveType(node: Ast.TNode): Ast.NullablePrimitiveType {
-    return assertAs(TypeGuards.isNullablePrimitiveType, node, [Ast.NodeKind.NullablePrimitiveType]);
+    return assertAs(node, [Ast.NodeKind.NullablePrimitiveType]);
 }
 
 export function assertAsNullableType(node: Ast.TNode): Ast.NullableType {
-    return assertAs(TypeGuards.isNullableType, node, [Ast.NodeKind.NullableType]);
+    return assertAs(node, [Ast.NodeKind.NullableType]);
 }
 
 export function assertAsOtherwiseExpression(node: Ast.TNode): Ast.OtherwiseExpression {
-    return assertAs(TypeGuards.isOtherwiseExpression, node, [Ast.NodeKind.OtherwiseExpression]);
+    return assertAs(node, [Ast.NodeKind.OtherwiseExpression]);
 }
 
 export function assertAsParameter(node: Ast.TNode): Ast.TParameter {
-    return assertAs(TypeGuards.isParameter, node, [Ast.NodeKind.Parameter]);
+    return assertAs(node, [Ast.NodeKind.Parameter]);
 }
 
 export function assertAsParenthesizedExpression(node: Ast.TNode): Ast.ParenthesizedExpression {
-    return assertAs(TypeGuards.isParenthesizedExpression, node, [Ast.NodeKind.ParenthesizedExpression]);
+    return assertAs(node, [Ast.NodeKind.ParenthesizedExpression]);
 }
 
 export function assertAsPrimitiveType(node: Ast.TNode): Ast.PrimitiveType {
-    return assertAs(TypeGuards.isPrimitiveType, node, [Ast.NodeKind.PrimitiveType]);
+    return assertAs(node, [Ast.NodeKind.PrimitiveType]);
 }
 
 export function assertAsRangeExpression(node: Ast.TNode): Ast.RangeExpression {
-    return assertAs(TypeGuards.isRangeExpression, node, [Ast.NodeKind.RangeExpression]);
+    return assertAs(node, [Ast.NodeKind.RangeExpression]);
 }
 
 export function assertAsRecordExpression(node: Ast.TNode): Ast.RecordExpression {
-    return assertAs(TypeGuards.isRecordExpression, node, [Ast.NodeKind.RecordExpression]);
+    return assertAs(node, [Ast.NodeKind.RecordExpression]);
 }
 
 export function assertAsRecordLiteral(node: Ast.TNode): Ast.RecordLiteral {
-    return assertAs(TypeGuards.isRecordLiteral, node, [Ast.NodeKind.RecordLiteral]);
+    return assertAs(node, [Ast.NodeKind.RecordLiteral]);
 }
 
 export function assertAsRecordType(node: Ast.TNode): Ast.RecordType {
-    return assertAs(TypeGuards.isRecordType, node, [Ast.NodeKind.RecordType]);
+    return assertAs(node, [Ast.NodeKind.RecordType]);
 }
 
 export function assertAsRecursivePrimaryExpression(node: Ast.TNode): Ast.RecursivePrimaryExpression {
-    return assertAs(TypeGuards.isRecursivePrimaryExpression, node, [Ast.NodeKind.RecursivePrimaryExpression]);
+    return assertAs(node, [Ast.NodeKind.RecursivePrimaryExpression]);
 }
 
 export function assertAsRelationalExpression(node: Ast.TNode): Ast.RelationalExpression {
-    return assertAs(TypeGuards.isRelationalExpression, node, [Ast.NodeKind.RelationalExpression]);
+    return assertAs(node, [Ast.NodeKind.RelationalExpression]);
 }
 
 export function assertAsSection(node: Ast.TNode): Ast.Section {
-    return assertAs(TypeGuards.isSection, node, [Ast.NodeKind.Section]);
+    return assertAs(node, [Ast.NodeKind.Section]);
 }
 
 export function assertAsSectionMember(node: Ast.TNode): Ast.SectionMember {
-    return assertAs(TypeGuards.isSectionMember, node, [Ast.NodeKind.SectionMember]);
+    return assertAs(node, [Ast.NodeKind.SectionMember]);
 }
 
 export function assertAsTableType(node: Ast.TNode): Ast.TableType {
-    return assertAs(TypeGuards.isTableType, node, [Ast.NodeKind.TableType]);
+    return assertAs(node, [Ast.NodeKind.TableType]);
 }
 
 export function assertAsTArrayWrapper(node: Ast.TNode): Ast.TArrayWrapper {
-    return assertAs(TypeGuards.isTArrayWrapper, node, [Ast.NodeKind.ArrayWrapper]);
+    return assertAs(node, [Ast.NodeKind.ArrayWrapper]);
 }
 
 export function assertAsTBinOpExpression(node: Ast.TNode): Ast.TBinOpExpression {
-    return assertAs(TypeGuards.isTBinOpExpression, node, [
+    return assertAs(node, [
         Ast.NodeKind.ArithmeticExpression,
         Ast.NodeKind.AsExpression,
         Ast.NodeKind.EqualityExpression,
@@ -227,15 +223,15 @@ export function assertAsTBinOpExpression(node: Ast.TNode): Ast.TBinOpExpression 
 }
 
 export function assertAsTConstant(node: Ast.TNode): Ast.TConstant {
-    return assertAs(TypeGuards.isTConstant, node, [Ast.NodeKind.Constant]);
+    return assertAs(node, [Ast.NodeKind.Constant]);
 }
 
 export function assertAsTCsv(node: Ast.TNode): Ast.TCsv {
-    return assertAs(TypeGuards.isTCsv, node, [Ast.NodeKind.Csv]);
+    return assertAs(node, [Ast.NodeKind.Csv]);
 }
 
 export function assertAsTKeyValuePair(node: Ast.TNode): Ast.TKeyValuePair {
-    return assertAs(TypeGuards.isTKeyValuePair, node, [
+    return assertAs(node, [
         Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
         Ast.NodeKind.GeneralizedIdentifierPairedExpression,
         Ast.NodeKind.IdentifierPairedExpression,
@@ -243,7 +239,7 @@ export function assertAsTKeyValuePair(node: Ast.TNode): Ast.TKeyValuePair {
 }
 
 export function assertAsTPairedConstant(node: Ast.TNode): Ast.TPairedConstant {
-    return assertAs(TypeGuards.isTPairedConstant, node, [
+    return assertAs(node, [
         Ast.NodeKind.AsNullablePrimitiveType,
         Ast.NodeKind.AsType,
         Ast.NodeKind.ErrorRaisingExpression,
@@ -256,155 +252,150 @@ export function assertAsTPairedConstant(node: Ast.TNode): Ast.TPairedConstant {
 }
 
 export function assertAsTypePrimaryType(node: Ast.TNode): Ast.TypePrimaryType {
-    return assertAs(TypeGuards.isTypePrimaryType, node, Ast.NodeKind.TypePrimaryType);
+    return assertAs(node, Ast.NodeKind.TypePrimaryType);
 }
 
 export function assertAsUnaryExpression(node: Ast.TNode): Ast.UnaryExpression {
-    return assertAs(TypeGuards.isUnaryExpression, node, Ast.NodeKind.UnaryExpression);
+    return assertAs(node, Ast.NodeKind.UnaryExpression);
 }
 
 export function assertIsArithmeticExpression(node: Ast.TNode): asserts node is Ast.ArithmeticExpression {
-    assertIsNodeKind(TypeGuards.isArithmeticExpression, node, Ast.NodeKind.ArithmeticExpression);
+    assertIsNodeKind(node, Ast.NodeKind.ArithmeticExpression);
 }
 
 export function assertIsAsExpression(node: Ast.TNode): asserts node is Ast.AsExpression {
-    assertIsNodeKind(TypeGuards.isAsExpression, node, Ast.NodeKind.AsExpression);
+    assertIsNodeKind(node, Ast.NodeKind.AsExpression);
 }
 
 export function assertIsAsNullablePrimitiveType(node: Ast.TNode): asserts node is Ast.AsNullablePrimitiveType {
-    assertIsNodeKind(TypeGuards.isAsNullablePrimitiveType, node, Ast.NodeKind.AsNullablePrimitiveType);
+    assertIsNodeKind(node, Ast.NodeKind.AsNullablePrimitiveType);
 }
 
 export function assertIsEachExpression(node: Ast.TNode): asserts node is Ast.EachExpression {
-    assertIsNodeKind(TypeGuards.isEachExpression, node, Ast.NodeKind.EachExpression);
+    assertIsNodeKind(node, Ast.NodeKind.EachExpression);
 }
 
 export function assertIsEqualityExpression(node: Ast.TNode): asserts node is Ast.EqualityExpression {
-    assertIsNodeKind(TypeGuards.isEqualityExpression, node, Ast.NodeKind.EqualityExpression);
+    assertIsNodeKind(node, Ast.NodeKind.EqualityExpression);
 }
 
 export function assertIsErrorHandlingExpression(node: Ast.TNode): asserts node is Ast.ErrorHandlingExpression {
-    assertIsNodeKind(TypeGuards.isErrorHandlingExpression, node, Ast.NodeKind.ErrorHandlingExpression);
+    assertIsNodeKind(node, Ast.NodeKind.ErrorHandlingExpression);
 }
 
 export function assertIsErrorRaisingExpression(node: Ast.TNode): asserts node is Ast.ErrorRaisingExpression {
-    assertIsNodeKind(TypeGuards.isErrorRaisingExpression, node, Ast.NodeKind.ErrorRaisingExpression);
+    assertIsNodeKind(node, Ast.NodeKind.ErrorRaisingExpression);
 }
 
 export function assertIsFieldProjection(node: Ast.TNode): asserts node is Ast.FieldProjection {
-    assertIsNodeKind(TypeGuards.isFieldProjection, node, Ast.NodeKind.FieldProjection);
+    assertIsNodeKind(node, Ast.NodeKind.FieldProjection);
 }
 
 export function assertIsFieldSelector(node: Ast.TNode): asserts node is Ast.FieldSelector {
-    assertIsNodeKind(TypeGuards.isFieldSelector, node, Ast.NodeKind.FieldSelector);
+    assertIsNodeKind(node, Ast.NodeKind.FieldSelector);
 }
 
 export function assertIsFieldSpecification(node: Ast.TNode): asserts node is Ast.FieldSpecification {
-    assertIsNodeKind(TypeGuards.isFieldSpecification, node, Ast.NodeKind.FieldSpecification);
+    assertIsNodeKind(node, Ast.NodeKind.FieldSpecification);
 }
 
 export function assertIsFieldSpecificationList(node: Ast.TNode): asserts node is Ast.FieldSpecificationList {
-    assertIsNodeKind(TypeGuards.isFieldSpecificationList, node, Ast.NodeKind.FieldSpecificationList);
+    assertIsNodeKind(node, Ast.NodeKind.FieldSpecificationList);
 }
 
 export function assertIsFieldTypeSpecification(node: Ast.TNode): asserts node is Ast.FieldTypeSpecification {
-    assertIsNodeKind(TypeGuards.isFieldTypeSpecification, node, Ast.NodeKind.FieldTypeSpecification);
+    assertIsNodeKind(node, Ast.NodeKind.FieldTypeSpecification);
 }
 
 export function assertIsFunctionExpression(node: Ast.TNode): asserts node is Ast.FunctionExpression {
-    assertIsNodeKind(TypeGuards.isFunctionExpression, node, Ast.NodeKind.FunctionExpression);
+    assertIsNodeKind(node, Ast.NodeKind.FunctionExpression);
 }
 
 export function assertIsFunctionType(node: Ast.TNode): asserts node is Ast.FunctionType {
-    assertIsNodeKind(TypeGuards.isFunctionType, node, Ast.NodeKind.FunctionType);
+    assertIsNodeKind(node, Ast.NodeKind.FunctionType);
 }
 
 export function assertIsGeneralizedIdentifier(node: Ast.TNode): asserts node is Ast.GeneralizedIdentifier {
-    assertIsNodeKind(TypeGuards.isGeneralizedIdentifier, node, Ast.NodeKind.GeneralizedIdentifier);
+    assertIsNodeKind(node, Ast.NodeKind.GeneralizedIdentifier);
 }
 
 export function assertIsGeneralizedIdentifierPairedAnyLiteral(
     node: Ast.TNode,
 ): asserts node is Ast.GeneralizedIdentifierPairedAnyLiteral {
-    assertIsNodeKind(TypeGuards.isGeneralizedIdentifierPairedAnyLiteral, node, [
-        Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
-    ]);
+    assertIsNodeKind(node, [Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral]);
 }
 
 export function assertIsGeneralizedIdentifierPairedExpression(
     node: Ast.TNode,
 ): asserts node is Ast.GeneralizedIdentifierPairedExpression {
-    assertIsNodeKind(TypeGuards.isGeneralizedIdentifierPairedExpression, node, [
-        Ast.NodeKind.GeneralizedIdentifierPairedExpression,
-    ]);
+    assertIsNodeKind(node, [Ast.NodeKind.GeneralizedIdentifierPairedExpression]);
 }
 
 export function assertIsIdentifier(node: Ast.TNode): asserts node is Ast.Identifier {
-    assertIsNodeKind(TypeGuards.isIdentifier, node, Ast.NodeKind.Identifier);
+    assertIsNodeKind(node, Ast.NodeKind.Identifier);
 }
 
 export function assertIsIdentifierExpression(node: Ast.TNode): asserts node is Ast.IdentifierExpression {
-    assertIsNodeKind(TypeGuards.isIdentifierExpression, node, Ast.NodeKind.IdentifierExpression);
+    assertIsNodeKind(node, Ast.NodeKind.IdentifierExpression);
 }
 
 export function assertIsIdentifierPairedExpression(node: Ast.TNode): asserts node is Ast.IdentifierPairedExpression {
-    assertIsNodeKind(TypeGuards.isIdentifierPairedExpression, node, Ast.NodeKind.IdentifierPairedExpression);
+    assertIsNodeKind(node, Ast.NodeKind.IdentifierPairedExpression);
 }
 
 export function assertIsIfExpression(node: Ast.TNode): asserts node is Ast.IfExpression {
-    assertIsNodeKind(TypeGuards.isIfExpression, node, Ast.NodeKind.IfExpression);
+    assertIsNodeKind(node, Ast.NodeKind.IfExpression);
 }
 
 export function assertIsInvokeExpression(node: Ast.TNode): asserts node is Ast.InvokeExpression {
-    assertIsNodeKind(TypeGuards.isInvokeExpression, node, Ast.NodeKind.InvokeExpression);
+    assertIsNodeKind(node, Ast.NodeKind.InvokeExpression);
 }
 
 export function assertIsIsExpression(node: Ast.TNode): asserts node is Ast.IsExpression {
-    assertIsNodeKind(TypeGuards.isIsExpression, node, Ast.NodeKind.IsExpression);
+    assertIsNodeKind(node, Ast.NodeKind.IsExpression);
 }
 
 export function assertIsIsNullablePrimitiveType(node: Ast.TNode): asserts node is Ast.IsNullablePrimitiveType {
-    assertIsNodeKind(TypeGuards.isIsNullablePrimitiveType, node, Ast.NodeKind.IsNullablePrimitiveType);
+    assertIsNodeKind(node, Ast.NodeKind.IsNullablePrimitiveType);
 }
 
 export function assertIsItemAccessExpression(node: Ast.TNode): asserts node is Ast.ItemAccessExpression {
-    assertIsNodeKind(TypeGuards.isItemAccessExpression, node, Ast.NodeKind.ItemAccessExpression);
+    assertIsNodeKind(node, Ast.NodeKind.ItemAccessExpression);
 }
 
 export function assertIsLetExpression(node: Ast.TNode): asserts node is Ast.LetExpression {
-    assertIsNodeKind(TypeGuards.isLetExpression, node, Ast.NodeKind.LetExpression);
+    assertIsNodeKind(node, Ast.NodeKind.LetExpression);
 }
 
 export function assertIsListExpression(node: Ast.TNode): asserts node is Ast.ListExpression {
-    assertIsNodeKind(TypeGuards.isListExpression, node, Ast.NodeKind.ListExpression);
+    assertIsNodeKind(node, Ast.NodeKind.ListExpression);
 }
 
 export function assertIsListLiteral(node: Ast.TNode): asserts node is Ast.ListLiteral {
-    assertIsNodeKind(TypeGuards.isListLiteral, node, Ast.NodeKind.ListLiteral);
+    assertIsNodeKind(node, Ast.NodeKind.ListLiteral);
 }
 
 export function assertIsListType(node: Ast.TNode): asserts node is Ast.ListType {
-    assertIsNodeKind(TypeGuards.isListType, node, Ast.NodeKind.ListType);
+    assertIsNodeKind(node, Ast.NodeKind.ListType);
 }
 
 export function assertIsLiteralExpression(node: Ast.TNode): asserts node is Ast.LiteralExpression {
-    assertIsNodeKind(TypeGuards.isLiteralExpression, node, Ast.NodeKind.LiteralExpression);
+    assertIsNodeKind(node, Ast.NodeKind.LiteralExpression);
 }
 
 export function assertIsLogicalExpression(node: Ast.TNode): asserts node is Ast.LogicalExpression {
-    assertIsNodeKind(TypeGuards.isLogicalExpression, node, Ast.NodeKind.LogicalExpression);
+    assertIsNodeKind(node, Ast.NodeKind.LogicalExpression);
 }
 
 export function assertIsMetadataExpression(node: Ast.TNode): asserts node is Ast.MetadataExpression {
-    assertIsNodeKind(TypeGuards.isMetadataExpression, node, Ast.NodeKind.MetadataExpression);
+    assertIsNodeKind(node, Ast.NodeKind.MetadataExpression);
 }
 
 export function assertIsNodeKind<T extends Ast.TNode>(
-    predicateFn: (node: Ast.TNode, expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"]) => node is T,
     node: Ast.TNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): asserts node is T {
-    if (!predicateFn(node, expectedNodeKinds)) {
+    if (!TypeGuards.isNodeKind(node, expectedNodeKinds)) {
         throw new CommonError.InvariantError(`unexpected node kind`, {
             nodeId: node.id,
             nodeKind: node.kind,
@@ -414,79 +405,75 @@ export function assertIsNodeKind<T extends Ast.TNode>(
 }
 
 export function assertIsNotImplementedExpression(node: Ast.TNode): asserts node is Ast.NotImplementedExpression {
-    assertIsNodeKind<Ast.NotImplementedExpression>(
-        TypeGuards.isNotImplementedExpression,
-        node,
-        Ast.NodeKind.NotImplementedExpression,
-    );
+    assertIsNodeKind(node, Ast.NodeKind.NotImplementedExpression);
 }
 
 export function assertIsNullCoalescingExpression(node: Ast.TNode): asserts node is Ast.NullCoalescingExpression {
-    assertIsNodeKind(TypeGuards.isNullCoalescingExpression, node, Ast.NodeKind.NullCoalescingExpression);
+    assertIsNodeKind(node, Ast.NodeKind.NullCoalescingExpression);
 }
 
 export function assertIsNullablePrimitiveType(node: Ast.TNode): asserts node is Ast.NullablePrimitiveType {
-    assertIsNodeKind(TypeGuards.isNullablePrimitiveType, node, Ast.NodeKind.NullablePrimitiveType);
+    assertIsNodeKind(node, Ast.NodeKind.NullablePrimitiveType);
 }
 
 export function assertIsNullableType(node: Ast.TNode): asserts node is Ast.NullableType {
-    assertIsNodeKind(TypeGuards.isNullableType, node, Ast.NodeKind.NullableType);
+    assertIsNodeKind(node, Ast.NodeKind.NullableType);
 }
 
 export function assertIsOtherwiseExpression(node: Ast.TNode): asserts node is Ast.OtherwiseExpression {
-    assertIsNodeKind(TypeGuards.isOtherwiseExpression, node, Ast.NodeKind.OtherwiseExpression);
+    assertIsNodeKind(node, Ast.NodeKind.OtherwiseExpression);
 }
 
 export function assertIsParenthesizedExpression(node: Ast.TNode): asserts node is Ast.ParenthesizedExpression {
-    assertIsNodeKind(TypeGuards.isParenthesizedExpression, node, Ast.NodeKind.ParenthesizedExpression);
+    assertIsNodeKind(node, Ast.NodeKind.ParenthesizedExpression);
 }
 
 export function assertIsPrimitiveType(node: Ast.TNode): asserts node is Ast.PrimitiveType {
-    assertIsNodeKind(TypeGuards.isPrimitiveType, node, Ast.NodeKind.PrimitiveType);
+    assertIsNodeKind(node, Ast.NodeKind.PrimitiveType);
 }
 
 export function assertIsRangeExpression(node: Ast.TNode): asserts node is Ast.RangeExpression {
-    assertIsNodeKind(TypeGuards.isRangeExpression, node, Ast.NodeKind.RangeExpression);
+    assertIsNodeKind(node, Ast.NodeKind.RangeExpression);
 }
 
 export function assertIsRecordExpression(node: Ast.TNode): asserts node is Ast.RecordExpression {
-    assertIsNodeKind(TypeGuards.isRecordExpression, node, Ast.NodeKind.RecordExpression);
+    assertIsNodeKind(node, Ast.NodeKind.RecordExpression);
 }
 
 export function assertIsRecordLiteral(node: Ast.TNode): asserts node is Ast.RecordLiteral {
-    assertIsNodeKind(TypeGuards.isRecordLiteral, node, Ast.NodeKind.RecordLiteral);
+    assertIsNodeKind(node, Ast.NodeKind.RecordLiteral);
 }
 
 export function assertIsRecordType(node: Ast.TNode): asserts node is Ast.RecordType {
-    assertIsNodeKind(TypeGuards.isRecordType, node, Ast.NodeKind.RecordType);
+    assertIsNodeKind(node, Ast.NodeKind.RecordType);
 }
 
 export function assertIsRecursivePrimaryExpression(node: Ast.TNode): asserts node is Ast.RecursivePrimaryExpression {
-    assertIsNodeKind(TypeGuards.isRecursivePrimaryExpression, node, Ast.NodeKind.RecursivePrimaryExpression);
+    assertIsNodeKind(node, Ast.NodeKind.RecursivePrimaryExpression);
 }
 
 export function assertIsRelationalExpression(node: Ast.TNode): asserts node is Ast.RelationalExpression {
-    assertIsNodeKind(TypeGuards.isRelationalExpression, node, Ast.NodeKind.RelationalExpression);
+    assertIsNodeKind(node, Ast.NodeKind.RelationalExpression);
 }
 
 export function assertIsSection(node: Ast.TNode): asserts node is Ast.Section {
-    assertIsNodeKind(TypeGuards.isSection, node, Ast.NodeKind.Section);
+    assertIsNodeKind(node, Ast.NodeKind.Section);
 }
 
 export function assertIsSectionMember(node: Ast.TNode): asserts node is Ast.SectionMember {
-    assertIsNodeKind(TypeGuards.isSectionMember, node, Ast.NodeKind.SectionMember);
+    assertIsNodeKind(node, Ast.NodeKind.SectionMember);
 }
 
 export function assertIsTableType(node: Ast.TNode): asserts node is Ast.TableType {
-    assertIsNodeKind(TypeGuards.isTableType, node, Ast.NodeKind.TableType);
+    assertIsNodeKind(node, Ast.NodeKind.TableType);
 }
 
 export function assertIsTArrayWrapper(node: Ast.TNode): asserts node is Ast.TArrayWrapper {
-    assertIsNodeKind(TypeGuards.isTArrayWrapper, node, Ast.NodeKind.ArrayWrapper);
+    assertIsNodeKind(node, Ast.NodeKind.ArrayWrapper);
 }
 
 export function assertIsTBinOpExpression(node: Ast.TNode): asserts node is Ast.TBinOpExpression {
-    assertIsNodeKind(TypeGuards.isTBinOpExpression, node, [
+    assertIsNodeKind(node, [
         Ast.NodeKind.ArithmeticExpression,
         Ast.NodeKind.AsExpression,
         Ast.NodeKind.EqualityExpression,
@@ -498,15 +485,15 @@ export function assertIsTBinOpExpression(node: Ast.TNode): asserts node is Ast.T
 }
 
 export function assertIsTConstant(node: Ast.TNode): asserts node is Ast.TConstant {
-    assertIsNodeKind(TypeGuards.isTConstant, node, Ast.NodeKind.Constant);
+    assertIsNodeKind(node, Ast.NodeKind.Constant);
 }
 
 export function assertIsTCsv(node: Ast.TNode): asserts node is Ast.TCsv {
-    assertIsNodeKind(TypeGuards.isTCsv, node, [Ast.NodeKind.Csv]);
+    assertIsNodeKind(node, [Ast.NodeKind.Csv]);
 }
 
 export function assertIsTKeyValuePair(node: Ast.TNode): asserts node is Ast.TKeyValuePair {
-    assertIsNodeKind(TypeGuards.isTKeyValuePair, node, [
+    assertIsNodeKind(node, [
         Ast.NodeKind.GeneralizedIdentifierPairedAnyLiteral,
         Ast.NodeKind.GeneralizedIdentifierPairedExpression,
         Ast.NodeKind.IdentifierPairedExpression,
@@ -514,7 +501,7 @@ export function assertIsTKeyValuePair(node: Ast.TNode): asserts node is Ast.TKey
 }
 
 export function assertIsTPairedConstant(node: Ast.TNode): asserts node is Ast.TPairedConstant {
-    assertIsNodeKind(TypeGuards.isTPairedConstant, node, [
+    assertIsNodeKind(node, [
         Ast.NodeKind.AsNullablePrimitiveType,
         Ast.NodeKind.AsType,
         Ast.NodeKind.ErrorRaisingExpression,
@@ -527,19 +514,14 @@ export function assertIsTPairedConstant(node: Ast.TNode): asserts node is Ast.TP
 }
 
 export function assertIsTypePrimaryType(node: Ast.TNode): asserts node is Ast.TypePrimaryType {
-    assertIsNodeKind(TypeGuards.isTypePrimaryType, node, Ast.NodeKind.TypePrimaryType);
+    assertIsNodeKind(node, Ast.NodeKind.TypePrimaryType);
 }
 
 export function assertIsUnaryExpression(node: Ast.TNode): asserts node is Ast.UnaryExpression {
-    assertIsNodeKind(TypeGuards.isUnaryExpression, node, Ast.NodeKind.UnaryExpression);
+    assertIsNodeKind(node, Ast.NodeKind.UnaryExpression);
 }
 
-function assertAs<T extends Ast.TNode>(
-    predicateFn: (node: Ast.TNode) => node is T,
-    node: Ast.TNode,
-    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): T {
-    assertIsNodeKind<T>(predicateFn, node, expectedNodeKinds);
-
+function assertAs<T extends Ast.TNode>(node: Ast.TNode, expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"]): T {
+    assertIsNodeKind<T>(node, expectedNodeKinds);
     return node;
 }

--- a/src/powerquery-parser/language/ast/astUtils/typeGuards.ts
+++ b/src/powerquery-parser/language/ast/astUtils/typeGuards.ts
@@ -237,6 +237,23 @@ export function isTBinOpExpression(node: Ast.TNode): node is Ast.TBinOpExpressio
     ]);
 }
 
+export function isTBinOpExpressionKind(nodeKind: Ast.NodeKind): nodeKind is Ast.TBinOpExpressionNodeKind {
+    switch (nodeKind) {
+        case Ast.NodeKind.ArithmeticExpression:
+        case Ast.NodeKind.AsExpression:
+        case Ast.NodeKind.EqualityExpression:
+        case Ast.NodeKind.IsExpression:
+        case Ast.NodeKind.LogicalExpression:
+        case Ast.NodeKind.NullCoalescingExpression:
+        case Ast.NodeKind.MetadataExpression:
+        case Ast.NodeKind.RelationalExpression:
+            return true;
+
+        default:
+            return false;
+    }
+}
+
 export function isTConstant(node: Ast.TNode): node is Ast.TConstant {
     return node.kind === Ast.NodeKind.Constant;
 }

--- a/src/powerquery-parser/language/ast/astUtils/typeGuards.ts
+++ b/src/powerquery-parser/language/ast/astUtils/typeGuards.ts
@@ -15,10 +15,6 @@ export function isAsNullablePrimitiveType(node: Ast.TNode): node is Ast.AsNullab
     return node.kind === Ast.NodeKind.AsNullablePrimitiveType;
 }
 
-export function isAnyNodeKind<T extends Ast.TNode>(node: Ast.TNode, nodeKinds: ReadonlyArray<T["kind"]>): node is T {
-    return nodeKinds.includes(node.kind);
-}
-
 export function isAsType(node: Ast.TNode): node is Ast.AsType {
     return node.kind === Ast.NodeKind.AsType;
 }
@@ -143,8 +139,11 @@ export function isMetadataExpression(node: Ast.TNode): node is Ast.MetadataExpre
     return node.kind === Ast.NodeKind.MetadataExpression;
 }
 
-export function isNodeKind<T extends Ast.TNode>(node: Ast.TNode, nodeKind: T["kind"]): node is T {
-    return node.kind === nodeKind;
+export function isNodeKind<T extends Ast.TNode>(
+    node: Ast.TNode,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
+): node is T {
+    return Array.isArray(expectedNodeKinds) ? expectedNodeKinds.includes(node.kind) : node.kind === expectedNodeKinds;
 }
 
 export function isNotImplementedExpression(node: Ast.TNode): node is Ast.NotImplementedExpression {
@@ -216,7 +215,7 @@ export function isTArrayWrapper(node: Ast.TNode): node is Ast.TArrayWrapper {
 }
 
 export function isTBinOpExpression(node: Ast.TNode): node is Ast.TBinOpExpression {
-    return isAnyNodeKind<
+    return isNodeKind<
         | Ast.ArithmeticExpression
         | Ast.AsExpression
         | Ast.EqualityExpression

--- a/src/powerquery-parser/language/ast/astUtils/typeGuards.ts
+++ b/src/powerquery-parser/language/ast/astUtils/typeGuards.ts
@@ -15,6 +15,10 @@ export function isAsNullablePrimitiveType(node: Ast.TNode): node is Ast.AsNullab
     return node.kind === Ast.NodeKind.AsNullablePrimitiveType;
 }
 
+export function isAnyNodeKind<T extends Ast.TNode>(node: Ast.TNode, nodeKinds: ReadonlyArray<T["kind"]>): node is T {
+    return nodeKinds.includes(node.kind);
+}
+
 export function isAsType(node: Ast.TNode): node is Ast.AsType {
     return node.kind === Ast.NodeKind.AsType;
 }
@@ -139,6 +143,10 @@ export function isMetadataExpression(node: Ast.TNode): node is Ast.MetadataExpre
     return node.kind === Ast.NodeKind.MetadataExpression;
 }
 
+export function isNodeKind<T extends Ast.TNode>(node: Ast.TNode, nodeKind: T["kind"]): node is T {
+    return node.kind === nodeKind;
+}
+
 export function isNotImplementedExpression(node: Ast.TNode): node is Ast.NotImplementedExpression {
     return node.kind === Ast.NodeKind.NotImplementedExpression;
 }
@@ -208,24 +216,25 @@ export function isTArrayWrapper(node: Ast.TNode): node is Ast.TArrayWrapper {
 }
 
 export function isTBinOpExpression(node: Ast.TNode): node is Ast.TBinOpExpression {
-    return isTBinOpExpressionKind(node.kind);
-}
-
-export function isTBinOpExpressionKind(nodeKind: Ast.NodeKind): nodeKind is Ast.TBinOpExpressionNodeKind {
-    switch (nodeKind) {
-        case Ast.NodeKind.ArithmeticExpression:
-        case Ast.NodeKind.AsExpression:
-        case Ast.NodeKind.EqualityExpression:
-        case Ast.NodeKind.IsExpression:
-        case Ast.NodeKind.LogicalExpression:
-        case Ast.NodeKind.NullCoalescingExpression:
-        case Ast.NodeKind.MetadataExpression:
-        case Ast.NodeKind.RelationalExpression:
-            return true;
-
-        default:
-            return false;
-    }
+    return isAnyNodeKind<
+        | Ast.ArithmeticExpression
+        | Ast.AsExpression
+        | Ast.EqualityExpression
+        | Ast.IsExpression
+        | Ast.LogicalExpression
+        | Ast.NullCoalescingExpression
+        | Ast.MetadataExpression
+        | Ast.RelationalExpression
+    >(node, [
+        Ast.NodeKind.ArithmeticExpression,
+        Ast.NodeKind.AsExpression,
+        Ast.NodeKind.EqualityExpression,
+        Ast.NodeKind.IsExpression,
+        Ast.NodeKind.LogicalExpression,
+        Ast.NodeKind.NullCoalescingExpression,
+        Ast.NodeKind.MetadataExpression,
+        Ast.NodeKind.RelationalExpression,
+    ]);
 }
 
 export function isTConstant(node: Ast.TNode): node is Ast.TConstant {

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -163,9 +163,9 @@ function inspectAstParameter(node: Ast.TParameter): Type.FunctionParameter {
     };
 }
 
-function inspectContextParameter<T extends Ast.TNode>(
+function inspectContextParameter(
     nodeIdMapCollection: NodeIdMap.Collection,
-    parameter: ParseContext.Node<T>,
+    parameter: ParseContext.Node<Ast.TParameter>,
 ): Type.FunctionParameter | undefined {
     let isOptional: boolean;
     let isNullable: boolean;

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -171,7 +171,7 @@ function inspectContextParameter(
     let isNullable: boolean;
     let maybeType: Type.TypeKind | undefined;
 
-    const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeNthChildIfAst(
+    const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
         nodeIdMapCollection,
         parameter.id,
         1,
@@ -181,7 +181,7 @@ function inspectContextParameter(
         return undefined;
     }
 
-    const maybeOptional: Ast.TConstant | undefined = NodeIdMapUtils.maybeNthChildIfAst(
+    const maybeOptional: Ast.TConstant | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
         nodeIdMapCollection,
         parameter.id,
         0,
@@ -189,7 +189,7 @@ function inspectContextParameter(
     );
     isOptional = maybeOptional !== undefined;
 
-    const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeNthChildIfAst(
+    const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
         nodeIdMapCollection,
         parameter.id,
         2,

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -171,7 +171,7 @@ function inspectContextParameter(
     let isNullable: boolean;
     let maybeType: Type.TypeKind | undefined;
 
-    const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeNthChildAsAstChecked(
+    const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeNthChildIfAstChecked(
         nodeIdMapCollection,
         parameter.id,
         1,
@@ -181,7 +181,7 @@ function inspectContextParameter(
         return undefined;
     }
 
-    const maybeOptional: Ast.TConstant | undefined = NodeIdMapUtils.maybeNthChildAsAstChecked(
+    const maybeOptional: Ast.TConstant | undefined = NodeIdMapUtils.maybeNthChildIfAstChecked(
         nodeIdMapCollection,
         parameter.id,
         0,
@@ -189,7 +189,7 @@ function inspectContextParameter(
     );
     isOptional = maybeOptional !== undefined;
 
-    const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeNthChildAsAstChecked(
+    const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeNthChildIfAstChecked(
         nodeIdMapCollection,
         parameter.id,
         2,

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -4,7 +4,7 @@
 import { Type } from "..";
 import { Ast, AstUtils } from "../..";
 import { Assert } from "../../../common";
-import { NodeIdMap, NodeIdMapUtils, ParseContext, TXorNode, XorNodeKind } from "../../../parser";
+import { NodeIdMap, NodeIdMapUtils, ParseContext, XorNode, XorNodeKind } from "../../../parser";
 import { createPrimitiveType } from "./factories";
 import { isCompatible } from "./isCompatible";
 import { isEqualType } from "./isEqualType";
@@ -110,11 +110,11 @@ export function isValidInvocation(
 
 export function inspectParameter(
     nodeIdMapCollection: NodeIdMap.Collection,
-    parameter: TXorNode,
+    parameter: XorNode<Ast.TParameter>,
 ): Type.FunctionParameter | undefined {
     switch (parameter.kind) {
         case XorNodeKind.Ast:
-            return inspectAstParameter(parameter.node as Ast.TParameter);
+            return inspectAstParameter(parameter.node);
 
         case XorNodeKind.Context:
             return inspectContextParameter(nodeIdMapCollection, parameter.node);

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -171,7 +171,7 @@ function inspectContextParameter(
     let isNullable: boolean;
     let maybeType: Type.TypeKind | undefined;
 
-    const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+    const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
         nodeIdMapCollection,
         parameter.id,
         1,
@@ -181,7 +181,7 @@ function inspectContextParameter(
         return undefined;
     }
 
-    const maybeOptional: Ast.TConstant | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+    const maybeOptional: Ast.TConstant | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
         nodeIdMapCollection,
         parameter.id,
         0,
@@ -189,7 +189,7 @@ function inspectContextParameter(
     );
     isOptional = maybeOptional !== undefined;
 
-    const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+    const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
         nodeIdMapCollection,
         parameter.id,
         2,

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -163,9 +163,9 @@ function inspectAstParameter(node: Ast.TParameter): Type.FunctionParameter {
     };
 }
 
-function inspectContextParameter(
+function inspectContextParameter<T extends Ast.TNode>(
     nodeIdMapCollection: NodeIdMap.Collection,
-    parameter: ParseContext.Node,
+    parameter: ParseContext.Node<T>,
 ): Type.FunctionParameter | undefined {
     let isOptional: boolean;
     let isNullable: boolean;

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -171,32 +171,32 @@ function inspectContextParameter(
     let isNullable: boolean;
     let maybeType: Type.TypeKind | undefined;
 
-    const maybeName: Ast.TNode | undefined = NodeIdMapUtils.maybeChildAstByAttributeIndex(
+    const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeNthChildAsAstChecked(
         nodeIdMapCollection,
         parameter.id,
         1,
-        [Ast.NodeKind.Identifier],
+        Ast.NodeKind.Identifier,
     );
     if (maybeName === undefined) {
         return undefined;
     }
 
-    const maybeOptional: Ast.TNode | undefined = NodeIdMapUtils.maybeChildAstByAttributeIndex(
+    const maybeOptional: Ast.TConstant | undefined = NodeIdMapUtils.maybeNthChildAsAstChecked(
         nodeIdMapCollection,
         parameter.id,
         0,
-        [Ast.NodeKind.Constant],
+        Ast.NodeKind.Constant,
     );
     isOptional = maybeOptional !== undefined;
 
-    const maybeParameterType: Ast.TNode | undefined = NodeIdMapUtils.maybeChildAstByAttributeIndex(
+    const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeNthChildAsAstChecked(
         nodeIdMapCollection,
         parameter.id,
         2,
-        undefined,
+        Ast.NodeKind.AsNullablePrimitiveType,
     );
     if (maybeParameterType !== undefined) {
-        const parameterType: Ast.AsNullablePrimitiveType = maybeParameterType as Ast.AsNullablePrimitiveType;
+        const parameterType: Ast.AsNullablePrimitiveType = maybeParameterType;
         const simplified: AstUtils.SimplifiedType = AstUtils.simplifyAsNullablePrimitiveType(parameterType);
         isNullable = simplified.isNullable;
         maybeType = typeKindFromPrimitiveTypeConstantKind(simplified.primitiveTypeConstantKind);
@@ -206,7 +206,7 @@ function inspectContextParameter(
     }
 
     return {
-        nameLiteral: (maybeName as Ast.Identifier).literal,
+        nameLiteral: maybeName.literal,
         isOptional,
         isNullable,
         maybeType,

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -171,7 +171,7 @@ function inspectContextParameter(
     let isNullable: boolean;
     let maybeType: Type.TypeKind | undefined;
 
-    const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeNthChildIfAstChecked(
+    const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeNthChildIfAst(
         nodeIdMapCollection,
         parameter.id,
         1,
@@ -181,7 +181,7 @@ function inspectContextParameter(
         return undefined;
     }
 
-    const maybeOptional: Ast.TConstant | undefined = NodeIdMapUtils.maybeNthChildIfAstChecked(
+    const maybeOptional: Ast.TConstant | undefined = NodeIdMapUtils.maybeNthChildIfAst(
         nodeIdMapCollection,
         parameter.id,
         0,
@@ -189,7 +189,7 @@ function inspectContextParameter(
     );
     isOptional = maybeOptional !== undefined;
 
-    const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeNthChildIfAstChecked(
+    const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeNthChildIfAst(
         nodeIdMapCollection,
         parameter.id,
         2,

--- a/src/powerquery-parser/parser/context/context.ts
+++ b/src/powerquery-parser/parser/context/context.ts
@@ -27,14 +27,14 @@ import { Ast, Token } from "../../language";
 
 export interface State {
     readonly nodeIdMapCollection: NodeIdMap.Collection;
-    maybeRoot: Node | undefined;
+    maybeRoot: Node<Ast.TNode> | undefined;
     idCounter: number;
     leafIds: Set<number>;
 }
 
-export interface Node {
+export interface Node<T extends Ast.TNode> {
     readonly id: number;
-    readonly kind: Ast.NodeKind;
+    readonly kind: T["kind"];
     readonly tokenIndexStart: number;
     readonly maybeTokenStart: Token.Token | undefined;
     // Incremented for each child context created with the Node as its parent,
@@ -43,3 +43,5 @@ export interface Node {
     maybeAttributeIndex: number | undefined;
     isClosed: boolean;
 }
+
+export type TNode = Node<Ast.TNode>;

--- a/src/powerquery-parser/parser/context/contextUtils.ts
+++ b/src/powerquery-parser/parser/context/contextUtils.ts
@@ -5,12 +5,11 @@ import { NodeIdMap, ParseContext } from "..";
 import { ArrayUtils, Assert, CommonError, MapUtils, SetUtils, TypeScriptUtils } from "../../common";
 import { Ast, Token } from "../../language";
 import { NodeIdMapIterator, NodeIdMapUtils, TXorNode } from "../nodeIdMap";
-import { Node, State } from "./context";
 
 export function assertIsNodeKind<T extends Ast.TNode>(
-    node: Node,
+    node: ParseContext.TNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): void {
+): asserts node is ParseContext.Node<T> {
     if (!isNodeKind(node, expectedNodeKinds)) {
         throw new CommonError.InvariantError(`expected parse context node has a different than expected node kind`, {
             nodeId: node.id,
@@ -20,7 +19,7 @@ export function assertIsNodeKind<T extends Ast.TNode>(
     }
 }
 
-export function createState(): State {
+export function createState(): ParseContext.State {
     return {
         nodeIdMapCollection: {
             astNodeById: new Map(),
@@ -37,8 +36,9 @@ export function createState(): State {
     };
 }
 
-export function copyState(state: State): State {
-    const maybeRoot: Node | undefined = state.maybeRoot !== undefined ? { ...state.maybeRoot } : undefined;
+export function copyState(state: ParseContext.State): ParseContext.State {
+    const maybeRoot: ParseContext.TNode | undefined =
+        state.maybeRoot !== undefined ? { ...state.maybeRoot } : undefined;
 
     return {
         ...state,
@@ -47,28 +47,31 @@ export function copyState(state: State): State {
     };
 }
 
-export function isNodeKind(node: Node, expectedNodeKinds: ReadonlyArray<Ast.NodeKind> | Ast.NodeKind): boolean {
+export function isNodeKind<T extends Ast.TNode>(
+    node: ParseContext.TNode,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
+): node is ParseContext.Node<T> {
     return node.kind === expectedNodeKinds || expectedNodeKinds.includes(node.kind);
 }
 
-export function nextId(state: State): number {
+export function nextId(state: ParseContext.State): number {
     state.idCounter += 1;
     return state.idCounter;
 }
 
-export function nextAttributeIndex(parentNode: Node): number {
+export function nextAttributeIndex(parentNode: ParseContext.TNode): number {
     const result: number = parentNode.attributeCounter;
     parentNode.attributeCounter += 1;
     return result;
 }
 
-export function startContext(
-    state: State,
+export function startContext<T extends Ast.TNode>(
+    state: ParseContext.State,
     nodeKind: Ast.NodeKind,
     tokenIndexStart: number,
     maybeTokenStart: Token.Token | undefined,
-    maybeParentNode: Node | undefined,
-): Node {
+    maybeParentNode: ParseContext.TNode | undefined,
+): ParseContext.Node<T> {
     const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
     let maybeAttributeIndex: number | undefined;
 
@@ -77,7 +80,7 @@ export function startContext(
     // If a parent context Node exists, update the parent/child mapping attributes and attributeCounter.
     if (maybeParentNode) {
         const childIdsById: NodeIdMap.ChildIdsById = nodeIdMapCollection.childIdsById;
-        const parentNode: Node = maybeParentNode;
+        const parentNode: ParseContext.TNode = maybeParentNode;
         const parentId: number = parentNode.id;
 
         maybeAttributeIndex = nextAttributeIndex(parentNode);
@@ -92,7 +95,7 @@ export function startContext(
         }
     }
 
-    const contextNode: Node = {
+    const contextNode: ParseContext.Node<T> = {
         id: nodeId,
         kind: nodeKind,
         tokenIndexStart,
@@ -118,7 +121,11 @@ export function startContext(
 }
 
 // Returns the Node's parent context (if one exists).
-export function endContext(state: State, contextNode: Node, astNode: Ast.TNode): Node | undefined {
+export function endContext<T extends Ast.TNode>(
+    state: ParseContext.State,
+    contextNode: ParseContext.Node<T>,
+    astNode: T,
+): ParseContext.TNode | undefined {
     const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
 
     if (state.maybeRoot?.id === astNode.id) {
@@ -142,7 +149,7 @@ export function endContext(state: State, contextNode: Node, astNode: Ast.TNode):
 
     // Ending a context should return the context's parent node (if one exists).
     const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(contextNode.id);
-    const maybeParentNode: Node | undefined =
+    const maybeParentNode: ParseContext.TNode | undefined =
         maybeParentId !== undefined ? nodeIdMapCollection.contextNodeById.get(maybeParentId) : undefined;
 
     // Move nodeId from contextNodeMap to astNodeMap.
@@ -168,7 +175,7 @@ export function endContext(state: State, contextNode: Node, astNode: Ast.TNode):
     return maybeParentNode;
 }
 
-export function deleteAst(state: State, nodeId: number, parentWillBeDeleted: boolean): void {
+export function deleteAst(state: ParseContext.State, nodeId: number, parentWillBeDeleted: boolean): void {
     const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
 
     const astNodeById: NodeIdMap.AstNodeById = nodeIdMapCollection.astNodeById;
@@ -228,7 +235,7 @@ export function deleteAst(state: State, nodeId: number, parentWillBeDeleted: boo
     parentIdById.delete(nodeId);
 }
 
-export function deleteContext(state: State, nodeId: number): Node | undefined {
+export function deleteContext(state: ParseContext.State, nodeId: number): ParseContext.TNode | undefined {
     const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
 
     const childIdsById: NodeIdMap.ChildIdsById = nodeIdMapCollection.childIdsById;
@@ -236,13 +243,13 @@ export function deleteContext(state: State, nodeId: number): Node | undefined {
     const leafIds: Set<number> = nodeIdMapCollection.leafIds;
     const parentIdById: NodeIdMap.ParentIdById = nodeIdMapCollection.parentIdById;
 
-    const maybeContextNode: Node | undefined = contextNodeById.get(nodeId);
+    const maybeContextNode: ParseContext.TNode | undefined = contextNodeById.get(nodeId);
     if (maybeContextNode === undefined) {
         throw new CommonError.InvariantError(`failed to deleteContext as the given nodeId isn't a valid context node`, {
             nodeId,
         });
     }
-    const contextNode: Node = maybeContextNode;
+    const contextNode: ParseContext.TNode = maybeContextNode;
 
     const maybeParentId: number | undefined = parentIdById.get(nodeId);
     const maybeChildIds: ReadonlyArray<number> | undefined = childIdsById.get(nodeId);
@@ -257,9 +264,9 @@ export function deleteContext(state: State, nodeId: number): Node | undefined {
         // Promote the child to the root if it's a Context node.
         if (maybeParentId === undefined) {
             parentIdById.delete(childId);
-            const maybeChildContext: Node | undefined = contextNodeById.get(childId);
+            const maybeChildContext: ParseContext.TNode | undefined = contextNodeById.get(childId);
             if (maybeChildContext) {
-                const childContext: Node = maybeChildContext;
+                const childContext: ParseContext.TNode = maybeChildContext;
                 state.maybeRoot = childContext;
             }
         }
@@ -272,7 +279,7 @@ export function deleteContext(state: State, nodeId: number): Node | undefined {
 
         // The child Node inherits the attributeIndex.
         const childXorNode: TXorNode = NodeIdMapUtils.assertGetXor(state.nodeIdMapCollection, childId);
-        const mutableChildXorNode: TypeScriptUtils.StripReadonly<Ast.TNode | Node> = childXorNode.node;
+        const mutableChildXorNode: TypeScriptUtils.StripReadonly<Ast.TNode | ParseContext.TNode> = childXorNode.node;
         mutableChildXorNode.maybeAttributeIndex = contextNode.maybeAttributeIndex;
     }
     // Is a leaf node, not root node.
@@ -360,7 +367,7 @@ function removeOrReplaceChildId(
         childIdsById.delete(parentId);
     }
 
-    const maybeParent: ParseContext.Node | undefined = nodeIdMapCollection.contextNodeById.get(parentId);
+    const maybeParent: ParseContext.TNode | undefined = nodeIdMapCollection.contextNodeById.get(parentId);
     if (maybeParent !== undefined && maybeReplacementId === undefined) {
         maybeParent.attributeCounter -= 1;
     }

--- a/src/powerquery-parser/parser/context/contextUtils.ts
+++ b/src/powerquery-parser/parser/context/contextUtils.ts
@@ -275,7 +275,7 @@ export function deleteContext(state: State, nodeId: number): Node | undefined {
     leafIds.delete(nodeId);
 
     // Return the node's parent if it exits
-    return maybeParentId !== undefined ? NodeIdMapUtils.assertGetContext(contextNodeById, maybeParentId) : undefined;
+    return maybeParentId !== undefined ? NodeIdMapUtils.assertUnwrapContext(contextNodeById, maybeParentId) : undefined;
 }
 
 function deleteFromKindMap(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): void {

--- a/src/powerquery-parser/parser/context/contextUtils.ts
+++ b/src/powerquery-parser/parser/context/contextUtils.ts
@@ -275,7 +275,7 @@ export function deleteContext(state: State, nodeId: number): Node | undefined {
     leafIds.delete(nodeId);
 
     // Return the node's parent if it exits
-    return maybeParentId !== undefined ? NodeIdMapUtils.assertContext(contextNodeById, maybeParentId) : undefined;
+    return maybeParentId !== undefined ? NodeIdMapUtils.assertGetContext(contextNodeById, maybeParentId) : undefined;
 }
 
 function deleteFromKindMap(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): void {

--- a/src/powerquery-parser/parser/context/contextUtils.ts
+++ b/src/powerquery-parser/parser/context/contextUtils.ts
@@ -7,6 +7,19 @@ import { Ast, Token } from "../../language";
 import { NodeIdMapIterator, NodeIdMapUtils, TXorNode } from "../nodeIdMap";
 import { Node, State } from "./context";
 
+export function assertIsNodeKind<T extends Ast.TNode>(
+    node: Node,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
+): void {
+    if (!isNodeKind(node, expectedNodeKinds)) {
+        throw new CommonError.InvariantError(`expected parse context node has a different than expected node kind`, {
+            nodeId: node.id,
+            nodeKind: node.kind,
+            expectedNodeKinds,
+        });
+    }
+}
+
 export function createState(): State {
     return {
         nodeIdMapCollection: {
@@ -32,6 +45,10 @@ export function copyState(state: State): State {
         maybeRoot,
         nodeIdMapCollection: NodeIdMapUtils.copy(state.nodeIdMapCollection),
     };
+}
+
+export function isNodeKind(node: Node, expectedNodeKinds: ReadonlyArray<Ast.NodeKind> | Ast.NodeKind): boolean {
+    return node.kind === expectedNodeKinds || expectedNodeKinds.includes(node.kind);
 }
 
 export function nextId(state: State): number {

--- a/src/powerquery-parser/parser/context/contextUtils.ts
+++ b/src/powerquery-parser/parser/context/contextUtils.ts
@@ -275,7 +275,7 @@ export function deleteContext(state: State, nodeId: number): Node | undefined {
     leafIds.delete(nodeId);
 
     // Return the node's parent if it exits
-    return maybeParentId !== undefined ? NodeIdMapUtils.assertUnwrapContext(contextNodeById, maybeParentId) : undefined;
+    return maybeParentId !== undefined ? NodeIdMapUtils.assertContext(contextNodeById, maybeParentId) : undefined;
 }
 
 function deleteFromKindMap(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): void {

--- a/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
+++ b/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
@@ -306,7 +306,7 @@ function readParenthesizedExpressionOrBinOpExpression(
 ): Ast.ParenthesizedExpression | Ast.TLogicalExpression {
     const node: Ast.TNode = parser.readLogicalExpression(state, parser);
 
-    const leftMostNode: Ast.TNode = NodeIdMapUtils.assertUnwrapLeftMostAstXor(
+    const leftMostNode: Ast.TNode = NodeIdMapUtils.assertUnwrapLeftMostLeaf(
         state.contextState.nodeIdMapCollection,
         node.id,
     );

--- a/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
+++ b/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
@@ -306,7 +306,7 @@ function readParenthesizedExpressionOrBinOpExpression(
 ): Ast.ParenthesizedExpression | Ast.TLogicalExpression {
     const node: Ast.TNode = parser.readLogicalExpression(state, parser);
 
-    const leftMostNode: Ast.TNode = NodeIdMapUtils.assertGetLeftMostAst(
+    const leftMostNode: Ast.TNode = NodeIdMapUtils.assertUnwrapLeftMostAstXor(
         state.contextState.nodeIdMapCollection,
         node.id,
     );

--- a/src/powerquery-parser/parser/nodeIdMap/ancestryUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/ancestryUtils.ts
@@ -21,63 +21,63 @@ export function assertGetAncestry(nodeIdMapCollection: NodeIdMap.Collection, roo
 
 export function assertGetLeaf<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> {
-    return assertGetNthXor(ancestry, 0, expectedNodeKinds);
+    return assertGetNthXor(ancestry, 0, maybeExpectedNodeKinds);
 }
 
 export function assertGetRoot<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> {
     Assert.isTrue(ancestry.length > 0, "ancestry.length > 0");
-    return assertGetNthXor(ancestry, ancestry.length - 1, expectedNodeKinds);
+    return assertGetNthXor(ancestry, ancestry.length - 1, maybeExpectedNodeKinds);
 }
 
 export function assertGetNextXor<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     ancestryIndex: number,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> {
-    return assertGetNthXor(ancestry, ancestryIndex + 1, expectedNodeKinds);
+    return assertGetNthXor(ancestry, ancestryIndex + 1, maybeExpectedNodeKinds);
 }
 
 export function assertGetPreviousXor<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     ancestryIndex: number,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> {
-    return assertGetNthXor(ancestry, ancestryIndex - 1, expectedNodeKinds);
+    return assertGetNthXor(ancestry, ancestryIndex - 1, maybeExpectedNodeKinds);
 }
 
 export function assertGetNthNextXor<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     ancestryIndex: number,
     offset: number = 1,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> {
-    return assertGetNthXor(ancestry, ancestryIndex + offset, expectedNodeKinds);
+    return assertGetNthXor(ancestry, ancestryIndex + offset, maybeExpectedNodeKinds);
 }
 
 export function assertGetNthPreviousXor<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     ancestryIndex: number,
     offset: number = 1,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> {
-    return assertGetNthXor(ancestry, ancestryIndex - offset, expectedNodeKinds);
+    return assertGetNthXor(ancestry, ancestryIndex - offset, maybeExpectedNodeKinds);
 }
 
 export function assertGetNthXor<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     ancestryIndex: number,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> {
-    const maybeXorNode: XorNode<T> | undefined = maybeNthXor(ancestry, ancestryIndex, expectedNodeKinds);
+    const maybeXorNode: XorNode<T> | undefined = maybeNthXor(ancestry, ancestryIndex, maybeExpectedNodeKinds);
     if (maybeXorNode === undefined) {
         throw new CommonError.InvariantError(`couldn't find the nth node or it had the incorrect node type`, {
             ancestryIndex,
-            expectedNodeKinds,
+            maybeExpectedNodeKinds,
             leafNodeId: assertGetLeaf(ancestry, undefined).node.id,
         });
     }
@@ -88,10 +88,13 @@ export function assertGetNthXor<T extends Ast.TNode>(
 export function maybeNthXor<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     ancestryIndex: number,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> | undefined {
     const maybeNode: TXorNode | undefined = ancestry[ancestryIndex];
-    if (maybeNode === undefined || (expectedNodeKinds && !XorNodeUtils.isNodeKind(maybeNode, expectedNodeKinds))) {
+    if (
+        maybeNode === undefined ||
+        (maybeExpectedNodeKinds && !XorNodeUtils.isNodeKind(maybeNode, maybeExpectedNodeKinds))
+    ) {
         return undefined;
     }
 
@@ -101,35 +104,35 @@ export function maybeNthXor<T extends Ast.TNode>(
 export function maybeNextXor<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     ancestryIndex: number,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> | undefined {
-    return maybeNthXor(ancestry, ancestryIndex + 1, expectedNodeKinds);
+    return maybeNthXor(ancestry, ancestryIndex + 1, maybeExpectedNodeKinds);
 }
 
 export function maybePreviousXor<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     ancestryIndex: number,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> | undefined {
-    return maybeNthXor(ancestry, ancestryIndex - 1, expectedNodeKinds);
+    return maybeNthXor(ancestry, ancestryIndex - 1, maybeExpectedNodeKinds);
 }
 
 export function maybeNthNextXor<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     ancestryIndex: number,
     offset: number = 1,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> | undefined {
-    return maybeNthXor(ancestry, ancestryIndex + offset, expectedNodeKinds);
+    return maybeNthXor(ancestry, ancestryIndex + offset, maybeExpectedNodeKinds);
 }
 
 export function maybeNthPreviousXor<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     ancestryIndex: number,
     offset: number = 1,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> | undefined {
-    return maybeNthXor(ancestry, ancestryIndex - offset, expectedNodeKinds);
+    return maybeNthXor(ancestry, ancestryIndex - offset, maybeExpectedNodeKinds);
 }
 
 export function maybeFirstXorAndIndexWhere(

--- a/src/powerquery-parser/parser/nodeIdMap/ancestryUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/ancestryUtils.ts
@@ -73,17 +73,16 @@ export function assertGetNthXor<T extends Ast.TNode>(
     ancestryIndex: number,
     expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> {
-    const maybeXorNode: TXorNode | undefined = maybeNthXor(ancestry, ancestryIndex, undefined);
+    const maybeXorNode: XorNode<T> | undefined = maybeNthXor(ancestry, ancestryIndex, expectedNodeKinds);
     if (maybeXorNode === undefined) {
-        throw new CommonError.InvariantError(`the given ancestryIndex is out of bounds`, { ancestryIndex });
+        throw new CommonError.InvariantError(`couldn't find the nth node or it had the incorrect node type`, {
+            ancestryIndex,
+            expectedNodeKinds,
+            leafNodeId: assertGetLeaf(ancestry, undefined).node.id,
+        });
     }
 
-    if (expectedNodeKinds !== undefined) {
-        XorNodeUtils.assertIsNodeKind(maybeXorNode, expectedNodeKinds);
-        return maybeXorNode;
-    }
-
-    return maybeXorNode as XorNode<T>;
+    return maybeXorNode;
 }
 
 export function maybeNthXor<T extends Ast.TNode>(
@@ -92,11 +91,11 @@ export function maybeNthXor<T extends Ast.TNode>(
     expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): XorNode<T> | undefined {
     const maybeNode: TXorNode | undefined = ancestry[ancestryIndex];
-    if (maybeNode && !XorNodeUtils.isNodeKind(maybeNode, expectedNodeKinds)) {
+    if (maybeNode === undefined || (expectedNodeKinds && !XorNodeUtils.isNodeKind(maybeNode, expectedNodeKinds))) {
         return undefined;
     }
 
-    return maybeNode;
+    return maybeNode as XorNode<T>;
 }
 
 export function maybeNextXor<T extends Ast.TNode>(
@@ -153,11 +152,10 @@ export function maybeFirstXorOfNodeKind<T extends Ast.TNode>(
     nodeKind: T["kind"],
 ): XorNode<T> | undefined {
     const maybeNode: TXorNode | undefined = ancestry.find((xorNode: TXorNode) => xorNode.node.kind === nodeKind);
-    if (maybeNode === undefined) {
+    if (maybeNode === undefined || !XorNodeUtils.isNodeKind(maybeNode, nodeKind)) {
         return undefined;
     }
 
-    XorNodeUtils.assertIsNodeKind(maybeNode, nodeKind);
     return maybeNode;
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMap.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMap.ts
@@ -6,7 +6,7 @@ import { Ast } from "../../language";
 
 export type AstNodeById = NumberMap<Ast.TNode>;
 export type ChildIdsById = NumberMap<ReadonlyArray<number>>;
-export type ContextNodeById = NumberMap<ParseContext.Node>;
+export type ContextNodeById = NumberMap<ParseContext.TNode>;
 export type IdsByNodeKind = Map<Ast.NodeKind, Set<number>>;
 export type ParentIdById = NumberMap<number>;
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -225,11 +225,11 @@ export function iterLetExpression(
 ): ReadonlyArray<LetKeyValuePair> {
     XorNodeUtils.assertAstNodeKind(letExpression, Ast.NodeKind.LetExpression);
 
-    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeChildXorByAttributeIndex(
+    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeNthChildChecked(
         nodeIdMapCollection,
         letExpression.node.id,
         1,
-        [Ast.NodeKind.ArrayWrapper],
+        Ast.NodeKind.ArrayWrapper,
     );
     if (maybeArrayWrapper === undefined) {
         return [];
@@ -293,11 +293,12 @@ export function iterSection(
         });
     }
 
-    const maybeSectionMemberArrayWrapper:
-        | undefined
-        | TXorNode = NodeIdMapUtils.maybeChildXorByAttributeIndex(nodeIdMapCollection, section.node.id, 4, [
+    const maybeSectionMemberArrayWrapper: undefined | TXorNode = NodeIdMapUtils.maybeNthChildChecked(
+        nodeIdMapCollection,
+        section.node.id,
+        4,
         Ast.NodeKind.ArrayWrapper,
-    ]);
+    );
     if (maybeSectionMemberArrayWrapper === undefined) {
         return [];
     }
@@ -305,11 +306,12 @@ export function iterSection(
 
     const partial: SectionKeyValuePair[] = [];
     for (const sectionMember of assertIterChildrenXor(nodeIdMapCollection, sectionMemberArrayWrapper.node.id)) {
-        const maybeKeyValuePair:
-            | undefined
-            | TXorNode = NodeIdMapUtils.maybeChildXorByAttributeIndex(nodeIdMapCollection, sectionMember.node.id, 2, [
+        const maybeKeyValuePair: undefined | TXorNode = NodeIdMapUtils.maybeNthChildChecked(
+            nodeIdMapCollection,
+            sectionMember.node.id,
+            2,
             Ast.NodeKind.IdentifierPairedExpression,
-        ]);
+        );
         if (maybeKeyValuePair === undefined) {
             continue;
         }
@@ -333,12 +335,7 @@ export function iterSection(
             key,
             keyLiteral,
             normalizedKeyLiteral: StringUtils.normalizeIdentifier(keyLiteral),
-            maybeValue: NodeIdMapUtils.maybeChildXorByAttributeIndex(
-                nodeIdMapCollection,
-                keyValuePairNodeId,
-                2,
-                undefined,
-            ),
+            maybeValue: NodeIdMapUtils.maybeNthChild(nodeIdMapCollection, keyValuePairNodeId, 2),
             pairKind: PairKind.SectionMember,
         });
     }
@@ -369,12 +366,7 @@ function iterKeyValuePairs<
             key,
             keyLiteral,
             normalizedKeyLiteral: StringUtils.normalizeIdentifier(keyLiteral),
-            maybeValue: NodeIdMapUtils.maybeChildXorByAttributeIndex(
-                nodeIdMapCollection,
-                keyValuePair.node.id,
-                2,
-                undefined,
-            ),
+            maybeValue: NodeIdMapUtils.maybeNthChild(nodeIdMapCollection, keyValuePair.node.id, 2),
             pairKind,
         } as KVP);
     }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -53,7 +53,7 @@ export function assertIterChildrenAst(
 ): ReadonlyArray<Ast.TNode> {
     const astNodeById: NodeIdMap.AstNodeById = nodeIdMapCollection.astNodeById;
     return assertIterChildIds(nodeIdMapCollection.childIdsById, parentId).map(childId =>
-        NodeIdMapUtils.assertGetAst(astNodeById, childId),
+        NodeIdMapUtils.assertUnwrapAst(astNodeById, childId),
     );
 }
 
@@ -92,7 +92,7 @@ export function maybeIterChildrenAst(
     const childIds: ReadonlyArray<number> = maybeChildIds;
 
     const astNodeById: NodeIdMap.AstNodeById = nodeIdMapCollection.astNodeById;
-    return childIds.map(childId => NodeIdMapUtils.assertGetAst(astNodeById, childId));
+    return childIds.map(childId => NodeIdMapUtils.assertUnwrapAst(astNodeById, childId));
 }
 
 export function maybeNextSiblingXor(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): TXorNode | undefined {
@@ -134,7 +134,7 @@ export function iterArrayWrapper(
     nodeIdMapCollection: NodeIdMap.Collection,
     arrayWrapper: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    XorNodeUtils.assertAstNodeKind(arrayWrapper, Ast.NodeKind.ArrayWrapper);
+    XorNodeUtils.assertIsNodeKind(arrayWrapper, Ast.NodeKind.ArrayWrapper);
 
     if (arrayWrapper.kind === XorNodeKind.Ast) {
         return (arrayWrapper.node as Ast.TCsvArray).elements.map((wrapper: Ast.TCsv) =>
@@ -174,7 +174,7 @@ export function iterFieldProjection(
     nodeIdMapCollection: NodeIdMap.Collection,
     fieldProjection: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    XorNodeUtils.assertAstNodeKind(fieldProjection, Ast.NodeKind.FieldProjection);
+    XorNodeUtils.assertIsNodeKind(fieldProjection, Ast.NodeKind.FieldProjection);
 
     const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeArrayWrapper(
         nodeIdMapCollection,
@@ -211,7 +211,7 @@ export function iterFieldSpecification(
     nodeIdMapCollection: NodeIdMap.Collection,
     fieldSpecificationList: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    XorNodeUtils.assertAstNodeKind(fieldSpecificationList, Ast.NodeKind.FieldSpecificationList);
+    XorNodeUtils.assertIsNodeKind(fieldSpecificationList, Ast.NodeKind.FieldSpecificationList);
     return iterArrayWrapperInWrappedContent(nodeIdMapCollection, fieldSpecificationList);
 }
 
@@ -219,7 +219,7 @@ export function iterInvokeExpression(
     nodeIdMapCollection: NodeIdMap.Collection,
     invokeExpression: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    XorNodeUtils.assertAstNodeKind(invokeExpression, Ast.NodeKind.InvokeExpression);
+    XorNodeUtils.assertIsNodeKind(invokeExpression, Ast.NodeKind.InvokeExpression);
     return iterArrayWrapperInWrappedContent(nodeIdMapCollection, invokeExpression);
 }
 
@@ -228,7 +228,7 @@ export function iterLetExpression(
     nodeIdMapCollection: NodeIdMap.Collection,
     letExpression: TXorNode,
 ): ReadonlyArray<LetKeyValuePair> {
-    XorNodeUtils.assertAstNodeKind(letExpression, Ast.NodeKind.LetExpression);
+    XorNodeUtils.assertIsNodeKind(letExpression, Ast.NodeKind.LetExpression);
 
     const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
         nodeIdMapCollection,
@@ -277,7 +277,7 @@ export function iterSection(
     nodeIdMapCollection: NodeIdMap.Collection,
     section: TXorNode,
 ): ReadonlyArray<SectionKeyValuePair> {
-    XorNodeUtils.assertAstNodeKind(section, Ast.NodeKind.Section);
+    XorNodeUtils.assertIsNodeKind(section, Ast.NodeKind.Section);
 
     if (section.kind === XorNodeKind.Ast) {
         return (section.node as Ast.Section).sectionMembers.elements.map((sectionMember: Ast.SectionMember) => {
@@ -320,7 +320,7 @@ export function iterSection(
         const keyValuePair: TXorNode = maybeKeyValuePair;
         const keyValuePairNodeId: number = keyValuePair.node.id;
 
-        const maybeKey: Ast.Identifier | undefined = NodeIdMapUtils.maybeNthChildIfAst(
+        const maybeKey: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
             nodeIdMapCollection,
             keyValuePairNodeId,
             0,
@@ -351,7 +351,7 @@ function iterKeyValuePairs<
 >(nodeIdMapCollection: NodeIdMap.Collection, arrayWrapper: TXorNode, pairKind: KVP["pairKind"]): ReadonlyArray<KVP> {
     const partial: KVP[] = [];
     for (const keyValuePair of iterArrayWrapper(nodeIdMapCollection, arrayWrapper)) {
-        const maybeKey: Key | undefined = NodeIdMapUtils.maybeNthChildIfAst(
+        const maybeKey: Key | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
             nodeIdMapCollection,
             keyValuePair.node.id,
             0,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -52,7 +52,7 @@ export function assertIterChildrenAst(
 ): ReadonlyArray<Ast.TNode> {
     const astNodeById: NodeIdMap.AstNodeById = nodeIdMapCollection.astNodeById;
     return assertIterChildIds(nodeIdMapCollection.childIdsById, parentId).map(childId =>
-        NodeIdMapUtils.assertGetAst(astNodeById, childId),
+        NodeIdMapUtils.assertUnwrapAst(astNodeById, childId),
     );
 }
 
@@ -91,7 +91,7 @@ export function maybeIterChildrenAst(
     const childIds: ReadonlyArray<number> = maybeChildIds;
 
     const astNodeById: NodeIdMap.AstNodeById = nodeIdMapCollection.astNodeById;
-    return childIds.map(childId => NodeIdMapUtils.assertGetAst(astNodeById, childId));
+    return childIds.map(childId => NodeIdMapUtils.assertUnwrapAst(astNodeById, childId));
 }
 
 export function maybeNextSiblingXor(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): TXorNode | undefined {
@@ -115,7 +115,7 @@ export function maybeNthSiblingXor(
         return undefined;
     }
 
-    const parentXorNode: TXorNode = NodeIdMapUtils.assertGetParentXor(nodeIdMapCollection, rootId, undefined);
+    const parentXorNode: TXorNode = NodeIdMapUtils.assertGetParentXor(nodeIdMapCollection, rootId);
     const childIds: ReadonlyArray<number> = assertIterChildIds(nodeIdMapCollection.childIdsById, parentXorNode.node.id);
     if (childIds.length >= attributeIndex) {
         return undefined;

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -193,7 +193,7 @@ export function iterFieldProjectionNames(
     for (const selector of iterFieldProjection(nodeIdMapCollection, fieldProjection)) {
         const maybeIdentifier:
             | XorNode<Ast.GeneralizedIdentifier>
-            | undefined = NodeIdMapUtils.maybeWrappedContentChecked(
+            | undefined = NodeIdMapUtils.maybeWrappedContentChecked<Ast.GeneralizedIdentifier>(
             nodeIdMapCollection,
             selector,
             Ast.NodeKind.GeneralizedIdentifier,
@@ -221,11 +221,9 @@ export function iterFunctionExpressionParameters(
         );
     }
 
-    const maybeParameterList:
-        | XorNode<Ast.TParameterList>
-        | undefined = NodeIdMapUtils.maybeNthChildChecked(nodeIdMapCollection, functionExpression.node.id, 0, [
-        Ast.NodeKind.ParameterList,
-    ]);
+    const maybeParameterList: XorNode<Ast.TParameterList> | undefined = NodeIdMapUtils.maybeNthChildChecked<
+        Ast.TParameterList
+    >(nodeIdMapCollection, functionExpression.node.id, 0, Ast.NodeKind.ParameterList);
     if (maybeParameterList === undefined) {
         return [];
     }
@@ -347,12 +345,9 @@ export function iterSection(
         });
     }
 
-    const maybeSectionMemberArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeNthChildChecked(
-        nodeIdMapCollection,
-        section.node.id,
-        4,
-        Ast.NodeKind.ArrayWrapper,
-    );
+    const maybeSectionMemberArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeNthChildChecked<
+        Ast.TArrayWrapper
+    >(nodeIdMapCollection, section.node.id, 4, Ast.NodeKind.ArrayWrapper);
     if (maybeSectionMemberArrayWrapper === undefined) {
         return [];
     }
@@ -362,7 +357,7 @@ export function iterSection(
     for (const sectionMember of assertIterChildrenXor(nodeIdMapCollection, sectionMemberArrayWrapper.node.id)) {
         const maybeKeyValuePair:
             | XorNode<Ast.IdentifierPairedExpression>
-            | undefined = NodeIdMapUtils.maybeNthChildChecked(
+            | undefined = NodeIdMapUtils.maybeNthChildChecked<Ast.IdentifierPairedExpression>(
             nodeIdMapCollection,
             sectionMember.node.id,
             2,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -53,7 +53,7 @@ export function assertIterChildrenAst(
 ): ReadonlyArray<Ast.TNode> {
     const astNodeById: NodeIdMap.AstNodeById = nodeIdMapCollection.astNodeById;
     return assertIterChildIds(nodeIdMapCollection.childIdsById, parentId).map(childId =>
-        NodeIdMapUtils.assertAst(astNodeById, childId),
+        NodeIdMapUtils.assertGetAst(astNodeById, childId),
     );
 }
 
@@ -92,7 +92,7 @@ export function maybeIterChildrenAst(
     const childIds: ReadonlyArray<number> = maybeChildIds;
 
     const astNodeById: NodeIdMap.AstNodeById = nodeIdMapCollection.astNodeById;
-    return childIds.map(childId => NodeIdMapUtils.assertAst(astNodeById, childId));
+    return childIds.map(childId => NodeIdMapUtils.assertGetAst(astNodeById, childId));
 }
 
 export function maybeNextSiblingXor(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): TXorNode | undefined {
@@ -191,9 +191,7 @@ export function iterFieldProjectionNames(
     const result: string[] = [];
 
     for (const selector of iterFieldProjection(nodeIdMapCollection, fieldProjection)) {
-        const maybeIdentifier:
-            | XorNode<Ast.GeneralizedIdentifier>
-            | undefined = NodeIdMapUtils.maybeWrappedContentChecked(
+        const maybeIdentifier: XorNode<Ast.GeneralizedIdentifier> | undefined = NodeIdMapUtils.maybeWrappedContent(
             nodeIdMapCollection,
             selector,
             Ast.NodeKind.GeneralizedIdentifier,
@@ -232,7 +230,7 @@ export function iterLetExpression(
 ): ReadonlyArray<LetKeyValuePair> {
     XorNodeUtils.assertAstNodeKind(letExpression, Ast.NodeKind.LetExpression);
 
-    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeNthChildChecked(
+    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
         nodeIdMapCollection,
         letExpression.node.id,
         1,
@@ -297,7 +295,7 @@ export function iterSection(
         });
     }
 
-    const maybeSectionMemberArrayWrapper: undefined | TXorNode = NodeIdMapUtils.maybeNthChildChecked(
+    const maybeSectionMemberArrayWrapper: undefined | TXorNode = NodeIdMapUtils.maybeNthChild(
         nodeIdMapCollection,
         section.node.id,
         4,
@@ -310,7 +308,7 @@ export function iterSection(
 
     const partial: SectionKeyValuePair[] = [];
     for (const sectionMember of assertIterChildrenXor(nodeIdMapCollection, sectionMemberArrayWrapper.node.id)) {
-        const maybeKeyValuePair: undefined | TXorNode = NodeIdMapUtils.maybeNthChildChecked(
+        const maybeKeyValuePair: undefined | TXorNode = NodeIdMapUtils.maybeNthChild(
             nodeIdMapCollection,
             sectionMember.node.id,
             2,
@@ -322,7 +320,7 @@ export function iterSection(
         const keyValuePair: TXorNode = maybeKeyValuePair;
         const keyValuePairNodeId: number = keyValuePair.node.id;
 
-        const maybeKey: Ast.Identifier | undefined = NodeIdMapUtils.maybeNthChildIfAstChecked(
+        const maybeKey: Ast.Identifier | undefined = NodeIdMapUtils.maybeNthChildIfAst(
             nodeIdMapCollection,
             keyValuePairNodeId,
             0,
@@ -353,7 +351,7 @@ function iterKeyValuePairs<
 >(nodeIdMapCollection: NodeIdMap.Collection, arrayWrapper: TXorNode, pairKind: KVP["pairKind"]): ReadonlyArray<KVP> {
     const partial: KVP[] = [];
     for (const keyValuePair of iterArrayWrapper(nodeIdMapCollection, arrayWrapper)) {
-        const maybeKey: Key | undefined = NodeIdMapUtils.maybeNthChildIfAstCheckedMany(
+        const maybeKey: Key | undefined = NodeIdMapUtils.maybeNthChildIfAst(
             nodeIdMapCollection,
             keyValuePair.node.id,
             0,
@@ -381,7 +379,7 @@ function iterArrayWrapperInWrappedContent(
     nodeIdMapCollection: NodeIdMap.Collection,
     xorNode: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeWrappedContentChecked(
+    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeWrappedContent(
         nodeIdMapCollection,
         xorNode,
         Ast.NodeKind.ArrayWrapper,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -4,6 +4,7 @@
 import { NodeIdMap, NodeIdMapUtils, TXorNode, XorNodeKind, XorNodeUtils } from ".";
 import { Assert, MapUtils, StringUtils } from "../../common";
 import { Ast } from "../../language";
+import { XorNode } from "./xorNode";
 
 export type TKeyValuePair = LetKeyValuePair | RecordKeyValuePair | SectionKeyValuePair;
 
@@ -186,7 +187,7 @@ export function iterFieldProjectionNames(
     const result: string[] = [];
 
     for (const selector of iterFieldProjection(nodeIdMapCollection, fieldProjection)) {
-        const maybeIdentifier: TXorNode | undefined = NodeIdMapUtils.maybeWrappedContent(
+        const maybeIdentifier: XorNode<Ast.GeneralizedIdentifier> | undefined = NodeIdMapUtils.maybeWrappedContent(
             nodeIdMapCollection,
             selector,
             Ast.NodeKind.GeneralizedIdentifier,
@@ -194,7 +195,7 @@ export function iterFieldProjectionNames(
         if (maybeIdentifier?.kind !== XorNodeKind.Ast) {
             break;
         } else {
-            result.push((maybeIdentifier.node as Ast.GeneralizedIdentifier).literal);
+            result.push(maybeIdentifier.node.literal);
         }
     }
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -176,9 +176,9 @@ export function iterFieldProjection(
 ): ReadonlyArray<TXorNode> {
     XorNodeUtils.assertIsNodeKind(fieldProjection, Ast.NodeKind.FieldProjection);
 
-    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeArrayWrapper(
+    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeUnwrapArrayWrapper(
         nodeIdMapCollection,
-        fieldProjection,
+        fieldProjection.node.id,
     );
     return maybeArrayWrapper === undefined ? [] : iterArrayWrapper(nodeIdMapCollection, maybeArrayWrapper);
 }
@@ -193,9 +193,9 @@ export function iterFieldProjectionNames(
     for (const selector of iterFieldProjection(nodeIdMapCollection, fieldProjection)) {
         const maybeIdentifier:
             | XorNode<Ast.GeneralizedIdentifier>
-            | undefined = NodeIdMapUtils.maybeWrappedContentChecked<Ast.GeneralizedIdentifier>(
+            | undefined = NodeIdMapUtils.maybeUnwrapContentChecked<Ast.GeneralizedIdentifier>(
             nodeIdMapCollection,
-            selector,
+            selector.node.id,
             Ast.NodeKind.GeneralizedIdentifier,
         );
         if (maybeIdentifier?.kind !== XorNodeKind.Ast) {
@@ -258,30 +258,33 @@ export function iterFunctionExpressionParameterNames(
 // Return all FieldSpecification children under the given FieldSpecificationList.
 export function iterFieldSpecification(
     nodeIdMapCollection: NodeIdMap.Collection,
-    fieldSpecificationList: XorNode<Ast.FieldSpecificationList>,
+    fieldSpecificationList: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    XorNodeUtils.assertIsNodeKind(fieldSpecificationList, Ast.NodeKind.FieldSpecificationList);
+    XorNodeUtils.assertIsNodeKind<Ast.FieldSpecificationList>(
+        fieldSpecificationList,
+        Ast.NodeKind.FieldSpecificationList,
+    );
     return iterArrayWrapperInWrappedContent(nodeIdMapCollection, fieldSpecificationList);
 }
 
 export function iterInvokeExpression(
     nodeIdMapCollection: NodeIdMap.Collection,
-    invokeExpression: XorNode<Ast.InvokeExpression>,
+    invokeExpression: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    XorNodeUtils.assertIsNodeKind(invokeExpression, Ast.NodeKind.InvokeExpression);
+    XorNodeUtils.assertIsNodeKind<Ast.InvokeExpression>(invokeExpression, Ast.NodeKind.InvokeExpression);
     return iterArrayWrapperInWrappedContent(nodeIdMapCollection, invokeExpression);
 }
 
 // Return all key-value-pair children under the given LetExpression.
 export function iterLetExpression(
     nodeIdMapCollection: NodeIdMap.Collection,
-    letExpression: XorNode<Ast.LetExpression>,
+    letExpression: TXorNode,
 ): ReadonlyArray<LetKeyValuePair> {
-    XorNodeUtils.assertIsNodeKind(letExpression, Ast.NodeKind.LetExpression);
+    XorNodeUtils.assertIsNodeKind<Ast.LetExpression>(letExpression, Ast.NodeKind.LetExpression);
 
-    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeArrayWrapper(
+    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeUnwrapArrayWrapper(
         nodeIdMapCollection,
-        letExpression,
+        letExpression.node.id,
     );
     if (maybeArrayWrapper === undefined) {
         return [];
@@ -307,9 +310,9 @@ export function iterRecord(
 ): ReadonlyArray<RecordKeyValuePair> {
     XorNodeUtils.assertIsRecord(record);
 
-    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeArrayWrapper(
+    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeUnwrapArrayWrapper(
         nodeIdMapCollection,
-        record,
+        record.node.id,
     );
     if (maybeArrayWrapper === undefined) {
         return [];
@@ -426,11 +429,11 @@ function iterKeyValuePairs<
 
 function iterArrayWrapperInWrappedContent(
     nodeIdMapCollection: NodeIdMap.Collection,
-    xorNode: XorNode<Ast.TWrapped>,
+    xorNode: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeArrayWrapper(
+    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeUnwrapArrayWrapper(
         nodeIdMapCollection,
-        xorNode,
+        xorNode.node.id,
     );
     if (maybeArrayWrapper === undefined) {
         return [];

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -176,7 +176,7 @@ export function iterFieldProjection(
 ): ReadonlyArray<TXorNode> {
     XorNodeUtils.assertIsNodeKind(fieldProjection, Ast.NodeKind.FieldProjection);
 
-    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeArrayWrapper(
+    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeArrayWrapper(
         nodeIdMapCollection,
         fieldProjection,
     );
@@ -210,7 +210,7 @@ export function iterFunctionExpressionParameters(
     nodeIdMapCollection: NodeIdMap.Collection,
     functionExpression: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    XorNodeUtils.assertAstNodeKind(functionExpression, Ast.NodeKind.FunctionExpression);
+    XorNodeUtils.assertIsNodeKind(functionExpression, Ast.NodeKind.FunctionExpression);
 
     if (functionExpression.kind === XorNodeKind.Ast) {
         return (functionExpression.node as Ast.FunctionExpression).parameters.content.elements.map(
@@ -219,12 +219,11 @@ export function iterFunctionExpressionParameters(
         );
     }
 
-    const maybeParameterList: TXorNode | undefined = NodeIdMapUtils.maybeChildXorByAttributeIndex(
-        nodeIdMapCollection,
-        functionExpression.node.id,
-        0,
-        [Ast.NodeKind.ParameterList],
-    );
+    const maybeParameterList:
+        | XorNode<Ast.TParameterList>
+        | undefined = NodeIdMapUtils.maybeNthChild(nodeIdMapCollection, functionExpression.node.id, 0, [
+        Ast.NodeKind.ParameterList,
+    ]);
     if (maybeParameterList === undefined) {
         return [];
     }
@@ -239,11 +238,11 @@ export function iterFunctionExpressionParameterNames(
     const result: string[] = [];
 
     for (const parameter of iterFunctionExpressionParameters(nodeIdMapCollection, functionExpression)) {
-        const maybeName: Ast.TNode | undefined = NodeIdMapUtils.maybeChildAstByAttributeIndex(
+        const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
             nodeIdMapCollection,
             parameter.node.id,
             1,
-            [Ast.NodeKind.Identifier],
+            Ast.NodeKind.Identifier,
         );
 
         if (!maybeName) {
@@ -259,7 +258,7 @@ export function iterFunctionExpressionParameterNames(
 // Return all FieldSpecification children under the given FieldSpecificationList.
 export function iterFieldSpecification(
     nodeIdMapCollection: NodeIdMap.Collection,
-    fieldSpecificationList: TXorNode,
+    fieldSpecificationList: XorNode<Ast.FieldSpecificationList>,
 ): ReadonlyArray<TXorNode> {
     XorNodeUtils.assertIsNodeKind(fieldSpecificationList, Ast.NodeKind.FieldSpecificationList);
     return iterArrayWrapperInWrappedContent(nodeIdMapCollection, fieldSpecificationList);
@@ -267,7 +266,7 @@ export function iterFieldSpecification(
 
 export function iterInvokeExpression(
     nodeIdMapCollection: NodeIdMap.Collection,
-    invokeExpression: TXorNode,
+    invokeExpression: XorNode<Ast.InvokeExpression>,
 ): ReadonlyArray<TXorNode> {
     XorNodeUtils.assertIsNodeKind(invokeExpression, Ast.NodeKind.InvokeExpression);
     return iterArrayWrapperInWrappedContent(nodeIdMapCollection, invokeExpression);
@@ -276,15 +275,13 @@ export function iterInvokeExpression(
 // Return all key-value-pair children under the given LetExpression.
 export function iterLetExpression(
     nodeIdMapCollection: NodeIdMap.Collection,
-    letExpression: TXorNode,
+    letExpression: XorNode<Ast.LetExpression>,
 ): ReadonlyArray<LetKeyValuePair> {
     XorNodeUtils.assertIsNodeKind(letExpression, Ast.NodeKind.LetExpression);
 
-    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeNthChild(
+    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeArrayWrapper(
         nodeIdMapCollection,
-        letExpression.node.id,
-        1,
-        Ast.NodeKind.ArrayWrapper,
+        letExpression,
     );
     if (maybeArrayWrapper === undefined) {
         return [];
@@ -310,7 +307,10 @@ export function iterRecord(
 ): ReadonlyArray<RecordKeyValuePair> {
     XorNodeUtils.assertIsRecord(record);
 
-    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeArrayWrapper(nodeIdMapCollection, record);
+    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeArrayWrapper(
+        nodeIdMapCollection,
+        record,
+    );
     if (maybeArrayWrapper === undefined) {
         return [];
     }
@@ -345,7 +345,7 @@ export function iterSection(
         });
     }
 
-    const maybeSectionMemberArrayWrapper: undefined | TXorNode = NodeIdMapUtils.maybeNthChild(
+    const maybeSectionMemberArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeNthChild(
         nodeIdMapCollection,
         section.node.id,
         4,
@@ -358,7 +358,7 @@ export function iterSection(
 
     const partial: SectionKeyValuePair[] = [];
     for (const sectionMember of assertIterChildrenXor(nodeIdMapCollection, sectionMemberArrayWrapper.node.id)) {
-        const maybeKeyValuePair: undefined | TXorNode = NodeIdMapUtils.maybeNthChild(
+        const maybeKeyValuePair: XorNode<Ast.IdentifierPairedExpression> | undefined = NodeIdMapUtils.maybeNthChild(
             nodeIdMapCollection,
             sectionMember.node.id,
             2,
@@ -427,12 +427,11 @@ function iterKeyValuePairs<
 
 function iterArrayWrapperInWrappedContent(
     nodeIdMapCollection: NodeIdMap.Collection,
-    xorNode: TXorNode,
+    xorNode: XorNode<Ast.TWrapped>,
 ): ReadonlyArray<TXorNode> {
-    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeWrappedContent(
+    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeArrayWrapper(
         nodeIdMapCollection,
         xorNode,
-        Ast.NodeKind.ArrayWrapper,
     );
     if (maybeArrayWrapper === undefined) {
         return [];

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -191,7 +191,9 @@ export function iterFieldProjectionNames(
     const result: string[] = [];
 
     for (const selector of iterFieldProjection(nodeIdMapCollection, fieldProjection)) {
-        const maybeIdentifier: XorNode<Ast.GeneralizedIdentifier> | undefined = NodeIdMapUtils.maybeWrappedContent(
+        const maybeIdentifier:
+            | XorNode<Ast.GeneralizedIdentifier>
+            | undefined = NodeIdMapUtils.maybeWrappedContentChecked(
             nodeIdMapCollection,
             selector,
             Ast.NodeKind.GeneralizedIdentifier,
@@ -221,7 +223,7 @@ export function iterFunctionExpressionParameters(
 
     const maybeParameterList:
         | XorNode<Ast.TParameterList>
-        | undefined = NodeIdMapUtils.maybeNthChild(nodeIdMapCollection, functionExpression.node.id, 0, [
+        | undefined = NodeIdMapUtils.maybeNthChildChecked(nodeIdMapCollection, functionExpression.node.id, 0, [
         Ast.NodeKind.ParameterList,
     ]);
     if (maybeParameterList === undefined) {
@@ -238,7 +240,7 @@ export function iterFunctionExpressionParameterNames(
     const result: string[] = [];
 
     for (const parameter of iterFunctionExpressionParameters(nodeIdMapCollection, functionExpression)) {
-        const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+        const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
             nodeIdMapCollection,
             parameter.node.id,
             1,
@@ -345,7 +347,7 @@ export function iterSection(
         });
     }
 
-    const maybeSectionMemberArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeNthChild(
+    const maybeSectionMemberArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeNthChildChecked(
         nodeIdMapCollection,
         section.node.id,
         4,
@@ -358,7 +360,9 @@ export function iterSection(
 
     const partial: SectionKeyValuePair[] = [];
     for (const sectionMember of assertIterChildrenXor(nodeIdMapCollection, sectionMemberArrayWrapper.node.id)) {
-        const maybeKeyValuePair: XorNode<Ast.IdentifierPairedExpression> | undefined = NodeIdMapUtils.maybeNthChild(
+        const maybeKeyValuePair:
+            | XorNode<Ast.IdentifierPairedExpression>
+            | undefined = NodeIdMapUtils.maybeNthChildChecked(
             nodeIdMapCollection,
             sectionMember.node.id,
             2,
@@ -370,7 +374,7 @@ export function iterSection(
         const keyValuePair: TXorNode = maybeKeyValuePair;
         const keyValuePairNodeId: number = keyValuePair.node.id;
 
-        const maybeKey: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+        const maybeKey: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
             nodeIdMapCollection,
             keyValuePairNodeId,
             0,
@@ -401,7 +405,7 @@ function iterKeyValuePairs<
 >(nodeIdMapCollection: NodeIdMap.Collection, arrayWrapper: TXorNode, pairKind: KVP["pairKind"]): ReadonlyArray<KVP> {
     const partial: KVP[] = [];
     for (const keyValuePair of iterArrayWrapper(nodeIdMapCollection, arrayWrapper)) {
-        const maybeKey: Key | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAst(
+        const maybeKey: Key | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
             nodeIdMapCollection,
             keyValuePair.node.id,
             0,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -318,12 +318,12 @@ export function iterSection(
         const keyValuePair: TXorNode = maybeKeyValuePair;
         const keyValuePairNodeId: number = keyValuePair.node.id;
 
-        const maybeKey: Ast.Identifier | undefined = NodeIdMapUtils.maybeChildAstByAttributeIndex(
+        const maybeKey: Ast.Identifier | undefined = NodeIdMapUtils.maybeNthChildAsAstChecked(
             nodeIdMapCollection,
             keyValuePairNodeId,
             0,
-            [Ast.NodeKind.Identifier],
-        ) as Ast.Identifier;
+            Ast.NodeKind.Identifier,
+        );
         if (maybeKey === undefined) {
             continue;
         }
@@ -349,7 +349,7 @@ function iterKeyValuePairs<
 >(nodeIdMapCollection: NodeIdMap.Collection, arrayWrapper: TXorNode, pairKind: KVP["pairKind"]): ReadonlyArray<KVP> {
     const partial: KVP[] = [];
     for (const keyValuePair of iterArrayWrapper(nodeIdMapCollection, arrayWrapper)) {
-        const maybeKey: Ast.TNode | undefined = NodeIdMapUtils.maybeChildAstByAttributeIndex(
+        const maybeKey: Key | undefined = NodeIdMapUtils.maybeNthChildAsAstCheckedMany(
             nodeIdMapCollection,
             keyValuePair.node.id,
             0,
@@ -358,12 +358,11 @@ function iterKeyValuePairs<
         if (maybeKey === undefined) {
             break;
         }
-        const key: Key = maybeKey as Key;
-        const keyLiteral: string = key.literal;
+        const keyLiteral: string = maybeKey.literal;
 
         partial.push({
             source: keyValuePair,
-            key,
+            key: maybeKey,
             keyLiteral,
             normalizedKeyLiteral: StringUtils.normalizeIdentifier(keyLiteral),
             maybeValue: NodeIdMapUtils.maybeNthChild(nodeIdMapCollection, keyValuePair.node.id, 2),

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -41,6 +41,16 @@ export function assertGetNthChildChecked<T extends Ast.TNode>(
     return xorNode;
 }
 
+export function assertUnwrapArrayWrapperAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TArrayWrapper {
+    const maybeXorNode: XorNode<Ast.TArrayWrapper> | undefined = Assert.asDefined(
+        maybeUnwrapArrayWrapper(nodeIdMapCollection, nodeId),
+        "failure in assertUnwrapArrayWrapperAst",
+        { nodeId },
+    );
+    XorNodeUtils.assertIsAstXor(maybeXorNode);
+    return maybeXorNode.node;
+}
+
 export function assertUnwrapNthChildAsAst(
     nodeIdMapCollection: Collection,
     parentId: number,
@@ -98,13 +108,6 @@ export function assertUnwrapNthChildAsContextChecked<T extends Ast.TNode>(
     return parseContext;
 }
 
-export function maybeArrayWrapper(
-    nodeIdMapCollection: Collection,
-    wrapped: TXorNode,
-): XorNode<Ast.TArrayWrapper> | undefined {
-    return maybeNthChildChecked<Ast.TArrayWrapper>(nodeIdMapCollection, wrapped.node.id, 1, Ast.NodeKind.ArrayWrapper);
-}
-
 export function maybeNthChild(
     nodeIdMapCollection: Collection,
     parentId: number,
@@ -136,6 +139,13 @@ export function maybeNthChildChecked<T extends Ast.TNode>(
 ): XorNode<T> | undefined {
     const maybeXorNode: TXorNode | undefined = maybeNthChild(nodeIdMapCollection, parentId, attributeIndex);
     return maybeXorNode && XorNodeUtils.isNodeKind(maybeXorNode, expectedNodeKinds) ? maybeXorNode : undefined;
+}
+
+export function maybeUnwrapArrayWrapper(
+    nodeIdMapCollection: Collection,
+    nodeId: number,
+): XorNode<Ast.TArrayWrapper> | undefined {
+    return maybeNthChildChecked<Ast.TArrayWrapper>(nodeIdMapCollection, nodeId, 1, Ast.NodeKind.ArrayWrapper);
 }
 
 export function maybeUnwrapNthChildIfAst(
@@ -182,34 +192,31 @@ export function maybeUnwrapNthChildIfContextChecked<T extends Ast.TNode>(
         : undefined;
 }
 
-export function maybeUnwrapWrappedContentIfAst(
-    nodeIdMapCollection: Collection,
-    wrapped: TXorNode,
-): Ast.TWrapped | undefined {
-    const maybeXorNode: TXorNode | undefined = maybeWrappedContent(nodeIdMapCollection, wrapped);
+export function maybeUnwrapContentIfAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TWrapped | undefined {
+    const maybeXorNode: TXorNode | undefined = maybeUnwrapContent(nodeIdMapCollection, nodeId);
     return maybeXorNode && XorNodeUtils.isAstXor(maybeXorNode) && XorNodeUtils.isTWrapped(maybeXorNode)
         ? maybeXorNode.node
         : undefined;
 }
 
-export function maybeUnwrapWrappedContentIfAstChecked<T extends Ast.TWrapped, C extends T["content"]>(
+export function maybeUnwrapContentIfAstChecked<T extends Ast.TWrapped, C extends T["content"]>(
     nodeIdMapCollection: Collection,
-    wrapped: TXorNode,
+    nodeId: number,
     expectedNodeKinds: ReadonlyArray<C["kind"]> | C["kind"],
 ): C | undefined {
-    const maybeAstNode: Ast.TNode | undefined = maybeUnwrapWrappedContentIfAst(nodeIdMapCollection, wrapped);
+    const maybeAstNode: Ast.TNode | undefined = maybeUnwrapContentIfAst(nodeIdMapCollection, nodeId);
     return maybeAstNode && AstUtils.isNodeKind<C>(maybeAstNode, expectedNodeKinds) ? maybeAstNode : undefined;
 }
 
-export function maybeWrappedContent(nodeIdMapCollection: Collection, wrapped: TXorNode): TXorNode | undefined {
-    return maybeNthChild(nodeIdMapCollection, wrapped.node.id, 1);
+export function maybeUnwrapContent(nodeIdMapCollection: Collection, nodeId: number): TXorNode | undefined {
+    return maybeNthChild(nodeIdMapCollection, nodeId, 1);
 }
 
-export function maybeWrappedContentChecked<C extends Ast.TWrapped["content"]>(
+export function maybeUnwrapContentChecked<C extends Ast.TWrapped["content"]>(
     nodeIdMapCollection: Collection,
-    wrapped: TXorNode,
+    nodeId: number,
     expectedNodeKinds: ReadonlyArray<C["kind"]> | C["kind"],
 ): XorNode<C> | undefined {
-    const maybeXorNode: TXorNode | undefined = maybeWrappedContent(nodeIdMapCollection, wrapped);
+    const maybeXorNode: TXorNode | undefined = maybeUnwrapContent(nodeIdMapCollection, nodeId);
     return maybeXorNode && XorNodeUtils.isNodeKind(maybeXorNode, expectedNodeKinds) ? maybeXorNode : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { XorNodeUtils } from "..";
 import { ArrayUtils, Assert } from "../../../common";
 import { Ast } from "../../../language";
 import { ParseContext } from "../../context";
 import { ChildIdsById, Collection } from "../nodeIdMap";
-import { TXorNode, XorNodeKind } from "../xorNode";
+import { TXorNode, XorNode, XorNodeKind } from "../xorNode";
 import { assertGetXor } from "./commonSelectors";
 
 export function assertGetChildren(childIdsById: ChildIdsById, parentId: number): ReadonlyArray<number> {
@@ -48,7 +49,7 @@ export function assertGetChildXorByAttributeIndex(
     maybeChildNodeKinds: ReadonlyArray<Ast.NodeKind> | undefined,
 ): TXorNode {
     return Assert.asDefined(
-        maybeChildXorByAttributeIndex(nodeIdMapCollection, parentId, attributeIndex, maybeChildNodeKinds),
+        maybeNthChild(nodeIdMapCollection, parentId, attributeIndex, maybeChildNodeKinds),
         `parentId doesn't have a child at the given index`,
         { parentId, attributeIndex },
     );
@@ -60,7 +61,7 @@ export function maybeChildAstByAttributeIndex(
     attributeIndex: number,
     maybeChildNodeKinds: ReadonlyArray<Ast.NodeKind> | undefined,
 ): Ast.TNode | undefined {
-    const maybeNode: TXorNode | undefined = maybeChildXorByAttributeIndex(
+    const maybeNode: TXorNode | undefined = maybeNthChild(
         nodeIdMapCollection,
         parentId,
         attributeIndex,
@@ -76,7 +77,7 @@ export function maybeChildContextByAttributeIndex(
     attributeIndex: number,
     maybeChildNodeKinds: ReadonlyArray<Ast.NodeKind> | undefined,
 ): ParseContext.Node | undefined {
-    const maybeNode: TXorNode | undefined = maybeChildXorByAttributeIndex(
+    const maybeNode: TXorNode | undefined = maybeNthChild(
         nodeIdMapCollection,
         parentId,
         attributeIndex,
@@ -98,12 +99,46 @@ export function maybeChildContextByAttributeIndex(
 //
 // If an array of NodeKind is given then an assert is made on the child (if it exists)
 // that its kind matches any value inside is in it.
-export function maybeChildXorByAttributeIndex(
+export function maybeNthChild(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
-    maybeChildNodeKinds: ReadonlyArray<Ast.NodeKind> | undefined,
 ): TXorNode | undefined {
+    // Grab the node's childIds.
+    const maybeChildIds: ReadonlyArray<number> | undefined = nodeIdMapCollection.childIdsById.get(parentId);
+    if (maybeChildIds === undefined) {
+        return undefined;
+    }
+    const childIds: ReadonlyArray<number> = maybeChildIds;
+
+    // Iterate over the children and try to find one which matches attributeIndex.
+    for (const childId of childIds) {
+        const xorNode: TXorNode = assertGetXor(nodeIdMapCollection, childId);
+        if (xorNode.node.maybeAttributeIndex === attributeIndex) {
+            return xorNode;
+        }
+    }
+
+    return undefined;
+}
+
+export function maybeNthChildChecked<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    parentId: number,
+    attributeIndex: number,
+    expectedChildNodeKind: T["kind"],
+): XorNode<T> | undefined {
+    const maybeChild: TXorNode | undefined = maybeNthChild(nodeIdMapCollection, parentId, attributeIndex);
+    if (maybeChild === undefined) {
+        return undefined;
+    }
+
+    if (XorNodeUtils.isAst<T>(maybeChild, expectedChildNodeKind)) {
+        return maybeChild;
+    } else if (XorNodeUtils.isContextXor(maybeChild)) {
+        return maybeChild;
+    }
+
     // Grab the node's childIds.
     const maybeChildIds: ReadonlyArray<number> | undefined = nodeIdMapCollection.childIdsById.get(parentId);
     if (maybeChildIds === undefined) {

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -6,38 +6,20 @@ import { Assert } from "../../../common";
 import { Ast } from "../../../language";
 import { ParseContext } from "../../context";
 import { ChildIdsById, Collection } from "../nodeIdMap";
-import { TXorNode, XorNode, XorNodeKind } from "../xorNode";
+import { TXorNode, XorNode } from "../xorNode";
 import { assertGetXor } from "./commonSelectors";
+
+// You can think of a node as a collection which holds other nodes.
+// The ArithmeticExpression `1 + 2` has three nodes (i.e. attributes):
+//  * a literal node `1` as the first attribute.
+//  * a literal operator constant `+` as the second attribute.
+//  * a literal node `2` as the third attribute.
+//
+// The `INode` interface has the nullable field `maybeAttributeIndex`.
+// A truthy value indicates it contains a parent and if so what attribute number it is under the parent.
 
 export function assertGetChildren(childIdsById: ChildIdsById, parentId: number): ReadonlyArray<number> {
     return Assert.asDefined(childIdsById.get(parentId), `parentId doesn't have any children`, { parentId });
-}
-
-export function assertGetNthChildAsAst(
-    nodeIdMapCollection: Collection,
-    parentId: number,
-    attributeIndex: number,
-): Ast.TNode {
-    return Assert.asDefined(
-        maybeNthChildAsAst(nodeIdMapCollection, parentId, attributeIndex),
-        `parentId doesn't have an Ast child at the given index`,
-        { parentId, attributeIndex },
-    );
-}
-
-export function assertGetNthChildAsContext(
-    nodeIdMapCollection: Collection,
-    parentId: number,
-    attributeIndex: number,
-): ParseContext.Node {
-    return Assert.asDefined(
-        maybeNthChildAsContext(nodeIdMapCollection, parentId, attributeIndex),
-        `parentId doesn't have a context child at the given index`,
-        {
-            parentId,
-            attributeIndex,
-        },
-    );
 }
 
 export function assertGetNthChild(nodeIdMapCollection: Collection, parentId: number, attributeIndex: number): TXorNode {
@@ -48,66 +30,56 @@ export function assertGetNthChild(nodeIdMapCollection: Collection, parentId: num
     );
 }
 
-export function maybeNthChildAsAst(
-    nodeIdMapCollection: Collection,
-    parentId: number,
-    attributeIndex: number,
-): Ast.TNode | undefined {
-    const maybeNode: TXorNode | undefined = maybeNthChild(nodeIdMapCollection, parentId, attributeIndex);
-
-    return maybeNode?.kind === XorNodeKind.Ast ? maybeNode.node : undefined;
-}
-
-export function maybeNthChildAsAstChecked<T extends Ast.TNode>(
+export function assertGetNthChildChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
     expectedNodeKind: T["kind"],
-): T | undefined {
-    const maybeNode: TXorNode | undefined = maybeNthChild(nodeIdMapCollection, parentId, attributeIndex);
-    if (maybeNode === undefined) {
-        return undefined;
-    }
-
-    return XorNodeUtils.isAstXorChecked(maybeNode, expectedNodeKind) ? maybeNode.node : undefined;
+): XorNode<T> {
+    return Assert.asDefined(
+        maybeNthChildChecked(nodeIdMapCollection, parentId, attributeIndex, expectedNodeKind),
+        `parentId doesn't have a child at the given index`,
+        { parentId, attributeIndex },
+    );
 }
 
-export function maybeNthChildAsAstCheckedMany<T extends Ast.TNode>(
+export function assertGetNthChildIfAst(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
-    expectedNodeKinds: ReadonlyArray<T["kind"]>,
-): T | undefined {
-    const maybeNode: TXorNode | undefined = maybeNthChild(nodeIdMapCollection, parentId, attributeIndex);
-    if (maybeNode === undefined) {
-        return undefined;
-    }
-
-    return XorNodeUtils.isAstXorCheckedMany(maybeNode, expectedNodeKinds) ? maybeNode.node : undefined;
+): Ast.TNode {
+    return Assert.asDefined(
+        maybeNthChildIfAst(nodeIdMapCollection, parentId, attributeIndex),
+        `parentId doesn't have an Ast child at the given index`,
+        { parentId, attributeIndex },
+    );
 }
 
-export function maybeNthChildAsContext(
+export function assertGetNthChildIfAstChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
-): ParseContext.Node | undefined {
-    const maybeNode: TXorNode | undefined = maybeNthChild(nodeIdMapCollection, parentId, attributeIndex);
-
-    return maybeNode?.kind === XorNodeKind.Context ? maybeNode.node : undefined;
+    expectedNodeKind: T["kind"],
+): T {
+    return Assert.asDefined(
+        maybeNthChildIfAstChecked(nodeIdMapCollection, parentId, attributeIndex, expectedNodeKind),
+        `parentId doesn't have an Ast child at the given index`,
+        { parentId, attributeIndex, expectedNodeKind },
+    );
 }
 
-// Nodes can be thought of as a collection bag which hold other nodes.
-// The ArithmeticExpression `1 + 2` has three attributes:
-//  * a literal node `1` as the first attribute.
-//  * a literal operator constant `+` as the second attribute.
-//  * a literal node `2` as the third attribute.
-//
-// This function takes a node id and an attribute index, then returns the nth child of the parent.
-// Example: If the ArithmeticExpression above is the parent and attributeIndex is 0, you would get the node for '1'.
-// Example: If the ArithmeticExpression above is the parent and attributeIndex is 1, you would get the node for '+'.
-//
-// If an array of NodeKind is given then an assert is made on the child (if it exists)
-// that its kind matches any value inside is in it.
+export function assertGetNthChildIfContext(
+    nodeIdMapCollection: Collection,
+    parentId: number,
+    attributeIndex: number,
+): ParseContext.Node {
+    return Assert.asDefined(
+        maybeNthChildIfContext(nodeIdMapCollection, parentId, attributeIndex),
+        `parentId doesn't have a context child at the given index`,
+        { parentId, attributeIndex },
+    );
+}
+
 export function maybeNthChild(
     nodeIdMapCollection: Collection,
     parentId: number,
@@ -137,10 +109,68 @@ export function maybeNthChildChecked<T extends Ast.TNode>(
     attributeIndex: number,
     expectedChildNodeKind: T["kind"],
 ): XorNode<T> | undefined {
+    return maybeNthChildCheckedMany(nodeIdMapCollection, parentId, attributeIndex, [expectedChildNodeKind]);
+}
+
+export function maybeNthChildCheckedMany<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    parentId: number,
+    attributeIndex: number,
+    expectedChildNodeKinds: ReadonlyArray<T["kind"]>,
+): XorNode<T> | undefined {
     const maybeChild: TXorNode | undefined = maybeNthChild(nodeIdMapCollection, parentId, attributeIndex);
     if (maybeChild === undefined) {
         return undefined;
     }
 
-    return XorNodeUtils.isXorChecked(maybeChild, expectedChildNodeKind) ? maybeChild : undefined;
+    return XorNodeUtils.isXorCheckedMany(maybeChild, expectedChildNodeKinds) ? maybeChild : undefined;
+}
+
+export function maybeNthChildIfAst(
+    nodeIdMapCollection: Collection,
+    parentId: number,
+    attributeIndex: number,
+): Ast.TNode | undefined {
+    const maybeNode: TXorNode | undefined = maybeNthChild(nodeIdMapCollection, parentId, attributeIndex);
+    if (maybeNode === undefined) {
+        return undefined;
+    }
+
+    return XorNodeUtils.isAstXor(maybeNode) ? maybeNode.node : undefined;
+}
+
+export function maybeNthChildIfAstChecked<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    parentId: number,
+    attributeIndex: number,
+    expectedNodeKind: T["kind"],
+): T | undefined {
+    return maybeNthChildIfAstCheckedMany(nodeIdMapCollection, parentId, attributeIndex, [expectedNodeKind]);
+}
+
+export function maybeNthChildIfAstCheckedMany<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    parentId: number,
+    attributeIndex: number,
+    expectedNodeKinds: ReadonlyArray<T["kind"]>,
+): T | undefined {
+    const maybeNode: TXorNode | undefined = maybeNthChild(nodeIdMapCollection, parentId, attributeIndex);
+    if (maybeNode === undefined) {
+        return undefined;
+    }
+
+    return XorNodeUtils.isAstXorCheckedMany(maybeNode, expectedNodeKinds) ? maybeNode.node : undefined;
+}
+
+export function maybeNthChildIfContext(
+    nodeIdMapCollection: Collection,
+    parentId: number,
+    attributeIndex: number,
+): ParseContext.Node | undefined {
+    const maybeNode: TXorNode | undefined = maybeNthChild(nodeIdMapCollection, parentId, attributeIndex);
+    if (maybeNode === undefined) {
+        return undefined;
+    }
+
+    return XorNodeUtils.isContextXor(maybeNode) ? maybeNode.node : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -76,8 +76,11 @@ export function maybeNthChild<T extends Ast.TNode>(
 
     // Iterate over the children and try to find one which matches attributeIndex.
     for (const childId of childIds) {
-        const xorNode: XorNode<T> = assertGetXor(nodeIdMapCollection, childId, maybeExpectedNodeKinds);
-        if (xorNode.node.maybeAttributeIndex === attributeIndex) {
+        const xorNode: XorNode<T> = assertGetXor(nodeIdMapCollection, childId, undefined);
+        if (
+            xorNode.node.maybeAttributeIndex === attributeIndex &&
+            XorNodeUtils.checkNodeKind(xorNode, maybeExpectedNodeKinds)
+        ) {
             return xorNode;
         }
     }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -27,7 +27,7 @@ export function assertGetNthChild<T extends Ast.TNode>(
     parentId: number,
     attributeIndex: number,
     maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
-): TXorNode {
+): XorNode<T> {
     return Assert.asDefined(
         maybeNthChild(nodeIdMapCollection, parentId, attributeIndex, maybeExpectedNodeKinds),
         `parentId doesn't have a child at the given index`,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -60,7 +60,7 @@ export function assertUnwrapNthChildAsAstChecked<T extends Ast.TNode>(
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): T {
     const astNode: Ast.TNode = assertUnwrapNthChildAsAst(nodeIdMapCollection, parentId, attributeIndex);
-    AstUtils.assertIsNodeKind(AstUtils.isNodeKind, astNode, expectedNodeKinds);
+    AstUtils.assertIsNodeKind(astNode, expectedNodeKinds);
     return astNode;
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -35,27 +35,27 @@ export function assertGetNthChild<T extends Ast.TNode>(
     );
 }
 
-export function assertGetNthChildIfAst<T extends Ast.TNode>(
+export function assertUnwrapNthChildAsAst<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
     maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): T {
     return Assert.asDefined(
-        maybeNthChildIfAst<T>(nodeIdMapCollection, parentId, attributeIndex, maybeExpectedNodeKinds),
+        maybeUnwrapNthChildIfAst<T>(nodeIdMapCollection, parentId, attributeIndex, maybeExpectedNodeKinds),
         `parentId doesn't have an Ast child at the given index`,
         { parentId, attributeIndex, maybeExpectedNodeKinds },
     );
 }
 
-export function assertGetNthChildIfContext<T extends Ast.TNode>(
+export function assertUnwrapNthChildAsContext<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
     maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): ParseContext.Node {
     return Assert.asDefined(
-        maybeNthChildIfContext(nodeIdMapCollection, parentId, attributeIndex, maybeExpectedNodeKinds),
+        maybeUnwrapNthChildIfContext(nodeIdMapCollection, parentId, attributeIndex, maybeExpectedNodeKinds),
         `parentId doesn't have a context child at the given index`,
         { parentId, attributeIndex, maybeExpectedNodeKinds },
     );
@@ -79,7 +79,7 @@ export function maybeNthChild<T extends Ast.TNode>(
         const xorNode: XorNode<T> = assertGetXor(nodeIdMapCollection, childId, undefined);
         if (
             xorNode.node.maybeAttributeIndex === attributeIndex &&
-            XorNodeUtils.checkNodeKind(xorNode, maybeExpectedNodeKinds)
+            XorNodeUtils.isNodeKind(xorNode, maybeExpectedNodeKinds)
         ) {
             return xorNode;
         }
@@ -88,7 +88,7 @@ export function maybeNthChild<T extends Ast.TNode>(
     return undefined;
 }
 
-export function maybeNthChildIfAst<T extends Ast.TNode>(
+export function maybeUnwrapNthChildIfAst<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
@@ -109,7 +109,7 @@ export function maybeNthChildIfAst<T extends Ast.TNode>(
         : undefined;
 }
 
-export function maybeNthChildIfContext<T extends Ast.TNode>(
+export function maybeUnwrapNthChildIfContext<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -61,6 +61,13 @@ export function assertUnwrapNthChildAsContext<T extends Ast.TNode>(
     );
 }
 
+export function maybeArrayWrapper(
+    nodeIdMapCollection: Collection,
+    wrapped: TXorNode,
+): XorNode<Ast.TArrayWrapper> | undefined {
+    return maybeNthChild(nodeIdMapCollection, wrapped.node.id, 1, Ast.NodeKind.ArrayWrapper);
+}
+
 export function maybeNthChild<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     parentId: number,
@@ -128,4 +135,27 @@ export function maybeUnwrapNthChildIfContext<T extends Ast.TNode>(
     return XorNodeUtils.isContextXor<T>(maybeNode, /* already checked in maybeNthChild */ undefined)
         ? maybeNode.node
         : undefined;
+}
+
+export function maybeUnwrapWrappedContentIfAst<T extends Ast.TWrapped, C extends T["content"]>(
+    nodeIdMapCollection: Collection,
+    wrapped: TXorNode,
+    maybeExpectedNodeKinds?: ReadonlyArray<C["kind"]> | C["kind"] | undefined,
+): C | undefined {
+    const maybeNode: TXorNode | undefined = maybeWrappedContent(nodeIdMapCollection, wrapped, maybeExpectedNodeKinds);
+    if (maybeNode === undefined) {
+        return maybeNode;
+    }
+
+    return XorNodeUtils.isAstXor<C>(maybeNode, /* already checked in maybeNthChild */ undefined)
+        ? maybeNode.node
+        : undefined;
+}
+
+export function maybeWrappedContent<T extends Ast.TWrapped, C extends T["content"]>(
+    nodeIdMapCollection: Collection,
+    wrapped: TXorNode,
+    maybeExpectedNodeKinds?: ReadonlyArray<C["kind"]> | C["kind"] | undefined,
+): XorNode<C> | undefined {
+    return maybeNthChild(nodeIdMapCollection, wrapped.node.id, 1, maybeExpectedNodeKinds);
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -79,7 +79,7 @@ export function maybeNthChild<T extends Ast.TNode>(
         const xorNode: XorNode<T> = assertGetXor(nodeIdMapCollection, childId, undefined);
         if (
             xorNode.node.maybeAttributeIndex === attributeIndex &&
-            XorNodeUtils.isNodeKind(xorNode, maybeExpectedNodeKinds)
+            (!maybeExpectedNodeKinds || XorNodeUtils.isNodeKind(xorNode, maybeExpectedNodeKinds))
         ) {
             return xorNode;
         }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
@@ -35,9 +35,9 @@ export function assertUnwrapAstChecked<T extends Ast.TNode>(
     astNodeById: AstNodeById,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): Ast.TNode {
+): T {
     const astNode: Ast.TNode = assertUnwrapAst(astNodeById, nodeId);
-    AstUtils.assertIsNodeKind(AstUtils.isNodeKind, astNode, expectedNodeKinds);
+    AstUtils.assertIsNodeKind(astNode, expectedNodeKinds);
     return astNode;
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
@@ -6,7 +6,7 @@ import { Assert, MapUtils } from "../../../common";
 import { Ast, AstUtils } from "../../../language";
 import { ParseContext } from "../../context";
 import { AstNodeById, Collection, ContextNodeById } from "../nodeIdMap";
-import { TXorNode, XorNode, XorNodeKind } from "../xorNode";
+import { AstXorNode, TXorNode, XorNode } from "../xorNode";
 import { maybeNthChild, maybeNthChildChecked } from "./childSelectors";
 
 export function assertUnwrapAst(astNodeById: AstNodeById, nodeId: number): Ast.TNode {
@@ -66,18 +66,22 @@ export function maybeXorChecked<T extends Ast.TNode>(
     return XorNodeUtils.isXorChecked<T>(maybeNode, expectedNodeKind) ? maybeNode : undefined;
 }
 
-export function maybeWrappedContentAst(
+export function maybeWrappedContentAst<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     wrapped: TXorNode,
-    maybeChildNodeKind: Ast.NodeKind,
-): Ast.TNode | undefined {
-    const maybeAst: TXorNode | undefined = maybeNthChildChecked(
+    expectedNodeKind: T["kind"],
+): AstXorNode<T> | undefined {
+    const maybeNode: TXorNode | undefined = maybeNthChildChecked(
         nodeIdMapCollection,
         wrapped.node.id,
         1,
-        maybeChildNodeKind,
+        expectedNodeKind,
     );
-    return maybeAst?.kind === XorNodeKind.Ast ? maybeAst.node : undefined;
+    if (maybeNode === undefined) {
+        return maybeNode;
+    }
+
+    return XorNodeUtils.isAstXorChecked(maybeNode, expectedNodeKind) ? maybeNode : undefined;
 }
 
 export function maybeCsv(nodeIdMapCollection: Collection, csv: TXorNode): TXorNode | undefined {

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
@@ -17,7 +17,7 @@ export function assertGetXor<T extends Ast.TNode>(
     return Assert.asDefined(maybeXor(nodeIdMapCollection, nodeId, maybeExpectedNodeKinds), undefined, { nodeId });
 }
 
-export function assertGetAst<T extends Ast.TNode>(
+export function assertUnwrapAst<T extends Ast.TNode>(
     astNodeById: AstNodeById,
     nodeId: number,
     maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
@@ -33,7 +33,7 @@ export function assertGetAst<T extends Ast.TNode>(
     return node;
 }
 
-export function assertGetContext<T extends Ast.TNode>(
+export function assertUnwrapContext<T extends Ast.TNode>(
     contextNodeById: ContextNodeById,
     nodeId: number,
     maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
@@ -64,23 +64,18 @@ export function maybeWrappedContent<T extends Ast.TNode>(
     return maybeNthChild(nodeIdMapCollection, wrapped.node.id, 1, maybeExpectedNodeKinds);
 }
 
-export function maybeWrappedContentIfAst<T extends Ast.TNode>(
+export function maybeUnwrapWrappedContentIfAst<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     wrapped: TXorNode,
     maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
-): XorNode<T> | undefined {
-    const maybeNode: TXorNode | undefined = maybeNthChild(
-        nodeIdMapCollection,
-        wrapped.node.id,
-        1,
-        maybeExpectedNodeKinds,
-    );
+): T | undefined {
+    const maybeNode: TXorNode | undefined = maybeWrappedContent(nodeIdMapCollection, wrapped, maybeExpectedNodeKinds);
     if (maybeNode === undefined) {
         return maybeNode;
     }
 
     return XorNodeUtils.isAstXor<T>(maybeNode, /* already checked in maybeNthChild */ undefined)
-        ? maybeNode
+        ? maybeNode.node
         : undefined;
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
@@ -27,7 +27,7 @@ export function assertUnwrapAst<T extends Ast.TNode>(
     );
 
     if (maybeExpectedNodeKinds !== undefined) {
-        assertNodeKind(node.kind, maybeExpectedNodeKinds);
+        assertNodeKind(nodeId, node.kind, maybeExpectedNodeKinds);
     }
 
     return node;
@@ -43,7 +43,7 @@ export function assertUnwrapContext<T extends Ast.TNode>(
     );
 
     if (maybeExpectedNodeKinds !== undefined) {
-        assertNodeKind(node.kind, maybeExpectedNodeKinds);
+        assertNodeKind(nodeId, node.kind, maybeExpectedNodeKinds);
     }
 
     return node;
@@ -53,7 +53,7 @@ export function maybeArrayWrapper(
     nodeIdMapCollection: Collection,
     wrapped: TXorNode,
 ): XorNode<Ast.TArrayWrapper> | undefined {
-    return maybeNthChild(nodeIdMapCollection, wrapped.node.id, 1, Ast.NodeKind.ArrayWrapper);
+    return maybeWrappedContent(nodeIdMapCollection, wrapped, Ast.NodeKind.ArrayWrapper);
 }
 
 export function maybeWrappedContent<T extends Ast.TNode>(
@@ -104,12 +104,14 @@ export function maybeXor<T extends Ast.TNode>(
 }
 
 function assertNodeKind<T extends Ast.TNode>(
+    nodeId: number,
     nodeKind: Ast.NodeKind,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): void {
     if (expectedNodeKinds !== undefined && nodeKind !== expectedNodeKinds && !expectedNodeKinds.includes(nodeKind)) {
-        throw new CommonError.InvariantError(`either failed to find the given node or it was an invalid node kind`, {
-            actualNodeKind: nodeKind,
+        throw new CommonError.InvariantError(`found the node but it was an invalid node kind`, {
+            nodeId,
+            nodeKind,
             maybeExpectedNodeKinds: expectedNodeKinds,
         });
     }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
@@ -3,17 +3,27 @@
 
 import { XorNodeUtils } from "..";
 import { Assert, MapUtils } from "../../../common";
-import { Ast } from "../../../language";
+import { Ast, AstUtils } from "../../../language";
 import { ParseContext } from "../../context";
 import { AstNodeById, Collection, ContextNodeById } from "../nodeIdMap";
 import { TXorNode, XorNodeKind } from "../xorNode";
 import { maybeChildXorByAttributeIndex } from "./childSelectors";
 
-export function assertGetAst(astNodeById: AstNodeById, nodeId: number): Ast.TNode {
+export function assertUnwrapAst(astNodeById: AstNodeById, nodeId: number): Ast.TNode {
     return MapUtils.assertGet(astNodeById, nodeId);
 }
 
-export function assertGetContext(contextNodeById: ContextNodeById, nodeId: number): ParseContext.Node {
+export function assertUnwrapAstChecked<T extends Ast.TNode>(
+    astNodeById: AstNodeById,
+    nodeId: number,
+    nodeKind: T["kind"],
+): Ast.TNode {
+    const ast: Ast.TNode = MapUtils.assertGet(astNodeById, nodeId);
+    AstUtils.assertHasNodeKind(ast, nodeKind);
+    return ast;
+}
+
+export function assertUnwrapContext(contextNodeById: ContextNodeById, nodeId: number): ParseContext.Node {
     return MapUtils.assertGet(contextNodeById, nodeId);
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
@@ -88,10 +88,10 @@ export function maybeArrayWrapperContent(nodeIdMapCollection: Collection, wrappe
     return maybeNthChildChecked(nodeIdMapCollection, wrapped.node.id, 1, Ast.NodeKind.ArrayWrapper);
 }
 
-export function maybeWrappedContent(
+export function maybeWrappedContent<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     wrapped: TXorNode,
-    maybeChildNodeKind: Ast.NodeKind,
-): TXorNode | undefined {
+    maybeChildNodeKind: T["kind"],
+): XorNode<T> | undefined {
     return maybeNthChildChecked(nodeIdMapCollection, wrapped.node.id, 1, maybeChildNodeKind);
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
@@ -7,7 +7,7 @@ import { Ast, AstUtils } from "../../../language";
 import { ParseContext } from "../../context";
 import { AstNodeById, Collection, ContextNodeById } from "../nodeIdMap";
 import { TXorNode, XorNodeKind } from "../xorNode";
-import { maybeChildXorByAttributeIndex } from "./childSelectors";
+import { maybeNthChild, maybeNthChildChecked } from "./childSelectors";
 
 export function assertUnwrapAst(astNodeById: AstNodeById, nodeId: number): Ast.TNode {
     return MapUtils.assertGet(astNodeById, nodeId);
@@ -50,18 +50,21 @@ export function maybeWrappedContentAst(
     wrapped: TXorNode,
     maybeChildNodeKind: Ast.NodeKind,
 ): Ast.TNode | undefined {
-    const maybeAst: TXorNode | undefined = maybeChildXorByAttributeIndex(nodeIdMapCollection, wrapped.node.id, 1, [
+    const maybeAst: TXorNode | undefined = maybeNthChildChecked(
+        nodeIdMapCollection,
+        wrapped.node.id,
+        1,
         maybeChildNodeKind,
-    ]);
+    );
     return maybeAst?.kind === XorNodeKind.Ast ? maybeAst.node : undefined;
 }
 
 export function maybeCsv(nodeIdMapCollection: Collection, csv: TXorNode): TXorNode | undefined {
-    return maybeChildXorByAttributeIndex(nodeIdMapCollection, csv.node.id, 0, undefined);
+    return maybeNthChild(nodeIdMapCollection, csv.node.id, 0);
 }
 
 export function maybeArrayWrapperContent(nodeIdMapCollection: Collection, wrapped: TXorNode): TXorNode | undefined {
-    return maybeChildXorByAttributeIndex(nodeIdMapCollection, wrapped.node.id, 1, [Ast.NodeKind.ArrayWrapper]);
+    return maybeNthChildChecked(nodeIdMapCollection, wrapped.node.id, 1, Ast.NodeKind.ArrayWrapper);
 }
 
 export function maybeWrappedContent(
@@ -69,5 +72,5 @@ export function maybeWrappedContent(
     wrapped: TXorNode,
     maybeChildNodeKind: Ast.NodeKind,
 ): TXorNode | undefined {
-    return maybeChildXorByAttributeIndex(nodeIdMapCollection, wrapped.node.id, 1, [maybeChildNodeKind]);
+    return maybeNthChildChecked(nodeIdMapCollection, wrapped.node.id, 1, maybeChildNodeKind);
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
@@ -6,7 +6,7 @@ import { Assert, MapUtils } from "../../../common";
 import { Ast, AstUtils } from "../../../language";
 import { ParseContext } from "../../context";
 import { AstNodeById, Collection, ContextNodeById } from "../nodeIdMap";
-import { TXorNode, XorNodeKind } from "../xorNode";
+import { TXorNode, XorNode, XorNodeKind } from "../xorNode";
 import { maybeNthChild, maybeNthChildChecked } from "./childSelectors";
 
 export function assertUnwrapAst(astNodeById: AstNodeById, nodeId: number): Ast.TNode {
@@ -31,6 +31,14 @@ export function assertGetXor(nodeIdMapCollection: Collection, nodeId: number): T
     return Assert.asDefined(maybeXor(nodeIdMapCollection, nodeId), undefined, { nodeId });
 }
 
+export function assertGetXorChecked<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    nodeId: number,
+    expectedNodeKind: T["kind"],
+): XorNode<T> {
+    return Assert.asDefined(maybeXorChecked(nodeIdMapCollection, nodeId, expectedNodeKind), undefined, { nodeId });
+}
+
 export function maybeXor(nodeIdMapCollection: Collection, nodeId: number): TXorNode | undefined {
     const maybeAstNode: Ast.TNode | undefined = nodeIdMapCollection.astNodeById.get(nodeId);
     if (maybeAstNode) {
@@ -43,6 +51,19 @@ export function maybeXor(nodeIdMapCollection: Collection, nodeId: number): TXorN
     }
 
     return undefined;
+}
+
+export function maybeXorChecked<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    nodeId: number,
+    expectedNodeKind: T["kind"],
+): XorNode<T> | undefined {
+    const maybeNode: TXorNode | undefined = maybeXor(nodeIdMapCollection, nodeId);
+    if (maybeNode === undefined) {
+        return undefined;
+    }
+
+    return XorNodeUtils.isXorChecked<T>(maybeNode, expectedNodeKind) ? maybeNode : undefined;
 }
 
 export function maybeWrappedContentAst(

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
@@ -6,8 +6,7 @@ import { Assert, CommonError, MapUtils } from "../../../common";
 import { Ast, AstUtils } from "../../../language";
 import { ParseContext } from "../../context";
 import { AstNodeById, Collection, ContextNodeById } from "../nodeIdMap";
-import { TXorNode, XorNode } from "../xorNode";
-import { maybeNthChild } from "./childSelectors";
+import { XorNode } from "../xorNode";
 
 export function assertGetXor<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
@@ -47,36 +46,6 @@ export function assertUnwrapContext<T extends Ast.TNode>(
     }
 
     return node;
-}
-
-export function maybeArrayWrapper(
-    nodeIdMapCollection: Collection,
-    wrapped: TXorNode,
-): XorNode<Ast.TArrayWrapper> | undefined {
-    return maybeWrappedContent(nodeIdMapCollection, wrapped, Ast.NodeKind.ArrayWrapper);
-}
-
-export function maybeWrappedContent<T extends Ast.TNode>(
-    nodeIdMapCollection: Collection,
-    wrapped: TXorNode,
-    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
-): XorNode<T> | undefined {
-    return maybeNthChild(nodeIdMapCollection, wrapped.node.id, 1, maybeExpectedNodeKinds);
-}
-
-export function maybeUnwrapWrappedContentIfAst<T extends Ast.TNode>(
-    nodeIdMapCollection: Collection,
-    wrapped: TXorNode,
-    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
-): T | undefined {
-    const maybeNode: TXorNode | undefined = maybeWrappedContent(nodeIdMapCollection, wrapped, maybeExpectedNodeKinds);
-    if (maybeNode === undefined) {
-        return maybeNode;
-    }
-
-    return XorNodeUtils.isAstXor<T>(maybeNode, /* already checked in maybeNthChild */ undefined)
-        ? maybeNode.node
-        : undefined;
 }
 
 export function maybeXor<T extends Ast.TNode>(

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
@@ -6,26 +6,8 @@ import { Assert, MapUtils } from "../../../common";
 import { Ast, AstUtils } from "../../../language";
 import { ParseContext } from "../../context";
 import { AstNodeById, Collection, ContextNodeById } from "../nodeIdMap";
-import { AstXorNode, TXorNode, XorNode } from "../xorNode";
+import { TXorNode, XorNode } from "../xorNode";
 import { maybeNthChild, maybeNthChildChecked } from "./childSelectors";
-
-export function assertUnwrapAst(astNodeById: AstNodeById, nodeId: number): Ast.TNode {
-    return MapUtils.assertGet(astNodeById, nodeId);
-}
-
-export function assertUnwrapAstChecked<T extends Ast.TNode>(
-    astNodeById: AstNodeById,
-    nodeId: number,
-    nodeKind: T["kind"],
-): Ast.TNode {
-    const ast: Ast.TNode = MapUtils.assertGet(astNodeById, nodeId);
-    AstUtils.assertHasNodeKind(ast, nodeKind);
-    return ast;
-}
-
-export function assertUnwrapContext(contextNodeById: ContextNodeById, nodeId: number): ParseContext.Node {
-    return MapUtils.assertGet(contextNodeById, nodeId);
-}
 
 export function assertGetXor(nodeIdMapCollection: Collection, nodeId: number): TXorNode {
     return Assert.asDefined(maybeXor(nodeIdMapCollection, nodeId), undefined, { nodeId });
@@ -36,7 +18,87 @@ export function assertGetXorChecked<T extends Ast.TNode>(
     nodeId: number,
     expectedNodeKind: T["kind"],
 ): XorNode<T> {
-    return Assert.asDefined(maybeXorChecked(nodeIdMapCollection, nodeId, expectedNodeKind), undefined, { nodeId });
+    return assertGetXorCheckedMany(nodeIdMapCollection, nodeId, [expectedNodeKind]);
+}
+
+export function assertGetXorCheckedMany<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    nodeId: number,
+    expectedNodeKinds: ReadonlyArray<T["kind"]>,
+): XorNode<T> {
+    return Assert.asDefined(maybeXorCheckedMany(nodeIdMapCollection, nodeId, expectedNodeKinds), undefined, { nodeId });
+}
+
+export function assertAst(astNodeById: AstNodeById, nodeId: number): Ast.TNode {
+    return MapUtils.assertGet(astNodeById, nodeId);
+}
+
+export function assertAstChecked<T extends Ast.TNode>(
+    astNodeById: AstNodeById,
+    nodeId: number,
+    expectedNodeKind: T["kind"],
+): T {
+    return assertAstCheckedMany(astNodeById, nodeId, [expectedNodeKind]);
+}
+
+export function assertAstCheckedMany<T extends Ast.TNode>(
+    astNodeById: AstNodeById,
+    nodeId: number,
+    expectedNodeKinds: ReadonlyArray<T["kind"]>,
+): T {
+    const ast: Ast.TNode = assertAst(astNodeById, nodeId);
+    AstUtils.assertHasAnyNodeKind(ast, expectedNodeKinds);
+    return ast;
+}
+
+export function assertContext(contextNodeById: ContextNodeById, nodeId: number): ParseContext.Node {
+    return MapUtils.assertGet(contextNodeById, nodeId);
+}
+
+export function maybeArrayWrapper(
+    nodeIdMapCollection: Collection,
+    wrapped: TXorNode,
+): XorNode<Ast.TArrayWrapper> | undefined {
+    return maybeNthChildChecked(nodeIdMapCollection, wrapped.node.id, 1, Ast.NodeKind.ArrayWrapper);
+}
+
+export function maybeWrappedContent(nodeIdMapCollection: Collection, wrapped: TXorNode): TXorNode | undefined {
+    return maybeNthChild(nodeIdMapCollection, wrapped.node.id, 1);
+}
+
+export function maybeWrappedContentChecked<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    wrapped: TXorNode,
+    expectedNodeKind: T["kind"],
+): XorNode<T> | undefined {
+    return maybeNthChildChecked(nodeIdMapCollection, wrapped.node.id, 1, expectedNodeKind);
+}
+
+export function maybeWrappedContentIfAst(nodeIdMapCollection: Collection, wrapped: TXorNode): TXorNode | undefined {
+    const maybeNode: TXorNode | undefined = maybeNthChild(nodeIdMapCollection, wrapped.node.id, 1);
+    if (maybeNode === undefined) {
+        return maybeNode;
+    }
+
+    return XorNodeUtils.isAstXor(maybeNode) ? maybeNode : undefined;
+}
+
+export function maybeWrappedContentIfAstChecked<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    wrapped: TXorNode,
+    expectedNodeKind: T["kind"],
+): T | undefined {
+    const maybeNode: TXorNode | undefined = maybeNthChildChecked(
+        nodeIdMapCollection,
+        wrapped.node.id,
+        1,
+        expectedNodeKind,
+    );
+    if (maybeNode === undefined) {
+        return maybeNode;
+    }
+
+    return XorNodeUtils.isAstXorChecked(maybeNode, expectedNodeKind) ? maybeNode.node : undefined;
 }
 
 export function maybeXor(nodeIdMapCollection: Collection, nodeId: number): TXorNode | undefined {
@@ -58,44 +120,18 @@ export function maybeXorChecked<T extends Ast.TNode>(
     nodeId: number,
     expectedNodeKind: T["kind"],
 ): XorNode<T> | undefined {
+    return maybeXorCheckedMany(nodeIdMapCollection, nodeId, [expectedNodeKind]);
+}
+
+export function maybeXorCheckedMany<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    nodeId: number,
+    expectedNodeKinds: ReadonlyArray<T["kind"]>,
+): XorNode<T> | undefined {
     const maybeNode: TXorNode | undefined = maybeXor(nodeIdMapCollection, nodeId);
     if (maybeNode === undefined) {
         return undefined;
     }
 
-    return XorNodeUtils.isXorChecked<T>(maybeNode, expectedNodeKind) ? maybeNode : undefined;
-}
-
-export function maybeWrappedContentAst<T extends Ast.TNode>(
-    nodeIdMapCollection: Collection,
-    wrapped: TXorNode,
-    expectedNodeKind: T["kind"],
-): AstXorNode<T> | undefined {
-    const maybeNode: TXorNode | undefined = maybeNthChildChecked(
-        nodeIdMapCollection,
-        wrapped.node.id,
-        1,
-        expectedNodeKind,
-    );
-    if (maybeNode === undefined) {
-        return maybeNode;
-    }
-
-    return XorNodeUtils.isAstXorChecked(maybeNode, expectedNodeKind) ? maybeNode : undefined;
-}
-
-export function maybeCsv(nodeIdMapCollection: Collection, csv: TXorNode): TXorNode | undefined {
-    return maybeNthChild(nodeIdMapCollection, csv.node.id, 0);
-}
-
-export function maybeArrayWrapperContent(nodeIdMapCollection: Collection, wrapped: TXorNode): TXorNode | undefined {
-    return maybeNthChildChecked(nodeIdMapCollection, wrapped.node.id, 1, Ast.NodeKind.ArrayWrapper);
-}
-
-export function maybeWrappedContent<T extends Ast.TNode>(
-    nodeIdMapCollection: Collection,
-    wrapped: TXorNode,
-    maybeChildNodeKind: T["kind"],
-): XorNode<T> | undefined {
-    return maybeNthChildChecked(nodeIdMapCollection, wrapped.node.id, 1, maybeChildNodeKind);
+    return XorNodeUtils.isXorCheckedMany(maybeNode, expectedNodeKinds) ? maybeNode : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
@@ -144,7 +144,7 @@ function applyDelta(
                 nodeIdMapCollection.astNodeById.delete(oldId);
             }
         } else {
-            const mutableNode: TypeScriptUtils.StripReadonly<ParseContext.Node> = xorNode.node;
+            const mutableNode: TypeScriptUtils.StripReadonly<ParseContext.TNode> = xorNode.node;
             mutableNode.id = newId;
             nodeIdMapCollection.contextNodeById.set(newId, mutableNode);
             if (!delta.contextNodeById.has(oldId)) {

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
@@ -8,8 +8,8 @@ import { AstNodeById, Collection } from "../nodeIdMap";
 import { TXorNode, XorNodeKind } from "../xorNode";
 import { maybeXor } from "./commonSelectors";
 
-export function assertUnwrapLeftMostAstXor(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode {
-    return XorNodeUtils.assertUnwrapTAst(
+export function assertUnwrapLeftMostLeaf(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode {
+    return XorNodeUtils.assertUnwrapAst(
         Assert.asDefined(
             maybeLeftMostXor(nodeIdMapCollection, nodeId),
             `nodeId does not exist in nodeIdMapCollection`,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
@@ -8,8 +8,8 @@ import { AstNodeById, Collection } from "../nodeIdMap";
 import { TXorNode, XorNodeKind } from "../xorNode";
 import { maybeXor } from "./commonSelectors";
 
-export function assertGetLeftMostAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode {
-    return XorNodeUtils.assertGetAst(
+export function assertUnwrapLeftMostAstXor(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode {
+    return XorNodeUtils.assertUnwrapTAst(
         Assert.asDefined(
             maybeLeftMostXor(nodeIdMapCollection, nodeId),
             `nodeId does not exist in nodeIdMapCollection`,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/nodeIdMapUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/nodeIdMapUtils.ts
@@ -9,8 +9,8 @@ import { TXorNode, XorNodeKind, XorNodeTokenRange } from "../xorNode";
 import { maybeRightMostLeaf } from "./leafSelectors";
 
 export function copy(nodeIdMapCollection: Collection): Collection {
-    const contextNodeById: Map<number, ParseContext.Node> = new Map(
-        [...nodeIdMapCollection.contextNodeById.entries()].map(([id, contextNode]: [number, ParseContext.Node]) => {
+    const contextNodeById: Map<number, ParseContext.TNode> = new Map(
+        [...nodeIdMapCollection.contextNodeById.entries()].map(([id, contextNode]: [number, ParseContext.TNode]) => {
             return [id, { ...contextNode }];
         }),
     );
@@ -77,7 +77,7 @@ export function xorNodeTokenRange(nodeIdMapCollection: Collection, xorNode: TXor
         }
 
         case XorNodeKind.Context: {
-            const contextNode: ParseContext.Node = xorNode.node;
+            const contextNode: ParseContext.TNode = xorNode.node;
             let tokenIndexEnd: number;
 
             const maybeRightMostChild: Ast.TNode | undefined = maybeRightMostLeaf(nodeIdMapCollection, xorNode.node.id);

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
@@ -108,5 +108,7 @@ export function maybeParentXorChecked<T extends Ast.TNode>(
         return undefined;
     }
 
-    return XorNodeUtils.isAst(maybeXor, expectedNodeKind) || XorNodeUtils.isContextXor(maybeXor) ? maybeXor : undefined;
+    return XorNodeUtils.isAstXorKind(maybeXor, expectedNodeKind) || XorNodeUtils.isContextXor(maybeXor)
+        ? maybeXor
+        : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
@@ -9,12 +9,21 @@ import { Collection } from "../nodeIdMap";
 import { TXorNode, XorNode } from "../xorNode";
 import { createAstNode, createContextNode } from "../xorNodeUtils";
 
-export function assertUnwrapParentAst<T extends Ast.TNode>(
+export function assertUnwrapParentAstChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     nodeId: number,
     expectedNodeKind: T["kind"],
 ): T {
     const maybeNode: T | undefined = maybeParentAstChecked(nodeIdMapCollection, nodeId, expectedNodeKind);
+    return Assert.asDefined(maybeNode, `nodeId doesn't have a parent`, { nodeId });
+}
+
+export function assertUnwrapParentAstCheckedMany<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    nodeId: number,
+    expectedNodeKinds: ReadonlyArray<T["kind"]>,
+): T {
+    const maybeNode: T | undefined = maybeParentAstCheckedMany(nodeIdMapCollection, nodeId, expectedNodeKinds);
     return Assert.asDefined(maybeNode, `nodeId doesn't have a parent`, { nodeId });
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
@@ -27,7 +27,7 @@ export function assertUnwrapParentAstChecked<T extends Ast.TNode>(
     return astNode;
 }
 
-export function assertUnwrapParentContext(nodeIdMapCollection: Collection, nodeId: number): ParseContext.Node {
+export function assertUnwrapParentContext(nodeIdMapCollection: Collection, nodeId: number): ParseContext.TNode {
     return Assert.asDefined(
         maybeParentContext(nodeIdMapCollection, nodeId),
         "couldn't find the expected parent context for nodeId",
@@ -39,8 +39,8 @@ export function assertUnwrapParentContextChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): ParseContext.Node {
-    const contextNode: ParseContext.Node = assertUnwrapParentContext(nodeIdMapCollection, nodeId);
+): ParseContext.Node<T> {
+    const contextNode: ParseContext.TNode = assertUnwrapParentContext(nodeIdMapCollection, nodeId);
     ParseContextUtils.assertIsNodeKind(contextNode, expectedNodeKinds);
     return contextNode;
 }
@@ -75,7 +75,7 @@ export function maybeParentAstChecked<T extends Ast.TNode>(
     return maybeAstNode && AstUtils.isNodeKind(maybeAstNode, expectedNodeKinds) ? maybeAstNode : undefined;
 }
 
-export function maybeParentContext(nodeIdMapCollection: Collection, childId: number): ParseContext.Node | undefined {
+export function maybeParentContext(nodeIdMapCollection: Collection, childId: number): ParseContext.TNode | undefined {
     const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(childId);
     return maybeParentId !== undefined ? nodeIdMapCollection.contextNodeById.get(maybeParentId) : undefined;
 }
@@ -84,8 +84,8 @@ export function maybeParentContextChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     childId: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): ParseContext.Node | undefined {
-    const maybeContextNode: ParseContext.Node | undefined = maybeParentContext(nodeIdMapCollection, childId);
+): ParseContext.Node<T> | undefined {
+    const maybeContextNode: ParseContext.TNode | undefined = maybeParentContext(nodeIdMapCollection, childId);
     return maybeContextNode && ParseContextUtils.isNodeKind(maybeContextNode, expectedNodeKinds)
         ? maybeContextNode
         : undefined;
@@ -97,7 +97,7 @@ export function maybeParentXor(nodeIdMapCollection: Collection, childId: number)
         return createAstNode(maybeAstNode);
     }
 
-    const maybeContext: ParseContext.Node | undefined = maybeParentContext(nodeIdMapCollection, childId);
+    const maybeContext: ParseContext.TNode | undefined = maybeParentContext(nodeIdMapCollection, childId);
     if (maybeContext !== undefined) {
         return createContextNode(maybeContext);
     }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
@@ -23,7 +23,7 @@ export function assertUnwrapParentAstChecked<T extends Ast.TNode>(
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): T {
     const astNode: Ast.TNode = assertUnwrapParentAst(nodeIdMapCollection, nodeId);
-    AstUtils.assertIsNodeKind(AstUtils.isNodeKind, astNode, expectedNodeKinds);
+    AstUtils.assertIsNodeKind(astNode, expectedNodeKinds);
     return astNode;
 }
 
@@ -54,7 +54,7 @@ export function assertGetParentXorChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): TXorNode {
+): XorNode<T> {
     const maybeXorNode: TXorNode = assertGetParentXor(nodeIdMapCollection, nodeId);
     XorNodeUtils.assertIsNodeKind(maybeXorNode, expectedNodeKinds);
     return maybeXorNode;

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { XorNodeUtils } from "..";
 import { Assert } from "../../../common";
 import { Ast, AstUtils } from "../../../language";
 import { ParseContext } from "../../context";
@@ -9,115 +8,79 @@ import { Collection } from "../nodeIdMap";
 import { TXorNode, XorNode } from "../xorNode";
 import { createAstNode, createContextNode } from "../xorNodeUtils";
 
-export function assertUnwrapParentAstChecked<T extends Ast.TNode>(
+export function assertUnwrapParentAst<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     nodeId: number,
-    expectedNodeKind: T["kind"],
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): T {
-    const maybeNode: T | undefined = maybeParentAstChecked(nodeIdMapCollection, nodeId, expectedNodeKind);
-    return Assert.asDefined(maybeNode, `nodeId doesn't have a parent`, { nodeId });
+    const maybeNode: T | undefined = maybeParentAst(nodeIdMapCollection, nodeId, maybeExpectedNodeKinds);
+    return Assert.asDefined(maybeNode, `nodeId doesn't have a parent`, { nodeId, maybeExpectedNodeKinds });
 }
 
-export function assertUnwrapParentAstCheckedMany<T extends Ast.TNode>(
+export function assertGetParentXor<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     nodeId: number,
-    expectedNodeKinds: ReadonlyArray<T["kind"]>,
-): T {
-    const maybeNode: T | undefined = maybeParentAstCheckedMany(nodeIdMapCollection, nodeId, expectedNodeKinds);
-    return Assert.asDefined(maybeNode, `nodeId doesn't have a parent`, { nodeId });
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+): TXorNode {
+    const maybeNode: TXorNode | undefined = maybeParentXor(nodeIdMapCollection, nodeId, maybeExpectedNodeKinds);
+    return Assert.asDefined(maybeNode, `nodeId doesn't have a parent`, { nodeId, maybeExpectedNodeKinds });
 }
 
-export function assertGetParentXor(nodeIdMapCollection: Collection, nodeId: number): TXorNode {
-    const maybeNode: TXorNode | undefined = maybeParentXor(nodeIdMapCollection, nodeId);
-    return Assert.asDefined(maybeNode, `nodeId doesn't have a parent`, { nodeId });
-}
-
-export function assertGetParentXorChecked<T extends Ast.TNode>(
-    nodeIdMapCollection: Collection,
-    nodeId: number,
-    expectedNodeKind: T["kind"],
-): XorNode<T> {
-    const maybeNode: XorNode<T> | undefined = maybeParentXorChecked(nodeIdMapCollection, nodeId, expectedNodeKind);
-    return Assert.asDefined(maybeNode, `nodeId doesn't have a parent`, { nodeId });
-}
-
-export function maybeParentAst(nodeIdMapCollection: Collection, childId: number): Ast.TNode | undefined {
-    const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(childId);
-    if (maybeParentId === undefined) {
-        return undefined;
-    }
-    return nodeIdMapCollection.astNodeById.get(maybeParentId);
-}
-
-export function maybeParentAstChecked<T extends Ast.TNode>(
+export function maybeParentAst<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     childId: number,
-    expectedNodeKind: T["kind"],
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): T | undefined {
-    const maybeParent: Ast.TNode | undefined = maybeParentAst(nodeIdMapCollection, childId);
-    if (maybeParent === undefined) {
-        return undefined;
-    }
-
-    return AstUtils.isNodeKind(maybeParent, expectedNodeKind) ? maybeParent : undefined;
-}
-
-export function maybeParentAstCheckedMany<T extends Ast.TNode>(
-    nodeIdMapCollection: Collection,
-    childId: number,
-    expectedNodeKinds: ReadonlyArray<T["kind"]>,
-): T | undefined {
-    const maybeParent: Ast.TNode | undefined = maybeParentAst(nodeIdMapCollection, childId);
-    if (maybeParent === undefined) {
-        return undefined;
-    }
-
-    return AstUtils.isAnyNodeKind(maybeParent, expectedNodeKinds) ? maybeParent : undefined;
-}
-
-export function maybeParentContext(nodeIdMapCollection: Collection, childId: number): ParseContext.Node | undefined {
     const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(childId);
     if (maybeParentId === undefined) {
         return undefined;
     }
 
-    return nodeIdMapCollection.contextNodeById.get(maybeParentId);
+    const maybeNode: T | undefined = nodeIdMapCollection.astNodeById.get(maybeParentId) as T | undefined;
+
+    return maybeNode && (!maybeExpectedNodeKinds || AstUtils.isNodeKind(maybeNode, maybeExpectedNodeKinds))
+        ? maybeNode
+        : undefined;
 }
 
-export function maybeParentContextChecked(
+export function maybeParentContext<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     childId: number,
-    expectedNodeKind: Ast.NodeKind,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): ParseContext.Node | undefined {
-    const maybeParent: ParseContext.Node | undefined = maybeParentContext(nodeIdMapCollection, childId);
-    return maybeParent?.kind === expectedNodeKind ? maybeParent : undefined;
-}
-
-export function maybeParentXor(nodeIdMapCollection: Collection, childId: number): TXorNode | undefined {
-    const maybeAst: Ast.TNode | undefined = maybeParentAst(nodeIdMapCollection, childId);
-    if (maybeAst !== undefined) {
-        return createAstNode(maybeAst);
+    const maybeParentId: number | undefined = nodeIdMapCollection.parentIdById.get(childId);
+    if (maybeParentId === undefined) {
+        return undefined;
     }
 
-    const maybeContext: ParseContext.Node | undefined = maybeParentContext(nodeIdMapCollection, childId);
+    const maybeNode: ParseContext.Node | undefined = nodeIdMapCollection.contextNodeById.get(maybeParentId);
+
+    return maybeNode &&
+        (!maybeExpectedNodeKinds ||
+            maybeNode.kind === maybeExpectedNodeKinds ||
+            maybeExpectedNodeKinds.includes(maybeNode.kind))
+        ? maybeNode
+        : undefined;
+}
+
+export function maybeParentXor<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    childId: number,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+): XorNode<T> | undefined {
+    const maybeAst: T | undefined = maybeParentAst<T>(nodeIdMapCollection, childId, maybeExpectedNodeKinds);
+    if (maybeAst !== undefined) {
+        return createAstNode<T>(maybeAst);
+    }
+
+    const maybeContext: ParseContext.Node | undefined = maybeParentContext(
+        nodeIdMapCollection,
+        childId,
+        maybeExpectedNodeKinds,
+    );
     if (maybeContext !== undefined) {
         return createContextNode(maybeContext);
     }
 
     return undefined;
-}
-
-export function maybeParentXorChecked<T extends Ast.TNode>(
-    nodeIdMapCollection: Collection,
-    childId: number,
-    expectedNodeKind: T["kind"],
-): XorNode<T> | undefined {
-    const maybeXor: TXorNode | undefined = maybeParentXor(nodeIdMapCollection, childId);
-    if (maybeXor === undefined) {
-        return undefined;
-    }
-
-    return XorNodeUtils.isAstXorChecked(maybeXor, expectedNodeKind) || XorNodeUtils.isContextXor(maybeXor)
-        ? maybeXor
-        : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
@@ -17,6 +17,19 @@ export function assertUnwrapParentAst<T extends Ast.TNode>(
     return Assert.asDefined(maybeNode, `nodeId doesn't have a parent`, { nodeId, maybeExpectedNodeKinds });
 }
 
+export function assertUnwrapParentContext<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    nodeId: number,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+): ParseContext.Node {
+    const maybeNode: ParseContext.Node | undefined = maybeParentContext(
+        nodeIdMapCollection,
+        nodeId,
+        maybeExpectedNodeKinds,
+    );
+    return Assert.asDefined(maybeNode, `nodeId doesn't have a parent`, { nodeId, maybeExpectedNodeKinds });
+}
+
 export function assertGetParentXor<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     nodeId: number,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
@@ -108,7 +108,7 @@ export function maybeParentXorChecked<T extends Ast.TNode>(
         return undefined;
     }
 
-    return XorNodeUtils.isAstXorKind(maybeXor, expectedNodeKind) || XorNodeUtils.isContextXor(maybeXor)
+    return XorNodeUtils.isAstXorChecked(maybeXor, expectedNodeKind) || XorNodeUtils.isContextXor(maybeXor)
         ? maybeXor
         : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
@@ -54,7 +54,7 @@ export function maybeInvokeExpressionIdentifier(
     nodeId: number,
 ): XorNode<Ast.IdentifierExpression> | undefined {
     const invokeExprXorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId);
-    XorNodeUtils.assertAstNodeKind(invokeExprXorNode, Ast.NodeKind.InvokeExpression);
+    XorNodeUtils.assertIsNodeKind(invokeExprXorNode, Ast.NodeKind.InvokeExpression);
 
     // The only place for an identifier in a RecursivePrimaryExpression is as the head, therefore an InvokeExpression
     // only has a name if the InvokeExpression is the 0th element in the RecursivePrimaryExpressionArray.
@@ -99,7 +99,7 @@ export function maybeInvokeExpressionIdentifierLiteral(
     nodeId: number,
 ): string | undefined {
     const invokeExprXorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId);
-    XorNodeUtils.assertAstNodeKind(invokeExprXorNode, Ast.NodeKind.InvokeExpression);
+    XorNodeUtils.assertIsNodeKind(invokeExprXorNode, Ast.NodeKind.InvokeExpression);
 
     const maybeIdentifierExpressionXorNode: TXorNode | undefined = maybeInvokeExpressionIdentifier(
         nodeIdMapCollection,
@@ -109,7 +109,7 @@ export function maybeInvokeExpressionIdentifierLiteral(
         return undefined;
     }
     const identifierExpressionXorNode: TXorNode = maybeIdentifierExpressionXorNode;
-    XorNodeUtils.assertAstNodeKind(identifierExpressionXorNode, Ast.NodeKind.IdentifierExpression);
+    XorNodeUtils.assertIsNodeKind(identifierExpressionXorNode, Ast.NodeKind.IdentifierExpression);
     const identifierExpression: Ast.IdentifierExpression = identifierExpressionXorNode.node as Ast.IdentifierExpression;
 
     return identifierExpression.maybeInclusiveConstant === undefined

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
@@ -16,7 +16,7 @@ export function assertGetRecursiveExpressionPreviousSibling<T extends Ast.TNode>
     nodeIdMapCollection: Collection,
     nodeId: number,
     maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
-): XorNode<T> {
+): TXorNode {
     const xorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId);
     const arrayWrapper: TXorNode = assertGetParentXorChecked(nodeIdMapCollection, nodeId, Ast.NodeKind.ArrayWrapper);
     const maybePrimaryExpressionAttributeId: number | undefined = xorNode.node.maybeAttributeIndex;
@@ -78,12 +78,9 @@ export function maybeInvokeExpressionIdentifier(
     // Grab the RecursivePrimaryExpression's head if it's an IdentifierExpression
     const recursiveArrayXorNode: TXorNode = assertGetParentXor(nodeIdMapCollection, invokeExprXorNode.node.id);
     const recursiveExprXorNode: TXorNode = assertGetParentXor(nodeIdMapCollection, recursiveArrayXorNode.node.id);
-    const maybeHeadXorNode: XorNode<Ast.IdentifierExpression> | undefined = maybeNthChildChecked(
-        nodeIdMapCollection,
-        recursiveExprXorNode.node.id,
-        0,
-        Ast.NodeKind.IdentifierExpression,
-    );
+    const maybeHeadXorNode: XorNode<Ast.IdentifierExpression> | undefined = maybeNthChildChecked<
+        Ast.IdentifierExpression
+    >(nodeIdMapCollection, recursiveExprXorNode.node.id, 0, Ast.NodeKind.IdentifierExpression);
 
     // It's not an identifier expression so there's nothing we can do.
     if (maybeHeadXorNode === undefined) {

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
@@ -5,8 +5,8 @@ import { NodeIdMapIterator, XorNodeUtils } from "..";
 import { CommonError } from "../../../common";
 import { Ast } from "../../../language";
 import { Collection } from "../nodeIdMap";
-import { TXorNode, XorNodeKind } from "../xorNode";
-import { assertGetChildXorByAttributeIndex, maybeNthChildChecked } from "./childSelectors";
+import { TXorNode, XorNode, XorNodeKind } from "../xorNode";
+import { assertGetNthChild, maybeNthChildChecked } from "./childSelectors";
 import { assertGetXor } from "./commonSelectors";
 import { assertGetParentXor, assertGetParentXorChecked } from "./parentSelectors";
 
@@ -36,21 +36,19 @@ export function assertGetRecursiveExpressionPreviousSibling(nodeIdMapCollection:
             );
         }
 
-        return assertGetChildXorByAttributeIndex(
-            nodeIdMapCollection,
-            arrayWrapper.node.id,
-            indexOfPrimaryExpressionId - 1,
-            undefined,
-        );
+        return assertGetNthChild(nodeIdMapCollection, arrayWrapper.node.id, indexOfPrimaryExpressionId - 1);
     }
     // It's the first element in ArrayWrapper, meaning we must grab RecursivePrimaryExpression.head
     else {
         const recursivePrimaryExpression: TXorNode = assertGetParentXor(nodeIdMapCollection, arrayWrapper.node.id);
-        return assertGetChildXorByAttributeIndex(nodeIdMapCollection, recursivePrimaryExpression.node.id, 0, undefined);
+        return assertGetNthChild(nodeIdMapCollection, recursivePrimaryExpression.node.id, 0);
     }
 }
 
-export function maybeInvokeExpressionIdentifier(nodeIdMapCollection: Collection, nodeId: number): TXorNode | undefined {
+export function maybeInvokeExpressionIdentifier(
+    nodeIdMapCollection: Collection,
+    nodeId: number,
+): XorNode<Ast.IdentifierExpression> | undefined {
     const invokeExprXorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId);
     XorNodeUtils.assertAstNodeKind(invokeExprXorNode, Ast.NodeKind.InvokeExpression);
 
@@ -63,7 +61,7 @@ export function maybeInvokeExpressionIdentifier(nodeIdMapCollection: Collection,
     // Grab the RecursivePrimaryExpression's head if it's an IdentifierExpression
     const recursiveArrayXorNode: TXorNode = assertGetParentXor(nodeIdMapCollection, invokeExprXorNode.node.id);
     const recursiveExprXorNode: TXorNode = assertGetParentXor(nodeIdMapCollection, recursiveArrayXorNode.node.id);
-    const maybeHeadXorNode: TXorNode | undefined = maybeNthChildChecked(
+    const maybeHeadXorNode: XorNode<Ast.IdentifierExpression> | undefined = maybeNthChildChecked(
         nodeIdMapCollection,
         recursiveExprXorNode.node.id,
         0,
@@ -74,7 +72,7 @@ export function maybeInvokeExpressionIdentifier(nodeIdMapCollection: Collection,
     if (maybeHeadXorNode === undefined) {
         return undefined;
     }
-    const headXorNode: TXorNode = maybeHeadXorNode;
+    const headXorNode: XorNode<Ast.IdentifierExpression> = maybeHeadXorNode;
 
     // The only place for an identifier in a RecursivePrimaryExpression is as the head, therefore an InvokeExpression
     // only has a name if the InvokeExpression is the 0th element in the RecursivePrimaryExpressionArray.

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
@@ -58,8 +58,7 @@ export function maybeInvokeExpressionIdentifier(
     nodeIdMapCollection: Collection,
     nodeId: number,
 ): XorNode<Ast.IdentifierExpression> | undefined {
-    const invokeExprXorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId);
-    XorNodeUtils.assertIsNodeKind(invokeExprXorNode, Ast.NodeKind.InvokeExpression);
+    const invokeExprXorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId, Ast.NodeKind.InvokeExpression);
 
     // The only place for an identifier in a RecursivePrimaryExpression is as the head, therefore an InvokeExpression
     // only has a name if the InvokeExpression is the 0th element in the RecursivePrimaryExpressionArray.
@@ -103,19 +102,16 @@ export function maybeInvokeExpressionIdentifierLiteral(
     nodeIdMapCollection: Collection,
     nodeId: number,
 ): string | undefined {
-    const invokeExprXorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId);
-    XorNodeUtils.assertIsNodeKind(invokeExprXorNode, Ast.NodeKind.InvokeExpression);
+    assertGetXor(nodeIdMapCollection, nodeId, Ast.NodeKind.InvokeExpression);
 
-    const maybeIdentifierExpressionXorNode: TXorNode | undefined = maybeInvokeExpressionIdentifier(
-        nodeIdMapCollection,
-        nodeId,
-    );
-    if (maybeIdentifierExpressionXorNode === undefined || maybeIdentifierExpressionXorNode.kind !== XorNodeKind.Ast) {
+    const maybeIdentifierExpressionXorNode:
+        | XorNode<Ast.IdentifierExpression>
+        | undefined = maybeInvokeExpressionIdentifier(nodeIdMapCollection, nodeId);
+    if (maybeIdentifierExpressionXorNode === undefined || !XorNodeUtils.isAstXor(maybeIdentifierExpressionXorNode)) {
         return undefined;
     }
-    const identifierExpressionXorNode: TXorNode = maybeIdentifierExpressionXorNode;
-    XorNodeUtils.assertIsNodeKind(identifierExpressionXorNode, Ast.NodeKind.IdentifierExpression);
-    const identifierExpression: Ast.IdentifierExpression = identifierExpressionXorNode.node as Ast.IdentifierExpression;
+
+    const identifierExpression: Ast.IdentifierExpression = maybeIdentifierExpressionXorNode.node;
 
     return identifierExpression.maybeInclusiveConstant === undefined
         ? identifierExpression.identifier.literal

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
@@ -8,13 +8,13 @@ import { Collection } from "../nodeIdMap";
 import { TXorNode, XorNodeKind } from "../xorNode";
 import { assertGetChildXorByAttributeIndex, maybeChildXorByAttributeIndex } from "./childSelectors";
 import { assertGetXor } from "./commonSelectors";
-import { assertGetParentXor } from "./parentSelectors";
+import { assertGetParentXor, assertGetParentXorChecked } from "./parentSelectors";
 
 // Returns the previous sibling of the given recursive expression.
 // Commonly used for things like getting the identifier name used in an InvokeExpression.
 export function assertGetRecursiveExpressionPreviousSibling(nodeIdMapCollection: Collection, nodeId: number): TXorNode {
     const xorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId);
-    const arrayWrapper: TXorNode = assertGetParentXor(nodeIdMapCollection, nodeId, [Ast.NodeKind.ArrayWrapper]);
+    const arrayWrapper: TXorNode = assertGetParentXorChecked(nodeIdMapCollection, nodeId, Ast.NodeKind.ArrayWrapper);
     const maybePrimaryExpressionAttributeId: number | undefined = xorNode.node.maybeAttributeIndex;
 
     // It's not the first element in the ArrayWrapper.

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
@@ -6,15 +6,19 @@ import { CommonError } from "../../../common";
 import { Ast } from "../../../language";
 import { Collection } from "../nodeIdMap";
 import { TXorNode, XorNode, XorNodeKind } from "../xorNode";
-import { assertGetNthChild, maybeNthChildChecked } from "./childSelectors";
+import { assertGetNthChild, maybeNthChild } from "./childSelectors";
 import { assertGetXor } from "./commonSelectors";
-import { assertGetParentXor, assertGetParentXorChecked } from "./parentSelectors";
+import { assertGetParentXor } from "./parentSelectors";
 
 // Returns the previous sibling of the given recursive expression.
 // Commonly used for things like getting the identifier name used in an InvokeExpression.
-export function assertGetRecursiveExpressionPreviousSibling(nodeIdMapCollection: Collection, nodeId: number): TXorNode {
-    const xorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId);
-    const arrayWrapper: TXorNode = assertGetParentXorChecked(nodeIdMapCollection, nodeId, Ast.NodeKind.ArrayWrapper);
+export function assertGetRecursiveExpressionPreviousSibling<T extends Ast.TNode>(
+    nodeIdMapCollection: Collection,
+    nodeId: number,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+): TXorNode {
+    const xorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId, maybeExpectedNodeKinds);
+    const arrayWrapper: TXorNode = assertGetParentXor(nodeIdMapCollection, nodeId, Ast.NodeKind.ArrayWrapper);
     const maybePrimaryExpressionAttributeId: number | undefined = xorNode.node.maybeAttributeIndex;
 
     // It's not the first element in the ArrayWrapper.
@@ -61,7 +65,7 @@ export function maybeInvokeExpressionIdentifier(
     // Grab the RecursivePrimaryExpression's head if it's an IdentifierExpression
     const recursiveArrayXorNode: TXorNode = assertGetParentXor(nodeIdMapCollection, invokeExprXorNode.node.id);
     const recursiveExprXorNode: TXorNode = assertGetParentXor(nodeIdMapCollection, recursiveArrayXorNode.node.id);
-    const maybeHeadXorNode: XorNode<Ast.IdentifierExpression> | undefined = maybeNthChildChecked(
+    const maybeHeadXorNode: XorNode<Ast.IdentifierExpression> | undefined = maybeNthChild(
         nodeIdMapCollection,
         recursiveExprXorNode.node.id,
         0,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
@@ -16,8 +16,8 @@ export function assertGetRecursiveExpressionPreviousSibling<T extends Ast.TNode>
     nodeIdMapCollection: Collection,
     nodeId: number,
     maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
-): TXorNode {
-    const xorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId, maybeExpectedNodeKinds);
+): XorNode<T> {
+    const xorNode: TXorNode = assertGetXor(nodeIdMapCollection, nodeId);
     const arrayWrapper: TXorNode = assertGetParentXor(nodeIdMapCollection, nodeId, Ast.NodeKind.ArrayWrapper);
     const maybePrimaryExpressionAttributeId: number | undefined = xorNode.node.maybeAttributeIndex;
 
@@ -40,12 +40,17 @@ export function assertGetRecursiveExpressionPreviousSibling<T extends Ast.TNode>
             );
         }
 
-        return assertGetNthChild(nodeIdMapCollection, arrayWrapper.node.id, indexOfPrimaryExpressionId - 1);
+        return assertGetNthChild(
+            nodeIdMapCollection,
+            arrayWrapper.node.id,
+            indexOfPrimaryExpressionId - 1,
+            maybeExpectedNodeKinds,
+        );
     }
     // It's the first element in ArrayWrapper, meaning we must grab RecursivePrimaryExpression.head
     else {
         const recursivePrimaryExpression: TXorNode = assertGetParentXor(nodeIdMapCollection, arrayWrapper.node.id);
-        return assertGetNthChild(nodeIdMapCollection, recursivePrimaryExpression.node.id, 0);
+        return assertGetNthChild(nodeIdMapCollection, recursivePrimaryExpression.node.id, 0, maybeExpectedNodeKinds);
     }
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
@@ -6,7 +6,7 @@ import { CommonError } from "../../../common";
 import { Ast } from "../../../language";
 import { Collection } from "../nodeIdMap";
 import { TXorNode, XorNodeKind } from "../xorNode";
-import { assertGetChildXorByAttributeIndex, maybeChildXorByAttributeIndex } from "./childSelectors";
+import { assertGetChildXorByAttributeIndex, maybeNthChildChecked } from "./childSelectors";
 import { assertGetXor } from "./commonSelectors";
 import { assertGetParentXor, assertGetParentXorChecked } from "./parentSelectors";
 
@@ -63,11 +63,11 @@ export function maybeInvokeExpressionIdentifier(nodeIdMapCollection: Collection,
     // Grab the RecursivePrimaryExpression's head if it's an IdentifierExpression
     const recursiveArrayXorNode: TXorNode = assertGetParentXor(nodeIdMapCollection, invokeExprXorNode.node.id);
     const recursiveExprXorNode: TXorNode = assertGetParentXor(nodeIdMapCollection, recursiveArrayXorNode.node.id);
-    const maybeHeadXorNode: TXorNode | undefined = maybeChildXorByAttributeIndex(
+    const maybeHeadXorNode: TXorNode | undefined = maybeNthChildChecked(
         nodeIdMapCollection,
         recursiveExprXorNode.node.id,
         0,
-        [Ast.NodeKind.IdentifierExpression],
+        Ast.NodeKind.IdentifierExpression,
     );
 
     // It's not an identifier expression so there's nothing we can do.

--- a/src/powerquery-parser/parser/nodeIdMap/xorNode.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNode.ts
@@ -11,13 +11,15 @@ export const enum XorNodeKind {
 
 export type TXorNode = XorNode<Ast.TNode>;
 
-export type TAstXorNode = AstXorNode<Ast.TNode>;
+export type XorNode<T extends Ast.TNode> = AstXorNode<T> | ContextXorNode<T>;
 
-export type XorNode<T extends Ast.TNode> = AstXorNode<T> | ContextXorNode;
+export type TAstXorNode = AstXorNode<Ast.TNode>;
 
 export type AstXorNode<T extends Ast.TNode> = IXorNode<XorNodeKind.Ast, T>;
 
-export type ContextXorNode = IXorNode<XorNodeKind.Context, ParseContext.Node>;
+export type TContextXorNode = ContextXorNode<Ast.TNode>;
+
+export type ContextXorNode<T extends Ast.TNode> = IXorNode<XorNodeKind.Context, ParseContext.Node<T>>;
 
 export interface IXorNode<Kind extends XorNodeKind, T> {
     readonly kind: Kind;

--- a/src/powerquery-parser/parser/nodeIdMap/xorNode.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNode.ts
@@ -9,9 +9,13 @@ export const enum XorNodeKind {
     Context = "Context",
 }
 
-export type TXorNode = AstXorNode | ContextXorNode;
+export type TXorNode = XorNode<Ast.TNode>;
 
-export type AstXorNode = IXorNode<XorNodeKind.Ast, Ast.TNode>;
+export type TAstXorNode = AstXorNode<Ast.TNode>;
+
+export type XorNode<T extends Ast.TNode> = AstXorNode<T> | ContextXorNode;
+
+export type AstXorNode<T extends Ast.TNode> = IXorNode<XorNodeKind.Ast, T>;
 
 export type ContextXorNode = IXorNode<XorNodeKind.Context, ParseContext.Node>;
 

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -3,7 +3,8 @@
 
 import { ParseContext } from "..";
 import { ArrayUtils, Assert } from "../../common";
-import { Ast } from "../../language";
+import { Ast, AstUtils } from "../../language";
+import { ParseContextUtils } from "../context";
 import { AstXorNode, ContextXorNode, TAstXorNode, TXorNode, XorNode, XorNodeKind } from "./xorNode";
 
 export function createAstNode<T extends Ast.TNode>(node: T): XorNode<T> {
@@ -62,34 +63,34 @@ export function assertIsNodeKind<T extends Ast.TNode>(
     }
 }
 
-export function assertIsAstXor<T extends Ast.TNode>(
-    xorNode: TXorNode,
-    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
-): asserts xorNode is TAstXorNode {
-    Assert.isTrue(
-        isAstXor(xorNode, maybeExpectedNodeKinds),
-        "expected xorNode to hold an Ast node an to optionally be a specified type node kind",
-        {
-            xorNodeKind: xorNode.kind,
-            xorNodeId: xorNode.node.id,
-            maybeExpectedNodeKinds,
-        },
-    );
+export function assertIsAstXor(xorNode: TXorNode): asserts xorNode is TAstXorNode {
+    Assert.asDefined(isAstXor(xorNode), "expected xorNode to hold an Ast node", {
+        xorNodeKind: xorNode.kind,
+        xorNodeId: xorNode.node.id,
+    });
 }
 
-export function assertIsContextXor<T extends Ast.TNode>(
+export function assertIsAstXorChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
-    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
+): asserts xorNode is AstXorNode<T> {
+    assertIsAstXor(xorNode);
+    assertIsNodeKind(xorNode, expectedNodeKinds);
+}
+
+export function assertIsContextXor(xorNode: TXorNode): asserts xorNode is ContextXorNode {
+    Assert.isTrue(isContextXor(xorNode), "expected xorNode to hold an Context node", {
+        xorNodeKind: xorNode.kind,
+        xorNodeId: xorNode.node.id,
+    });
+}
+
+export function assertIsContextXorChecked<T extends Ast.TNode>(
+    xorNode: TXorNode,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): asserts xorNode is ContextXorNode {
-    Assert.isTrue(
-        isContextXor(xorNode, maybeExpectedNodeKinds),
-        "expected xorNode to hold an Context node an to optionally be a specified type node kind",
-        {
-            xorNodeKind: xorNode.kind,
-            xorNodeId: xorNode.node.id,
-            maybeExpectedNodeKinds,
-        },
-    );
+    assertIsContextXor(xorNode);
+    assertIsNodeKind(xorNode, expectedNodeKinds);
 }
 
 export function assertIsIdentifier(
@@ -108,42 +109,52 @@ export function assertIsList(xorNode: TXorNode): asserts xorNode is XorNode<Ast.
     assertIsNodeKind(xorNode, [Ast.NodeKind.ListExpression, Ast.NodeKind.ListLiteral]);
 }
 
-export function assertUnwrapAst<T extends Ast.TNode>(
+export function assertUnwrapAst(xorNode: TXorNode): Ast.TNode {
+    assertIsAstXor(xorNode);
+    return xorNode.node;
+}
+
+export function assertUnwrapAstChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
-    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): Ast.TNode {
-    assertIsAstXor(xorNode, maybeExpectedNodeKinds);
+    assertIsAstXorChecked(xorNode, expectedNodeKinds);
     return xorNode.node;
 }
 
-export function assertUnwrapContext<T extends Ast.TNode>(
+export function assertUnwrapContext(xorNode: TXorNode): ParseContext.Node {
+    assertIsContextXor(xorNode);
+    return xorNode.node;
+}
+
+export function assertUnwrapContextChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
-    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): ParseContext.Node {
-    assertIsContextXor(xorNode, maybeExpectedNodeKinds);
+    assertIsContextXorChecked(xorNode, expectedNodeKinds);
     return xorNode.node;
 }
 
-export function isAstXor<T extends Ast.TNode>(
-    xorNode: TXorNode,
-    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
-): xorNode is AstXorNode<T> {
-    if (xorNode.kind !== XorNodeKind.Ast) {
-        return false;
-    } else {
-        return !maybeExpectedNodeKinds || isNodeKind(xorNode, maybeExpectedNodeKinds);
-    }
+export function isAstXor(xorNode: TXorNode): xorNode is TAstXorNode {
+    return xorNode.kind === XorNodeKind.Ast;
 }
 
-export function isContextXor<T extends Ast.TNode>(
+export function isAstXorChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
-    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
+): xorNode is AstXorNode<T> {
+    return isAstXor(xorNode) && AstUtils.isNodeKind(xorNode.node, expectedNodeKinds);
+}
+
+export function isContextXor(xorNode: TXorNode): xorNode is ContextXorNode {
+    return xorNode.kind !== XorNodeKind.Context;
+}
+
+export function isContextXorChecked<T extends Ast.TNode>(
+    xorNode: TXorNode,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): xorNode is ContextXorNode {
-    if (xorNode.kind !== XorNodeKind.Context) {
-        return false;
-    } else {
-        return !maybeExpectedNodeKinds || isNodeKind(xorNode, maybeExpectedNodeKinds);
-    }
+    return isContextXor(xorNode) && ParseContextUtils.isNodeKind(xorNode.node, expectedNodeKinds);
 }
 
 export function isNodeKind<T extends Ast.TNode>(
@@ -157,7 +168,7 @@ export function isNodeKind<T extends Ast.TNode>(
 }
 
 export function maybeIdentifierExpressionLiteral(xorNode: TXorNode): string | undefined {
-    const maybeIdentifierExpression: Ast.IdentifierExpression | undefined = maybeUnwrapAst(
+    const maybeIdentifierExpression: Ast.IdentifierExpression | undefined = maybeUnwrapAstChecked(
         xorNode,
         Ast.NodeKind.IdentifierExpression,
     );
@@ -171,9 +182,14 @@ export function maybeIdentifierExpressionLiteral(xorNode: TXorNode): string | un
         : identifierExpression.maybeInclusiveConstant.constantKind + identifierExpression.identifier.literal;
 }
 
-export function maybeUnwrapAst<T extends Ast.TNode>(
+export function maybeUnwrapAst(xorNode: TXorNode): Ast.TNode | undefined {
+    return isAstXor(xorNode) ? xorNode.node : undefined;
+}
+
+export function maybeUnwrapAstChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
-    expectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): T | undefined {
-    return isAstXor(xorNode, expectedNodeKinds) ? xorNode.node : undefined;
+    const maybeAstNode: Ast.TNode | undefined = maybeUnwrapAst(xorNode);
+    return maybeAstNode && AstUtils.isNodeKind(maybeAstNode, expectedNodeKinds) ? maybeAstNode : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -4,9 +4,9 @@
 import { ParseContext } from "..";
 import { ArrayUtils, Assert } from "../../common";
 import { Ast } from "../../language";
-import { AstXorNode, ContextXorNode, TXorNode, XorNodeKind } from "./xorNode";
+import { AstXorNode, ContextXorNode, TAstXorNode, TXorNode, XorNode, XorNodeKind } from "./xorNode";
 
-export function createAstNode(node: Ast.TNode): TXorNode {
+export function createAstNode<T extends Ast.TNode>(node: T): XorNode<T> {
     return {
         kind: XorNodeKind.Ast,
         node,
@@ -49,10 +49,10 @@ export function isTFieldAccessExpression(xorNode: TXorNode): boolean {
     return xorNode.node.kind === Ast.NodeKind.FieldSelector || xorNode.node.kind === Ast.NodeKind.FieldProjection;
 }
 
-export function assertAstNodeKind(xorNode: TXorNode, expected: Ast.NodeKind): void {
-    Assert.isTrue(xorNode.node.kind === expected, `xorNode.node.kind === expected`, {
+export function assertAstNodeKind(xorNode: TXorNode, expectedNodeKind: Ast.NodeKind): void {
+    Assert.isTrue(xorNode.node.kind === expectedNodeKind, `xorNode.node.kind === expected`, {
         xorNodeKind: xorNode.node.kind,
-        expected,
+        expectedNodeKind,
     });
 }
 
@@ -60,15 +60,26 @@ export function assertAnyAstNodeKind(xorNode: TXorNode, allowedNodeKinds: Readon
     ArrayUtils.assertIn(allowedNodeKinds, xorNode.node.kind, `incorrect Ast NodeKind`);
 }
 
-export function assertIsAst(xorNode: TXorNode): asserts xorNode is AstXorNode {
-    Assert.isTrue(isAst(xorNode), "expected xorNode to hold an Ast node", {
+export function assertIsAst<T extends Ast.TNode>(
+    xorNode: TXorNode,
+    expectedNodeKind: T["kind"],
+): asserts xorNode is AstXorNode<T> {
+    Assert.isTrue(isAst(xorNode, expectedNodeKind), "expected xorNode to hold an Ast node of a specific node kind", {
+        xorNodeKind: xorNode.kind,
+        xorNodeId: xorNode.node.id,
+        expectedNodeKind,
+    });
+}
+
+export function assertIsAstXor(xorNode: TXorNode): asserts xorNode is TAstXorNode {
+    Assert.isTrue(isAstXor(xorNode), "expected xorNode to hold an Ast node", {
         xorNodeKind: xorNode.kind,
         xorNodeId: xorNode.node.id,
     });
 }
 
-export function assertIsContext(xorNode: TXorNode): asserts xorNode is ContextXorNode {
-    Assert.isTrue(isContext(xorNode), "expected xorNode to hold a Context node", {
+export function assertIsContextXor(xorNode: TXorNode): asserts xorNode is ContextXorNode {
+    Assert.isTrue(isContextXor(xorNode), "expected xorNode to hold a Context node", {
         xorNodeKind: xorNode.kind,
         xorNodeId: xorNode.node.id,
     });
@@ -86,33 +97,53 @@ export function assertIsList(xorNode: TXorNode): void {
     assertAnyAstNodeKind(xorNode, [Ast.NodeKind.ListExpression, Ast.NodeKind.ListLiteral]);
 }
 
-export function assertGetAst(xorNode: TXorNode): Ast.TNode {
-    assertIsAst(xorNode);
+export function assertGetAst<T extends Ast.TNode>(xorNode: TXorNode, expectedNodeKind: T["kind"]): T {
+    assertIsAst(xorNode, expectedNodeKind);
     return xorNode.node;
 }
 
-export function assertGetContext(xorNode: TXorNode): ParseContext.Node {
-    assertIsContext(xorNode);
+export function assertUnwrapAst<T extends Ast.TNode>(xorNode: TXorNode, expectedNodeKind: T["kind"]): T {
+    assertIsAst(xorNode, expectedNodeKind);
     return xorNode.node;
 }
 
-export function isAst(xorNode: TXorNode): xorNode is AstXorNode {
+export function assertUnwrapTAst(xorNode: TXorNode): Ast.TNode {
+    assertIsAstXor(xorNode);
+    return xorNode.node;
+}
+
+export function assertUnwrapContext(xorNode: TXorNode): ParseContext.Node {
+    assertIsContextXor(xorNode);
+    return xorNode.node;
+}
+
+export function isAst<T extends Ast.TNode>(xorNode: TXorNode, nodeKind: T["kind"]): xorNode is AstXorNode<T> {
+    return isAstXor(xorNode) && xorNode.node.kind === nodeKind;
+}
+
+export function isAstXor(xorNode: TXorNode): xorNode is TAstXorNode {
     return xorNode.kind === XorNodeKind.Ast;
 }
 
-export function isContext(xorNode: TXorNode): xorNode is ContextXorNode {
+export function isContextXor(xorNode: TXorNode): xorNode is ContextXorNode {
     return xorNode.kind === XorNodeKind.Context;
 }
 
 export function maybeIdentifierExpressionLiteral(xorNode: TXorNode): string | undefined {
-    assertAstNodeKind(xorNode, Ast.NodeKind.IdentifierExpression);
-
-    if (isContext(xorNode)) {
+    const maybeIdentifierExpression: Ast.IdentifierExpression | undefined = maybeUnwrapAst(
+        xorNode,
+        Ast.NodeKind.IdentifierExpression,
+    );
+    if (maybeIdentifierExpression === undefined) {
         return undefined;
     }
-    const identifierExpression: Ast.IdentifierExpression = xorNode.node as Ast.IdentifierExpression;
+    const identifierExpression: Ast.IdentifierExpression = maybeIdentifierExpression;
 
     return identifierExpression.maybeInclusiveConstant === undefined
         ? identifierExpression.identifier.literal
         : identifierExpression.maybeInclusiveConstant.constantKind + identifierExpression.identifier.literal;
+}
+
+export function maybeUnwrapAst<T extends Ast.TNode>(xorNode: TXorNode, expectedNodeKind: T["kind"]): T | undefined {
+    return isAst(xorNode, expectedNodeKind) ? xorNode.node : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -68,6 +68,12 @@ export function assertIsNodeKind<T extends Ast.TNode>(
             actualNodeId: xorNode.node.id,
             expectedNodeKinds,
         });
+    } else {
+        Assert.isTrue(xorNode.node.kind === expectedNodeKinds, "xorNode.node.kind === expectedNodeKinds", {
+            nodeId: xorNode.node.id,
+            nodeKind: xorNode.node.kind,
+            expectedNodeKind: expectedNodeKinds,
+        });
     }
 }
 
@@ -125,9 +131,10 @@ export function assertUnwrapAst(xorNode: TXorNode): Ast.TNode {
 export function assertUnwrapAstChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): Ast.TNode {
-    assertIsAstXorChecked(xorNode, expectedNodeKinds);
-    return xorNode.node;
+): T {
+    const astNode: Ast.TNode = assertUnwrapAst(xorNode);
+    AstUtils.assertIsNodeKind(astNode, expectedNodeKinds);
+    return astNode;
 }
 
 export function assertUnwrapContext(xorNode: TXorNode): ParseContext.TNode {

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -5,7 +5,7 @@ import { ParseContext } from "..";
 import { ArrayUtils, Assert } from "../../common";
 import { Ast, AstUtils } from "../../language";
 import { ParseContextUtils } from "../context";
-import { AstXorNode, ContextXorNode, TAstXorNode, TXorNode, XorNode, XorNodeKind } from "./xorNode";
+import { AstXorNode, ContextXorNode, TAstXorNode, TContextXorNode, TXorNode, XorNode, XorNodeKind } from "./xorNode";
 
 export function createAstNode<T extends Ast.TNode>(node: T): XorNode<T> {
     return {
@@ -50,6 +50,14 @@ export function isTFieldAccessExpression(xorNode: TXorNode): xorNode is XorNode<
     return xorNode.node.kind === Ast.NodeKind.FieldSelector || xorNode.node.kind === Ast.NodeKind.FieldProjection;
 }
 
+export function assertAsNodeKind<T extends Ast.TNode>(
+    xorNode: TXorNode,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
+): XorNode<T> {
+    assertIsNodeKind(xorNode, expectedNodeKinds);
+    return xorNode;
+}
+
 export function assertIsNodeKind<T extends Ast.TNode>(
     xorNode: TXorNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
@@ -78,7 +86,7 @@ export function assertIsAstXorChecked<T extends Ast.TNode>(
     assertIsNodeKind(xorNode, expectedNodeKinds);
 }
 
-export function assertIsContextXor<T extends Ast.TNode>(xorNode: TXorNode): asserts xorNode is ContextXorNode<T> {
+export function assertIsContextXor(xorNode: TXorNode): asserts xorNode is TContextXorNode {
     Assert.isTrue(isContextXor(xorNode), "expected xorNode to hold an Context node", {
         xorNodeKind: xorNode.kind,
         xorNodeId: xorNode.node.id,
@@ -122,8 +130,8 @@ export function assertUnwrapAstChecked<T extends Ast.TNode>(
     return xorNode.node;
 }
 
-export function assertUnwrapContext<T extends Ast.TNode>(xorNode: TXorNode): ParseContext.Node<T> {
-    assertIsContextXor<T>(xorNode);
+export function assertUnwrapContext(xorNode: TXorNode): ParseContext.TNode {
+    assertIsContextXor(xorNode);
     return xorNode.node;
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -97,18 +97,13 @@ export function assertIsList(xorNode: TXorNode): void {
     assertAnyAstNodeKind(xorNode, [Ast.NodeKind.ListExpression, Ast.NodeKind.ListLiteral]);
 }
 
-export function assertGetAst<T extends Ast.TNode>(xorNode: TXorNode, expectedNodeKind: T["kind"]): T {
-    assertIsAst(xorNode, expectedNodeKind);
-    return xorNode.node;
-}
-
-export function assertUnwrapAst<T extends Ast.TNode>(xorNode: TXorNode, expectedNodeKind: T["kind"]): T {
-    assertIsAst(xorNode, expectedNodeKind);
-    return xorNode.node;
-}
-
-export function assertUnwrapTAst(xorNode: TXorNode): Ast.TNode {
+export function assertUnwrapAst(xorNode: TXorNode): Ast.TNode {
     assertIsAstXor(xorNode);
+    return xorNode.node;
+}
+
+export function assertUnwrapAstChecked<T extends Ast.TNode>(xorNode: TXorNode, expectedNodeKind: T["kind"]): T {
+    assertIsAst(xorNode, expectedNodeKind);
     return xorNode.node;
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -64,11 +64,15 @@ export function assertIsAst<T extends Ast.TNode>(
     xorNode: TXorNode,
     expectedNodeKind: T["kind"],
 ): asserts xorNode is AstXorNode<T> {
-    Assert.isTrue(isAst(xorNode, expectedNodeKind), "expected xorNode to hold an Ast node of a specific node kind", {
-        xorNodeKind: xorNode.kind,
-        xorNodeId: xorNode.node.id,
-        expectedNodeKind,
-    });
+    Assert.isTrue(
+        isAstXorKind(xorNode, expectedNodeKind),
+        "expected xorNode to hold an Ast node of a specific node kind",
+        {
+            xorNodeKind: xorNode.kind,
+            xorNodeId: xorNode.node.id,
+            expectedNodeKind,
+        },
+    );
 }
 
 export function assertIsAstXor(xorNode: TXorNode): asserts xorNode is TAstXorNode {
@@ -112,7 +116,7 @@ export function assertUnwrapContext(xorNode: TXorNode): ParseContext.Node {
     return xorNode.node;
 }
 
-export function isAst<T extends Ast.TNode>(xorNode: TXorNode, nodeKind: T["kind"]): xorNode is AstXorNode<T> {
+export function isAstXorKind<T extends Ast.TNode>(xorNode: TXorNode, nodeKind: T["kind"]): xorNode is AstXorNode<T> {
     return isAstXor(xorNode) && xorNode.node.kind === nodeKind;
 }
 
@@ -140,5 +144,5 @@ export function maybeIdentifierExpressionLiteral(xorNode: TXorNode): string | un
 }
 
 export function maybeUnwrapAst<T extends Ast.TNode>(xorNode: TXorNode, expectedNodeKind: T["kind"]): T | undefined {
-    return isAst(xorNode, expectedNodeKind) ? xorNode.node : undefined;
+    return isAstXorKind(xorNode, expectedNodeKind) ? xorNode.node : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -58,6 +58,31 @@ export function assertAsNodeKind<T extends Ast.TNode>(
     return xorNode;
 }
 
+export function assertAsFunctionParameterList(xorNode: TXorNode): XorNode<Ast.FieldSpecificationList> {
+    assertIsFieldSpecificationList(xorNode);
+    return xorNode;
+}
+
+export function assertAsInvokeExpression(xorNode: TXorNode): XorNode<Ast.InvokeExpression> {
+    assertIsInvokeExpression(xorNode);
+    return xorNode;
+}
+
+export function assertAsLetExpression(xorNode: TXorNode): XorNode<Ast.LetExpression> {
+    assertIsLetExpression(xorNode);
+    return xorNode;
+}
+
+export function assertAsList(xorNode: TXorNode): XorNode<Ast.ListExpression | Ast.ListLiteral> {
+    assertIsList(xorNode);
+    return xorNode;
+}
+
+export function assertAsParameter(xorNode: TXorNode): XorNode<Ast.TParameter> {
+    assertIsParameter(xorNode);
+    return xorNode;
+}
+
 export function assertIsNodeKind<T extends Ast.TNode>(
     xorNode: TXorNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
@@ -119,8 +144,26 @@ export function assertIsRecord(
     assertIsNodeKind(xorNode, [Ast.NodeKind.RecordExpression, Ast.NodeKind.RecordLiteral]);
 }
 
+export function assertIsFieldSpecificationList(
+    xorNode: TXorNode,
+): asserts xorNode is XorNode<Ast.FieldSpecificationList> {
+    assertIsNodeKind(xorNode, Ast.NodeKind.FieldSpecificationList);
+}
+
+export function assertIsInvokeExpression(xorNode: TXorNode): asserts xorNode is XorNode<Ast.InvokeExpression> {
+    assertIsNodeKind(xorNode, Ast.NodeKind.InvokeExpression);
+}
+
+export function assertIsLetExpression(xorNode: TXorNode): asserts xorNode is XorNode<Ast.LetExpression> {
+    assertIsNodeKind(xorNode, Ast.NodeKind.LetExpression);
+}
+
 export function assertIsList(xorNode: TXorNode): asserts xorNode is XorNode<Ast.ListExpression | Ast.ListLiteral> {
     assertIsNodeKind(xorNode, [Ast.NodeKind.ListExpression, Ast.NodeKind.ListLiteral]);
+}
+
+export function assertIsParameter(xorNode: TXorNode): asserts xorNode is XorNode<Ast.TParameter> {
+    assertIsNodeKind(xorNode, Ast.NodeKind.Parameter);
 }
 
 export function assertUnwrapAst(xorNode: TXorNode): Ast.TNode {

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -148,11 +148,11 @@ export function isContextXor<T extends Ast.TNode>(
 
 export function isNodeKind<T extends Ast.TNode>(
     xorNode: TXorNode,
-    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"],
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): xorNode is XorNode<T> {
     return (
-        xorNode.node.kind === maybeExpectedNodeKinds ||
-        (Array.isArray(maybeExpectedNodeKinds) && maybeExpectedNodeKinds.includes(xorNode.node.kind))
+        xorNode.node.kind === expectedNodeKinds ||
+        (Array.isArray(expectedNodeKinds) && expectedNodeKinds.includes(xorNode.node.kind))
     );
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -65,7 +65,7 @@ export function assertIsAst<T extends Ast.TNode>(
     expectedNodeKind: T["kind"],
 ): asserts xorNode is AstXorNode<T> {
     Assert.isTrue(
-        isAstXorKind(xorNode, expectedNodeKind),
+        isAstXorChecked(xorNode, expectedNodeKind),
         "expected xorNode to hold an Ast node of a specific node kind",
         {
             xorNodeKind: xorNode.kind,
@@ -116,16 +116,40 @@ export function assertUnwrapContext(xorNode: TXorNode): ParseContext.Node {
     return xorNode.node;
 }
 
-export function isAstXorKind<T extends Ast.TNode>(xorNode: TXorNode, nodeKind: T["kind"]): xorNode is AstXorNode<T> {
-    return isAstXor(xorNode) && xorNode.node.kind === nodeKind;
-}
-
 export function isAstXor(xorNode: TXorNode): xorNode is TAstXorNode {
     return xorNode.kind === XorNodeKind.Ast;
 }
 
+export function isAstXorChecked<T extends Ast.TNode>(
+    xorNode: TXorNode,
+    expectedNodeKind: T["kind"],
+): xorNode is AstXorNode<T> {
+    return isAstXor(xorNode) && xorNode.node.kind === expectedNodeKind;
+}
+
+export function isAstXorCheckedMany<T extends Ast.TNode>(
+    xorNode: TXorNode,
+    expectedNodeKinds: ReadonlyArray<T["kind"]>,
+): xorNode is AstXorNode<T> {
+    return isAstXor(xorNode) && expectedNodeKinds.includes(xorNode.node.kind);
+}
+
 export function isContextXor(xorNode: TXorNode): xorNode is ContextXorNode {
     return xorNode.kind === XorNodeKind.Context;
+}
+
+export function isXorChecked<T extends Ast.TNode>(
+    xorNode: TXorNode,
+    expectedNodeKind: T["kind"],
+): xorNode is XorNode<T> {
+    return isAstXorChecked(xorNode, expectedNodeKind) || isContextXor(xorNode);
+}
+
+export function isXorCheckedMany<T extends Ast.TNode>(
+    xorNode: TXorNode,
+    expectedNodeKinds: ReadonlyArray<T["kind"]>,
+): xorNode is XorNode<T> {
+    return isAstXorCheckedMany(xorNode, expectedNodeKinds) || isContextXor(xorNode);
 }
 
 export function maybeIdentifierExpressionLiteral(xorNode: TXorNode): string | undefined {
@@ -144,5 +168,5 @@ export function maybeIdentifierExpressionLiteral(xorNode: TXorNode): string | un
 }
 
 export function maybeUnwrapAst<T extends Ast.TNode>(xorNode: TXorNode, expectedNodeKind: T["kind"]): T | undefined {
-    return isAstXorKind(xorNode, expectedNodeKind) ? xorNode.node : undefined;
+    return isAstXorChecked(xorNode, expectedNodeKind) ? xorNode.node : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -127,11 +127,11 @@ export function assertUnwrapContext<T extends Ast.TNode>(
 
 export function checkNodeKind<T extends Ast.TNode>(
     xorNode: TXorNode,
-    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
 ): xorNode is XorNode<T> {
     return (
-        xorNode.node.kind === expectedNodeKinds ||
-        (Array.isArray(expectedNodeKinds) && expectedNodeKinds.includes(xorNode.node.kind))
+        xorNode.node.kind === maybeExpectedNodeKinds ||
+        (Array.isArray(maybeExpectedNodeKinds) && maybeExpectedNodeKinds.includes(xorNode.node.kind))
     );
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -14,22 +14,22 @@ export function createAstNode<T extends Ast.TNode>(node: T): XorNode<T> {
     };
 }
 
-export function createContextNode(node: ParseContext.Node): ContextXorNode {
+export function createContextNode<T extends Ast.TNode>(node: ParseContext.Node<T>): ContextXorNode<T> {
     return {
         kind: XorNodeKind.Context,
         node,
     };
 }
 
-export function isTUnaryType(xorNode: TXorNode): boolean {
+export function isTUnaryType(xorNode: TXorNode): xorNode is XorNode<Ast.TUnaryExpression> {
     return xorNode.node.kind === Ast.NodeKind.UnaryExpression || isTTypeExpression(xorNode);
 }
 
-export function isTTypeExpression(xorNode: TXorNode): boolean {
+export function isTTypeExpression(xorNode: TXorNode): xorNode is XorNode<Ast.TTypeExpression> {
     return xorNode.node.kind === Ast.NodeKind.TypePrimaryType || isTPrimaryExpression(xorNode);
 }
 
-export function isTPrimaryExpression(xorNode: TXorNode): boolean {
+export function isTPrimaryExpression(xorNode: TXorNode): xorNode is XorNode<Ast.TPrimaryExpression> {
     switch (xorNode.node.kind) {
         case Ast.NodeKind.LiteralExpression:
         case Ast.NodeKind.ListExpression:
@@ -46,7 +46,7 @@ export function isTPrimaryExpression(xorNode: TXorNode): boolean {
     }
 }
 
-export function isTFieldAccessExpression(xorNode: TXorNode): boolean {
+export function isTFieldAccessExpression(xorNode: TXorNode): xorNode is XorNode<Ast.TFieldAccessExpression> {
     return xorNode.node.kind === Ast.NodeKind.FieldSelector || xorNode.node.kind === Ast.NodeKind.FieldProjection;
 }
 
@@ -78,7 +78,7 @@ export function assertIsAstXorChecked<T extends Ast.TNode>(
     assertIsNodeKind(xorNode, expectedNodeKinds);
 }
 
-export function assertIsContextXor(xorNode: TXorNode): asserts xorNode is ContextXorNode {
+export function assertIsContextXor<T extends Ast.TNode>(xorNode: TXorNode): asserts xorNode is ContextXorNode<T> {
     Assert.isTrue(isContextXor(xorNode), "expected xorNode to hold an Context node", {
         xorNodeKind: xorNode.kind,
         xorNodeId: xorNode.node.id,
@@ -88,7 +88,7 @@ export function assertIsContextXor(xorNode: TXorNode): asserts xorNode is Contex
 export function assertIsContextXorChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): asserts xorNode is ContextXorNode {
+): asserts xorNode is ContextXorNode<T> {
     assertIsContextXor(xorNode);
     assertIsNodeKind(xorNode, expectedNodeKinds);
 }
@@ -122,15 +122,15 @@ export function assertUnwrapAstChecked<T extends Ast.TNode>(
     return xorNode.node;
 }
 
-export function assertUnwrapContext(xorNode: TXorNode): ParseContext.Node {
-    assertIsContextXor(xorNode);
+export function assertUnwrapContext<T extends Ast.TNode>(xorNode: TXorNode): ParseContext.Node<T> {
+    assertIsContextXor<T>(xorNode);
     return xorNode.node;
 }
 
 export function assertUnwrapContextChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): ParseContext.Node {
+): ParseContext.Node<T> {
     assertIsContextXorChecked(xorNode, expectedNodeKinds);
     return xorNode.node;
 }
@@ -146,14 +146,14 @@ export function isAstXorChecked<T extends Ast.TNode>(
     return isAstXor(xorNode) && AstUtils.isNodeKind(xorNode.node, expectedNodeKinds);
 }
 
-export function isContextXor(xorNode: TXorNode): xorNode is ContextXorNode {
-    return xorNode.kind !== XorNodeKind.Context;
+export function isContextXor<T extends Ast.TNode>(xorNode: TXorNode): xorNode is ContextXorNode<T> {
+    return xorNode.kind === XorNodeKind.Context;
 }
 
 export function isContextXorChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): xorNode is ContextXorNode {
+): xorNode is ContextXorNode<T> {
     return isContextXor(xorNode) && ParseContextUtils.isNodeKind(xorNode.node, expectedNodeKinds);
 }
 
@@ -165,6 +165,23 @@ export function isNodeKind<T extends Ast.TNode>(
         xorNode.node.kind === expectedNodeKinds ||
         (Array.isArray(expectedNodeKinds) && expectedNodeKinds.includes(xorNode.node.kind))
     );
+}
+
+export function isTWrapped(xorNode: TXorNode): xorNode is XorNode<Ast.TWrapped> {
+    return isNodeKind<Ast.TWrapped>(xorNode, [
+        Ast.NodeKind.FieldProjection,
+        Ast.NodeKind.FieldSelector,
+        Ast.NodeKind.FieldSpecificationList,
+        Ast.NodeKind.InvokeExpression,
+        Ast.NodeKind.ItemAccessExpression,
+        Ast.NodeKind.ListExpression,
+        Ast.NodeKind.ListLiteral,
+        Ast.NodeKind.ListType,
+        Ast.NodeKind.ParameterList,
+        Ast.NodeKind.ParenthesizedExpression,
+        Ast.NodeKind.RecordExpression,
+        Ast.NodeKind.RecordLiteral,
+    ]);
 }
 
 export function maybeIdentifierExpressionLiteral(xorNode: TXorNode): string | undefined {

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -92,15 +92,19 @@ export function assertIsContextXor<T extends Ast.TNode>(
     );
 }
 
-export function assertIsIdentifier(xorNode: TXorNode): void {
+export function assertIsIdentifier(
+    xorNode: TXorNode,
+): asserts xorNode is XorNode<Ast.Identifier | Ast.IdentifierExpression> {
     assertIsNodeKind(xorNode, [Ast.NodeKind.Identifier, Ast.NodeKind.IdentifierExpression]);
 }
 
-export function assertIsRecord(xorNode: TXorNode): void {
+export function assertIsRecord(
+    xorNode: TXorNode,
+): asserts xorNode is XorNode<Ast.RecordExpression | Ast.RecordLiteral> {
     assertIsNodeKind(xorNode, [Ast.NodeKind.RecordExpression, Ast.NodeKind.RecordLiteral]);
 }
 
-export function assertIsList(xorNode: TXorNode): void {
+export function assertIsList(xorNode: TXorNode): asserts xorNode is XorNode<Ast.ListExpression | Ast.ListLiteral> {
     assertIsNodeKind(xorNode, [Ast.NodeKind.ListExpression, Ast.NodeKind.ListLiteral]);
 }
 
@@ -144,7 +148,7 @@ export function isContextXor<T extends Ast.TNode>(
 
 export function isNodeKind<T extends Ast.TNode>(
     xorNode: TXorNode,
-    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"] | undefined,
+    maybeExpectedNodeKinds?: ReadonlyArray<T["kind"]> | T["kind"],
 ): xorNode is XorNode<T> {
     return (
         xorNode.node.kind === maybeExpectedNodeKinds ||

--- a/src/powerquery-parser/parser/parseState/parseState.ts
+++ b/src/powerquery-parser/parser/parseState/parseState.ts
@@ -16,5 +16,5 @@ export interface ParseState {
     maybeCurrentToken: Token.Token | undefined;
     maybeCurrentTokenKind: Token.TokenKind | undefined;
     contextState: ParseContext.State;
-    maybeCurrentContextNode: ParseContext.Node | undefined;
+    maybeCurrentContextNode: ParseContext.TNode | undefined;
 }

--- a/src/powerquery-parser/parser/parseState/parseStateUtils.ts
+++ b/src/powerquery-parser/parser/parseState/parseStateUtils.ts
@@ -21,7 +21,7 @@ export function createState(lexerSnapshot: LexerSnapshot, maybeOverrides: Partia
             ? Math.max(...contextState.nodeIdMapCollection.contextNodeById.keys())
             : undefined;
 
-    const maybeCurrentContextNode: ParseContext.Node | undefined =
+    const maybeCurrentContextNode: ParseContext.TNode | undefined =
         maybeCurrentContextNodeId !== undefined
             ? MapUtils.assertGet(contextState.nodeIdMapCollection.contextNodeById, maybeCurrentContextNodeId)
             : undefined;
@@ -60,8 +60,8 @@ export function copyState(state: ParseState): ParseState {
     };
 }
 
-export function startContext(state: ParseState, nodeKind: Ast.NodeKind): void {
-    const newContextNode: ParseContext.Node = ParseContextUtils.startContext(
+export function startContext<T extends Ast.TNode>(state: ParseState, nodeKind: T["kind"]): void {
+    const newContextNode: ParseContext.Node<T> = ParseContextUtils.startContext(
         state.contextState,
         nodeKind,
         state.tokenIndex,
@@ -71,13 +71,13 @@ export function startContext(state: ParseState, nodeKind: Ast.NodeKind): void {
     state.maybeCurrentContextNode = newContextNode;
 }
 
-export function endContext(state: ParseState, astNode: Ast.TNode): void {
-    const contextNode: ParseContext.Node = Assert.asDefined(
+export function endContext<T extends Ast.TNode>(state: ParseState, astNode: T): void {
+    const contextNode: ParseContext.TNode = Assert.asDefined(
         state.maybeCurrentContextNode,
         `can't end a context if one doesn't exist`,
     );
 
-    const maybeParentOfContextNode: ParseContext.Node | undefined = ParseContextUtils.endContext(
+    const maybeParentOfContextNode: ParseContext.TNode | undefined = ParseContextUtils.endContext(
         state.contextState,
         contextNode,
         astNode,
@@ -203,7 +203,7 @@ export function isRecursivePrimaryExpressionNext(
 // -----------------------------
 
 export function assertGetContextNodeMetadata(state: ParseState): ContextNodeMetadata {
-    const currentContextNode: ParseContext.Node = Assert.asDefined(state.maybeCurrentContextNode);
+    const currentContextNode: ParseContext.TNode = Assert.asDefined(state.maybeCurrentContextNode);
     const tokenStart: Token.Token = Assert.asDefined(currentContextNode.maybeTokenStart);
 
     // inclusive token index

--- a/src/powerquery-parser/parser/parser/parserUtils.ts
+++ b/src/powerquery-parser/parser/parser/parserUtils.ts
@@ -140,7 +140,7 @@ export function restoreCheckpoint(state: ParseState, checkpoint: ParseStateCheck
     }
 
     if (checkpoint.maybeContextNodeId) {
-        state.maybeCurrentContextNode = NodeIdMapUtils.assertUnwrapContext(
+        state.maybeCurrentContextNode = NodeIdMapUtils.assertContext(
             state.contextState.nodeIdMapCollection.contextNodeById,
             checkpoint.maybeContextNodeId,
         );

--- a/src/powerquery-parser/parser/parser/parserUtils.ts
+++ b/src/powerquery-parser/parser/parser/parserUtils.ts
@@ -140,7 +140,7 @@ export function restoreCheckpoint(state: ParseState, checkpoint: ParseStateCheck
     }
 
     if (checkpoint.maybeContextNodeId) {
-        state.maybeCurrentContextNode = NodeIdMapUtils.assertContext(
+        state.maybeCurrentContextNode = NodeIdMapUtils.assertGetContext(
             state.contextState.nodeIdMapCollection.contextNodeById,
             checkpoint.maybeContextNodeId,
         );

--- a/src/powerquery-parser/parser/parser/parserUtils.ts
+++ b/src/powerquery-parser/parser/parser/parserUtils.ts
@@ -140,7 +140,7 @@ export function restoreCheckpoint(state: ParseState, checkpoint: ParseStateCheck
     }
 
     if (checkpoint.maybeContextNodeId) {
-        state.maybeCurrentContextNode = NodeIdMapUtils.assertGetContext(
+        state.maybeCurrentContextNode = NodeIdMapUtils.assertUnwrapContext(
             state.contextState.nodeIdMapCollection.contextNodeById,
             checkpoint.maybeContextNodeId,
         );

--- a/src/powerquery-parser/parser/parsers/naive.ts
+++ b/src/powerquery-parser/parser/parsers/naive.ts
@@ -644,7 +644,7 @@ export function readRecursivePrimaryExpression(
     ParseStateUtils.startContext(state, nodeKind);
 
     const nodeIdMapCollection: NodeIdMap.Collection = state.contextState.nodeIdMapCollection;
-    const currentContextNode: ParseContext.Node = Assert.asDefined(
+    const currentContextNode: ParseContext.TNode = Assert.asDefined(
         state.maybeCurrentContextNode,
         "state.maybeCurrentContextNode",
     );
@@ -659,7 +659,7 @@ export function readRecursivePrimaryExpression(
     nodeIdMapCollection.parentIdById.set(head.id, currentContextNode.id);
 
     const newTokenIndexStart: number = head.tokenRange.tokenIndexStart;
-    const mutableContext: TypeScriptUtils.StripReadonly<ParseContext.Node> = currentContextNode;
+    const mutableContext: TypeScriptUtils.StripReadonly<ParseContext.TNode> = currentContextNode;
     const mutableHead: TypeScriptUtils.StripReadonly<Ast.TPrimaryExpression> = head;
 
     // Update token start to match the first parsed node under it, aka the head.

--- a/src/test/libraryTest/parser/idUtils.ts
+++ b/src/test/libraryTest/parser/idUtils.ts
@@ -180,7 +180,7 @@ function assertTraverseMatchesState(traverseState: TraverseState, nodeIdMapColle
 }
 
 function traverseVisitNode(state: TraverseState, xorNode: TXorNode): void {
-    if (XorNodeUtils.isAst(xorNode)) {
+    if (XorNodeUtils.isAstXor(xorNode)) {
         state.astIds.push(xorNode.node.id);
 
         if (xorNode.node.isLeaf) {

--- a/src/test/libraryTest/parser/nodeIdMapUtils.ts
+++ b/src/test/libraryTest/parser/nodeIdMapUtils.ts
@@ -64,10 +64,10 @@ describe("nodeIdMapIterator", () => {
             expect(parameters.length).to.equal(2);
 
             const firstParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.assertGetAst(parameters[0]),
+                XorNodeUtils.assertUnwrapAst(parameters[0]),
             );
             const secondParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.assertGetAst(parameters[1]),
+                XorNodeUtils.assertUnwrapAst(parameters[1]),
             );
 
             expect(firstParameter.name.literal).to.equal("x");
@@ -96,10 +96,10 @@ describe("nodeIdMapIterator", () => {
             expect(parameters.length).to.equal(2);
 
             const firstParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.assertGetAst(parameters[0]),
+                XorNodeUtils.assertUnwrapAst(parameters[0]),
             );
             const secondParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.assertGetAst(parameters[1]),
+                XorNodeUtils.assertUnwrapAst(parameters[1]),
             );
 
             expect(firstParameter.name.literal).to.equal("x");


### PR DESCRIPTION
The previous XorNode had partial type erasure. This is because the signature was:

```
export type TXorNode = AstXorNode | ContextXorNode;

export interface IXorNode<Kind extends XorNodeKind, T> {
    readonly kind: Kind;
    readonly node: T;
}

export type AstXorNode = IXorNode<XorNodeKind.Ast, Ast.TNode>;
export type ContextXorNode = IXorNode<XorNodeKind.Context, ParseContext.Node>;
```

Notice there was no way to say you had an TXorNode which held a specific node kind. The original change was to change the definition of AstXorNode:

```
export type AstXorNode = IXorNode<XorNodeKind.Ast, Ast.TNode>;
export type ContextXorNode = IXorNode<XorNodeKind.Context, ParseContext.Node>;
->
export type AstXorNode<T extends Ast.TNode> = IXorNode<XorNodeKind.Ast, T>;
export type ContextXorNode<T extends Ast.TNode> = IXorNode<XorNodeKind.Context, ParseContext.Node<T>>;
```

The rest of the changes are the fallout / refactoring / code health improvements stemming from the type change. There is no change to the runtime as the same checks are performed, but now the type system can know if something for sure would fail. It also has a more intuitive API for unboxing values.

```
// At compile time it now can check that the 4th argument matches the returned value.
// The function also handles the runtime assert & unboxing of a TXorNode into an Ast.TNode.
const identifierPairedExpression: PQP.Language.Ast.IdentifierPairedExpression = PQP.Parser.NodeIdMapUtils.assertUnwrapNthChildAsAstChecked(
    state.nodeIdMapCollection,
    state.parent.node.id,
    2,
    PQP.Language.Ast.NodeKind.IdentifierPairedExpression,
);
```

It's possible to do further compile time checks with something like the below:

```
export function assertIsAstXor<T extends Ast.TNode | undefined = undefined>(
    xorNode: TXorNode,
    maybeNodeKinds: T extends Ast.TNode ? ReadonlyArray<T["kind"]> | T["kind"] : undefined,
): asserts xorNode is T extends Ast.TNode ? AstXorNode<T> : TAstXorNode {
    Assert.asDefined(isAstXor(xorNode), "expected xorNode to hold an Ast node", {
        xorNodeKind: xorNode.kind,
        xorNodeId: xorNode.node.id,
    });

    if (maybeNodeKinds) {
        assertIsNodeKind(xorNode, maybeNodeKinds);
    }
}
```

This would perform the runtime assert if and only if you provide it with either a NodeKind or an array of NodeKinds. I don't think the increased compile time is worth the benefits.