### PR TITLE
Rename unwrap to unbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/assert.ts
+++ b/src/powerquery-parser/common/assert.ts
@@ -65,12 +65,12 @@ export function isError<T, E>(result: Result<T, E>): asserts result is ErrorResu
     }
 }
 
-export function unwrapOk<T, E>(result: Result<T, E>): T {
+export function unboxOk<T, E>(result: Result<T, E>): T {
     isOk(result);
     return result.value;
 }
 
-export function unwrapError<T, E>(result: Result<T, E>): E {
+export function unboxError<T, E>(result: Result<T, E>): E {
     isError(result);
     return result.error;
 }

--- a/src/powerquery-parser/common/result/resultUtils.ts
+++ b/src/powerquery-parser/common/result/resultUtils.ts
@@ -4,14 +4,14 @@
 import { CommonError } from "..";
 import { ErrorResult, OkResult, Result, ResultKind } from "./result";
 
-export function createOk<T>(value: T): OkResult<T> {
+export function boxOk<T>(value: T): OkResult<T> {
     return {
         kind: ResultKind.Ok,
         value,
     };
 }
 
-export function createError<E>(error: E): ErrorResult<E> {
+export function boxError<E>(error: E): ErrorResult<E> {
     return {
         kind: ResultKind.Error,
         error,
@@ -28,8 +28,8 @@ export function isError<T, E>(result: Result<T, E>): result is ErrorResult<E> {
 
 export function ensureResult<T>(locale: string, callbackFn: () => T): Result<T, CommonError.CommonError> {
     try {
-        return createOk(callbackFn());
+        return boxOk(callbackFn());
     } catch (err) {
-        return createError(CommonError.ensureCommonError(locale, err));
+        return boxError(CommonError.ensureCommonError(locale, err));
     }
 }

--- a/src/powerquery-parser/common/traversal.ts
+++ b/src/powerquery-parser/common/traversal.ts
@@ -117,7 +117,7 @@ export function assertGetAllAstChildren<State extends ITraversalState<ResultType
 
     if (maybeChildIds) {
         const childIds: ReadonlyArray<number> = maybeChildIds;
-        return childIds.map(nodeId => NodeIdMapUtils.assertUnwrapAst(nodeIdMapCollection.astNodeById, nodeId));
+        return childIds.map(nodeId => NodeIdMapUtils.assertUnboxAst(nodeIdMapCollection.astNodeById, nodeId));
     } else {
         return [];
     }
@@ -132,7 +132,7 @@ export function assertGetAllXorChildren<State extends ITraversalState<ResultType
     switch (xorNode.kind) {
         case XorNodeKind.Ast: {
             const astNode: Ast.TNode = xorNode.node;
-            return assertGetAllAstChildren(_state, astNode, nodeIdMapCollection).map(XorNodeUtils.createAstNode);
+            return assertGetAllAstChildren(_state, astNode, nodeIdMapCollection).map(XorNodeUtils.boxAst);
         }
         case XorNodeKind.Context: {
             const result: TXorNode[] = [];

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -171,7 +171,7 @@ function inspectContextParameter(
     let isNullable: boolean;
     let maybeType: Type.TypeKind | undefined;
 
-    const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
+    const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
         nodeIdMapCollection,
         parameter.id,
         1,
@@ -181,7 +181,7 @@ function inspectContextParameter(
         return undefined;
     }
 
-    const maybeOptional: Ast.TConstant | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
+    const maybeOptional: Ast.TConstant | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
         nodeIdMapCollection,
         parameter.id,
         0,
@@ -189,7 +189,7 @@ function inspectContextParameter(
     );
     isOptional = maybeOptional !== undefined;
 
-    const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
+    const maybeParameterType: Ast.AsNullablePrimitiveType | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
         nodeIdMapCollection,
         parameter.id,
         2,

--- a/src/powerquery-parser/lexer/lexer.ts
+++ b/src/powerquery-parser/lexer/lexer.ts
@@ -294,7 +294,7 @@ function ensureCommonOrLexerResult<T>(
     functionToWrap: () => T,
 ): Result<T, CommonError.CommonError | LexError.LexError> {
     try {
-        return ResultUtils.createOk(functionToWrap());
+        return ResultUtils.boxOk(functionToWrap());
     } catch (err) {
         let convertedError: CommonError.CommonError | LexError.LexError;
         if (LexError.isTInnerLexError(err)) {
@@ -302,7 +302,7 @@ function ensureCommonOrLexerResult<T>(
         } else {
             convertedError = CommonError.ensureCommonError(locale, err);
         }
-        return ResultUtils.createError(convertedError);
+        return ResultUtils.boxError(convertedError);
     }
 }
 

--- a/src/powerquery-parser/lexer/lexerSnapshot.ts
+++ b/src/powerquery-parser/lexer/lexerSnapshot.ts
@@ -63,7 +63,7 @@ export class LexerSnapshot {
 
 export function trySnapshot(state: Lexer.State): TriedLexerSnapshot {
     try {
-        return ResultUtils.createOk(createSnapshot(state));
+        return ResultUtils.boxOk(createSnapshot(state));
     } catch (e) {
         let error: LexError.TLexError;
         if (LexError.isTInnerLexError(e)) {
@@ -71,7 +71,7 @@ export function trySnapshot(state: Lexer.State): TriedLexerSnapshot {
         } else {
             error = CommonError.ensureCommonError(state.locale, e);
         }
-        return ResultUtils.createError(error);
+        return ResultUtils.boxError(error);
     }
 }
 

--- a/src/powerquery-parser/parser/context/contextUtils.ts
+++ b/src/powerquery-parser/parser/context/contextUtils.ts
@@ -299,7 +299,7 @@ export function deleteContext(state: ParseContext.State, nodeId: number): ParseC
     leafIds.delete(nodeId);
 
     // Return the node's parent if it exits
-    return maybeParentId !== undefined ? NodeIdMapUtils.assertUnwrapContext(contextNodeById, maybeParentId) : undefined;
+    return maybeParentId !== undefined ? NodeIdMapUtils.assertUnboxContext(contextNodeById, maybeParentId) : undefined;
 }
 
 function deleteFromKindMap(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): void {

--- a/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
+++ b/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
@@ -36,12 +36,12 @@ export function readAmbiguous<T extends Ast.TNode>(
 
         try {
             maybeNode = parseFn(variantState, parser);
-            variantResult = ResultUtils.createOk(maybeNode);
+            variantResult = ResultUtils.boxOk(maybeNode);
         } catch (err) {
             if (!ParseError.isTInnerParseError(err)) {
                 throw err;
             }
-            variantResult = ResultUtils.createError(new ParseError.ParseError(err, variantState));
+            variantResult = ResultUtils.boxError(new ParseError.ParseError(err, variantState));
         }
 
         const candiate: AmbiguousParse<T> = {
@@ -306,7 +306,7 @@ function readParenthesizedExpressionOrBinOpExpression(
 ): Ast.ParenthesizedExpression | Ast.TLogicalExpression {
     const node: Ast.TNode = parser.readLogicalExpression(state, parser);
 
-    const leftMostNode: Ast.TNode = NodeIdMapUtils.assertUnwrapLeftMostLeaf(
+    const leftMostNode: Ast.TNode = NodeIdMapUtils.assertUnboxLeftMostLeaf(
         state.contextState.nodeIdMapCollection,
         node.id,
     );

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -53,7 +53,7 @@ export function assertIterChildrenAst(
 ): ReadonlyArray<Ast.TNode> {
     const astNodeById: NodeIdMap.AstNodeById = nodeIdMapCollection.astNodeById;
     return assertIterChildIds(nodeIdMapCollection.childIdsById, parentId).map(childId =>
-        NodeIdMapUtils.assertUnwrapAst(astNodeById, childId),
+        NodeIdMapUtils.assertUnboxAst(astNodeById, childId),
     );
 }
 
@@ -92,7 +92,7 @@ export function maybeIterChildrenAst(
     const childIds: ReadonlyArray<number> = maybeChildIds;
 
     const astNodeById: NodeIdMap.AstNodeById = nodeIdMapCollection.astNodeById;
-    return childIds.map(childId => NodeIdMapUtils.assertUnwrapAst(astNodeById, childId));
+    return childIds.map(childId => NodeIdMapUtils.assertUnboxAst(astNodeById, childId));
 }
 
 export function maybeNextSiblingXor(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): TXorNode | undefined {
@@ -138,7 +138,7 @@ export function iterArrayWrapper(
 
     if (arrayWrapper.kind === XorNodeKind.Ast) {
         return (arrayWrapper.node as Ast.TCsvArray).elements.map((wrapper: Ast.TCsv) =>
-            XorNodeUtils.createAstNode(wrapper.node),
+            XorNodeUtils.boxAst(wrapper.node),
         );
     }
 
@@ -146,7 +146,7 @@ export function iterArrayWrapper(
     for (const csvXorNode of assertIterChildrenXor(nodeIdMapCollection, arrayWrapper.node.id)) {
         switch (csvXorNode.kind) {
             case XorNodeKind.Ast:
-                partial.push(XorNodeUtils.createAstNode((csvXorNode.node as Ast.TCsv).node));
+                partial.push(XorNodeUtils.boxAst((csvXorNode.node as Ast.TCsv).node));
                 break;
 
             case XorNodeKind.Context: {
@@ -176,7 +176,7 @@ export function iterFieldProjection(
 ): ReadonlyArray<TXorNode> {
     XorNodeUtils.assertIsNodeKind(fieldProjection, Ast.NodeKind.FieldProjection);
 
-    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeUnwrapArrayWrapper(
+    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeUnboxArrayWrapper(
         nodeIdMapCollection,
         fieldProjection.node.id,
     );
@@ -193,7 +193,7 @@ export function iterFieldProjectionNames(
     for (const selector of iterFieldProjection(nodeIdMapCollection, fieldProjection)) {
         const maybeIdentifier:
             | XorNode<Ast.GeneralizedIdentifier>
-            | undefined = NodeIdMapUtils.maybeUnwrapContentChecked<Ast.GeneralizedIdentifier>(
+            | undefined = NodeIdMapUtils.maybeUnboxWrappedContentChecked<Ast.GeneralizedIdentifier>(
             nodeIdMapCollection,
             selector.node.id,
             Ast.NodeKind.GeneralizedIdentifier,
@@ -217,7 +217,7 @@ export function iterFunctionExpressionParameters(
     if (functionExpression.kind === XorNodeKind.Ast) {
         return (functionExpression.node as Ast.FunctionExpression).parameters.content.elements.map(
             (parameter: Ast.ICsv<Ast.IParameter<Ast.AsNullablePrimitiveType | undefined>>) =>
-                XorNodeUtils.createAstNode(parameter.node),
+                XorNodeUtils.boxAst(parameter.node),
         );
     }
 
@@ -238,7 +238,7 @@ export function iterFunctionExpressionParameterNames(
     const result: string[] = [];
 
     for (const parameter of iterFunctionExpressionParameters(nodeIdMapCollection, functionExpression)) {
-        const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
+        const maybeName: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
             nodeIdMapCollection,
             parameter.node.id,
             1,
@@ -282,7 +282,7 @@ export function iterLetExpression(
 ): ReadonlyArray<LetKeyValuePair> {
     XorNodeUtils.assertIsNodeKind<Ast.LetExpression>(letExpression, Ast.NodeKind.LetExpression);
 
-    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeUnwrapArrayWrapper(
+    const maybeArrayWrapper: TXorNode | undefined = NodeIdMapUtils.maybeUnboxArrayWrapper(
         nodeIdMapCollection,
         letExpression.node.id,
     );
@@ -310,7 +310,7 @@ export function iterRecord(
 ): ReadonlyArray<RecordKeyValuePair> {
     XorNodeUtils.assertIsRecord(record);
 
-    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeUnwrapArrayWrapper(
+    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeUnboxArrayWrapper(
         nodeIdMapCollection,
         record.node.id,
     );
@@ -338,11 +338,11 @@ export function iterSection(
             const keyLiteral: string = namePairedExpression.key.literal;
 
             return {
-                source: XorNodeUtils.createAstNode(namePairedExpression),
+                source: XorNodeUtils.boxAst(namePairedExpression),
                 key: namePairedExpression.key,
                 keyLiteral,
                 normalizedKeyLiteral: StringUtils.normalizeIdentifier(keyLiteral),
-                maybeValue: XorNodeUtils.createAstNode(namePairedExpression.value),
+                maybeValue: XorNodeUtils.boxAst(namePairedExpression.value),
                 pairKind: PairKind.SectionMember,
             };
         });
@@ -372,7 +372,7 @@ export function iterSection(
         const keyValuePair: TXorNode = maybeKeyValuePair;
         const keyValuePairNodeId: number = keyValuePair.node.id;
 
-        const maybeKey: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
+        const maybeKey: Ast.Identifier | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
             nodeIdMapCollection,
             keyValuePairNodeId,
             0,
@@ -403,7 +403,7 @@ function iterKeyValuePairs<
 >(nodeIdMapCollection: NodeIdMap.Collection, arrayWrapper: TXorNode, pairKind: KVP["pairKind"]): ReadonlyArray<KVP> {
     const partial: KVP[] = [];
     for (const keyValuePair of iterArrayWrapper(nodeIdMapCollection, arrayWrapper)) {
-        const maybeKey: Key | undefined = NodeIdMapUtils.maybeUnwrapNthChildIfAstChecked(
+        const maybeKey: Key | undefined = NodeIdMapUtils.maybeUnboxNthChildIfAstChecked(
             nodeIdMapCollection,
             keyValuePair.node.id,
             0,
@@ -431,7 +431,7 @@ function iterArrayWrapperInWrappedContent(
     nodeIdMapCollection: NodeIdMap.Collection,
     xorNode: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeUnwrapArrayWrapper(
+    const maybeArrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.maybeUnboxArrayWrapper(
         nodeIdMapCollection,
         xorNode.node.id,
     );

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -41,58 +41,58 @@ export function assertGetNthChildChecked<T extends Ast.TNode>(
     return xorNode;
 }
 
-export function assertUnwrapArrayWrapperAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TArrayWrapper {
+export function assertUnboxArrayWrapperAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TArrayWrapper {
     const maybeXorNode: XorNode<Ast.TArrayWrapper> | undefined = Assert.asDefined(
-        maybeUnwrapArrayWrapper(nodeIdMapCollection, nodeId),
-        "failure in assertUnwrapArrayWrapperAst",
+        maybeUnboxArrayWrapper(nodeIdMapCollection, nodeId),
+        "failure in assertUnboxArrayWrapperAst",
         { nodeId },
     );
     XorNodeUtils.assertIsAstXor(maybeXorNode);
     return maybeXorNode.node;
 }
 
-export function assertUnwrapNthChildAsAst(
+export function assertUnboxNthChildAsAst(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
 ): Ast.TNode {
     return Assert.asDefined(
-        maybeUnwrapNthChildIfAst(nodeIdMapCollection, parentId, attributeIndex),
+        maybeUnboxNthChildIfAst(nodeIdMapCollection, parentId, attributeIndex),
         `parentId doesn't have an Ast child at the given index`,
         { parentId, attributeIndex },
     );
 }
 
-export function assertUnwrapNthChildAsAstChecked<T extends Ast.TNode>(
+export function assertUnboxNthChildAsAstChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): T {
-    const astNode: Ast.TNode = assertUnwrapNthChildAsAst(nodeIdMapCollection, parentId, attributeIndex);
+    const astNode: Ast.TNode = assertUnboxNthChildAsAst(nodeIdMapCollection, parentId, attributeIndex);
     AstUtils.assertIsNodeKind(astNode, expectedNodeKinds);
     return astNode;
 }
 
-export function assertUnwrapNthChildAsContext(
+export function assertUnboxNthChildAsContext(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
 ): ParseContext.TNode {
     return Assert.asDefined(
-        maybeUnwrapNthChildIfContext(nodeIdMapCollection, parentId, attributeIndex),
+        maybeUnboxNthChildIfContext(nodeIdMapCollection, parentId, attributeIndex),
         `parentId doesn't have a context child at the given index`,
         { parentId, attributeIndex },
     );
 }
 
-export function assertUnwrapNthChildAsContextChecked<T extends Ast.TNode>(
+export function assertUnboxNthChildAsContextChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): ParseContext.Node<T> {
-    const parseContext: ParseContext.TNode = assertUnwrapNthChildAsContext(
+    const parseContext: ParseContext.TNode = assertUnboxNthChildAsContext(
         nodeIdMapCollection,
         parentId,
         attributeIndex,
@@ -141,14 +141,14 @@ export function maybeNthChildChecked<T extends Ast.TNode>(
     return maybeXorNode && XorNodeUtils.isNodeKind(maybeXorNode, expectedNodeKinds) ? maybeXorNode : undefined;
 }
 
-export function maybeUnwrapArrayWrapper(
+export function maybeUnboxArrayWrapper(
     nodeIdMapCollection: Collection,
     nodeId: number,
 ): XorNode<Ast.TArrayWrapper> | undefined {
     return maybeNthChildChecked<Ast.TArrayWrapper>(nodeIdMapCollection, nodeId, 1, Ast.NodeKind.ArrayWrapper);
 }
 
-export function maybeUnwrapNthChildIfAst(
+export function maybeUnboxNthChildIfAst(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
@@ -157,17 +157,17 @@ export function maybeUnwrapNthChildIfAst(
     return maybeXorNode && XorNodeUtils.isAstXor(maybeXorNode) ? maybeXorNode.node : undefined;
 }
 
-export function maybeUnwrapNthChildIfAstChecked<T extends Ast.TNode>(
+export function maybeUnboxNthChildIfAstChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): T | undefined {
-    const maybeAstNode: Ast.TNode | undefined = maybeUnwrapNthChildIfAst(nodeIdMapCollection, parentId, attributeIndex);
+    const maybeAstNode: Ast.TNode | undefined = maybeUnboxNthChildIfAst(nodeIdMapCollection, parentId, attributeIndex);
     return maybeAstNode && AstUtils.isNodeKind(maybeAstNode, expectedNodeKinds) ? maybeAstNode : undefined;
 }
 
-export function maybeUnwrapNthChildIfContext(
+export function maybeUnboxNthChildIfContext(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
@@ -176,13 +176,13 @@ export function maybeUnwrapNthChildIfContext(
     return maybeXorNode && XorNodeUtils.isContextXor(maybeXorNode) ? maybeXorNode.node : undefined;
 }
 
-export function maybeUnwrapNthChildIfContextChecked<T extends Ast.TNode>(
+export function maybeUnboxNthChildIfContextChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     parentId: number,
     attributeIndex: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): ParseContext.Node<T> | undefined {
-    const maybeContextNode: ParseContext.TNode | undefined = maybeUnwrapNthChildIfContext(
+    const maybeContextNode: ParseContext.TNode | undefined = maybeUnboxNthChildIfContext(
         nodeIdMapCollection,
         parentId,
         attributeIndex,
@@ -192,31 +192,31 @@ export function maybeUnwrapNthChildIfContextChecked<T extends Ast.TNode>(
         : undefined;
 }
 
-export function maybeUnwrapContentIfAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TWrapped | undefined {
-    const maybeXorNode: TXorNode | undefined = maybeUnwrapContent(nodeIdMapCollection, nodeId);
+export function maybeUnboxIfAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TWrapped | undefined {
+    const maybeXorNode: TXorNode | undefined = maybeWrappedContent(nodeIdMapCollection, nodeId);
     return maybeXorNode && XorNodeUtils.isAstXor(maybeXorNode) && XorNodeUtils.isTWrapped(maybeXorNode)
         ? maybeXorNode.node
         : undefined;
 }
 
-export function maybeUnwrapContentIfAstChecked<T extends Ast.TWrapped, C extends T["content"]>(
+export function maybeUnboxWrappedContentIfAstChecked<C extends Ast.TWrapped["content"]>(
     nodeIdMapCollection: Collection,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<C["kind"]> | C["kind"],
 ): C | undefined {
-    const maybeAstNode: Ast.TNode | undefined = maybeUnwrapContentIfAst(nodeIdMapCollection, nodeId);
+    const maybeAstNode: Ast.TNode | undefined = maybeUnboxIfAst(nodeIdMapCollection, nodeId);
     return maybeAstNode && AstUtils.isNodeKind<C>(maybeAstNode, expectedNodeKinds) ? maybeAstNode : undefined;
 }
 
-export function maybeUnwrapContent(nodeIdMapCollection: Collection, nodeId: number): TXorNode | undefined {
+export function maybeWrappedContent(nodeIdMapCollection: Collection, nodeId: number): TXorNode | undefined {
     return maybeNthChild(nodeIdMapCollection, nodeId, 1);
 }
 
-export function maybeUnwrapContentChecked<C extends Ast.TWrapped["content"]>(
+export function maybeUnboxWrappedContentChecked<C extends Ast.TWrapped["content"]>(
     nodeIdMapCollection: Collection,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<C["kind"]> | C["kind"],
 ): XorNode<C> | undefined {
-    const maybeXorNode: TXorNode | undefined = maybeUnwrapContent(nodeIdMapCollection, nodeId);
+    const maybeXorNode: TXorNode | undefined = maybeWrappedContent(nodeIdMapCollection, nodeId);
     return maybeXorNode && XorNodeUtils.isNodeKind(maybeXorNode, expectedNodeKinds) ? maybeXorNode : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/commonSelectors.ts
@@ -23,7 +23,7 @@ export function assertGetXorChecked<T extends Ast.TNode>(
     });
 }
 
-export function assertUnwrapAst(astNodeById: AstNodeById, nodeId: number): Ast.TNode {
+export function assertUnboxAst(astNodeById: AstNodeById, nodeId: number): Ast.TNode {
     const node: Ast.TNode = Assert.asDefined(
         MapUtils.assertGet(astNodeById, nodeId, "failed to find the given ast node", { nodeId }),
     );
@@ -31,17 +31,17 @@ export function assertUnwrapAst(astNodeById: AstNodeById, nodeId: number): Ast.T
     return node;
 }
 
-export function assertUnwrapAstChecked<T extends Ast.TNode>(
+export function assertUnboxAstChecked<T extends Ast.TNode>(
     astNodeById: AstNodeById,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): T {
-    const astNode: Ast.TNode = assertUnwrapAst(astNodeById, nodeId);
+    const astNode: Ast.TNode = assertUnboxAst(astNodeById, nodeId);
     AstUtils.assertIsNodeKind(astNode, expectedNodeKinds);
     return astNode;
 }
 
-export function assertUnwrapContext(contextNodeById: ContextNodeById, nodeId: number): ParseContext.TNode {
+export function assertUnboxContext(contextNodeById: ContextNodeById, nodeId: number): ParseContext.TNode {
     const node: ParseContext.TNode = Assert.asDefined(
         MapUtils.assertGet(contextNodeById, nodeId, "failed to find the given context node", { nodeId }),
     );
@@ -49,12 +49,12 @@ export function assertUnwrapContext(contextNodeById: ContextNodeById, nodeId: nu
     return node;
 }
 
-export function assertUnwrapContextChecked<T extends Ast.TNode>(
+export function assertUnboxContextChecked<T extends Ast.TNode>(
     contextNodeById: ContextNodeById,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): ParseContext.Node<T> {
-    const contextNode: ParseContext.TNode = assertUnwrapContext(contextNodeById, nodeId);
+    const contextNode: ParseContext.TNode = assertUnboxContext(contextNodeById, nodeId);
     ParseContextUtils.assertIsNodeKind(contextNode, expectedNodeKinds);
     return contextNode;
 }
@@ -62,12 +62,12 @@ export function assertUnwrapContextChecked<T extends Ast.TNode>(
 export function maybeXor(nodeIdMapCollection: Collection, nodeId: number): TXorNode | undefined {
     const maybeAstNode: Ast.TNode | undefined = nodeIdMapCollection.astNodeById.get(nodeId);
     if (maybeAstNode !== undefined) {
-        return XorNodeUtils.createAstNode(maybeAstNode);
+        return XorNodeUtils.boxAst(maybeAstNode);
     }
 
     const maybeContextNode: ParseContext.TNode | undefined = nodeIdMapCollection.contextNodeById.get(nodeId);
     if (maybeContextNode !== undefined) {
-        return XorNodeUtils.createContextNode(maybeContextNode);
+        return XorNodeUtils.boxContext(maybeContextNode);
     }
 
     return undefined;

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
@@ -8,8 +8,8 @@ import { AstNodeById, Collection } from "../nodeIdMap";
 import { TXorNode, XorNodeKind } from "../xorNode";
 import { maybeXor } from "./commonSelectors";
 
-export function assertUnwrapLeftMostLeaf(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode {
-    return XorNodeUtils.assertUnwrapAst(
+export function assertUnboxLeftMostLeaf(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode {
+    return XorNodeUtils.asserUnboxAst(
         Assert.asDefined(
             maybeLeftMostXor(nodeIdMapCollection, nodeId),
             `nodeId does not exist in nodeIdMapCollection`,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/parentSelectors.ts
@@ -7,9 +7,9 @@ import { Ast, AstUtils } from "../../../language";
 import { ParseContext, ParseContextUtils } from "../../context";
 import { Collection } from "../nodeIdMap";
 import { TXorNode, XorNode } from "../xorNode";
-import { createAstNode, createContextNode } from "../xorNodeUtils";
+import { boxAst, boxContext } from "../xorNodeUtils";
 
-export function assertUnwrapParentAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode {
+export function assertUnboxParentAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode {
     return Assert.asDefined(
         maybeParentAst(nodeIdMapCollection, nodeId),
         "couldn't find the expected parent Ast for nodeId",
@@ -17,17 +17,17 @@ export function assertUnwrapParentAst(nodeIdMapCollection: Collection, nodeId: n
     );
 }
 
-export function assertUnwrapParentAstChecked<T extends Ast.TNode>(
+export function assertUnboxParentAstChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): T {
-    const astNode: Ast.TNode = assertUnwrapParentAst(nodeIdMapCollection, nodeId);
+    const astNode: Ast.TNode = assertUnboxParentAst(nodeIdMapCollection, nodeId);
     AstUtils.assertIsNodeKind(astNode, expectedNodeKinds);
     return astNode;
 }
 
-export function assertUnwrapParentContext(nodeIdMapCollection: Collection, nodeId: number): ParseContext.TNode {
+export function assertUnboxParentContext(nodeIdMapCollection: Collection, nodeId: number): ParseContext.TNode {
     return Assert.asDefined(
         maybeParentContext(nodeIdMapCollection, nodeId),
         "couldn't find the expected parent context for nodeId",
@@ -35,12 +35,12 @@ export function assertUnwrapParentContext(nodeIdMapCollection: Collection, nodeI
     );
 }
 
-export function assertUnwrapParentContextChecked<T extends Ast.TNode>(
+export function assertUnboxParentContextChecked<T extends Ast.TNode>(
     nodeIdMapCollection: Collection,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): ParseContext.Node<T> {
-    const contextNode: ParseContext.TNode = assertUnwrapParentContext(nodeIdMapCollection, nodeId);
+    const contextNode: ParseContext.TNode = assertUnboxParentContext(nodeIdMapCollection, nodeId);
     ParseContextUtils.assertIsNodeKind(contextNode, expectedNodeKinds);
     return contextNode;
 }
@@ -94,12 +94,12 @@ export function maybeParentContextChecked<T extends Ast.TNode>(
 export function maybeParentXor(nodeIdMapCollection: Collection, childId: number): TXorNode | undefined {
     const maybeAstNode: Ast.TNode | undefined = maybeParentAst(nodeIdMapCollection, childId);
     if (maybeAstNode !== undefined) {
-        return createAstNode(maybeAstNode);
+        return boxAst(maybeAstNode);
     }
 
     const maybeContext: ParseContext.TNode | undefined = maybeParentContext(nodeIdMapCollection, childId);
     if (maybeContext !== undefined) {
-        return createContextNode(maybeContext);
+        return boxContext(maybeContext);
     }
 
     return undefined;

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -7,14 +7,14 @@ import { Ast, AstUtils } from "../../language";
 import { ParseContextUtils } from "../context";
 import { AstXorNode, ContextXorNode, TAstXorNode, TContextXorNode, TXorNode, XorNode, XorNodeKind } from "./xorNode";
 
-export function createAstNode<T extends Ast.TNode>(node: T): XorNode<T> {
+export function boxAst<T extends Ast.TNode>(node: T): XorNode<T> {
     return {
         kind: XorNodeKind.Ast,
         node,
     };
 }
 
-export function createContextNode<T extends Ast.TNode>(node: ParseContext.Node<T>): ContextXorNode<T> {
+export function boxContext<T extends Ast.TNode>(node: ParseContext.Node<T>): ContextXorNode<T> {
     return {
         kind: XorNodeKind.Context,
         node,
@@ -166,26 +166,26 @@ export function assertIsParameter(xorNode: TXorNode): asserts xorNode is XorNode
     assertIsNodeKind(xorNode, Ast.NodeKind.Parameter);
 }
 
-export function assertUnwrapAst(xorNode: TXorNode): Ast.TNode {
+export function asserUnboxAst(xorNode: TXorNode): Ast.TNode {
     assertIsAstXor(xorNode);
     return xorNode.node;
 }
 
-export function assertUnwrapAstChecked<T extends Ast.TNode>(
+export function assertUnboxAstChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): T {
-    const astNode: Ast.TNode = assertUnwrapAst(xorNode);
+    const astNode: Ast.TNode = asserUnboxAst(xorNode);
     AstUtils.assertIsNodeKind(astNode, expectedNodeKinds);
     return astNode;
 }
 
-export function assertUnwrapContext(xorNode: TXorNode): ParseContext.TNode {
+export function assertUnboxContext(xorNode: TXorNode): ParseContext.TNode {
     assertIsContextXor(xorNode);
     return xorNode.node;
 }
 
-export function assertUnwrapContextChecked<T extends Ast.TNode>(
+export function assertUnboxContextChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): ParseContext.Node<T> {
@@ -243,7 +243,7 @@ export function isTWrapped(xorNode: TXorNode): xorNode is XorNode<Ast.TWrapped> 
 }
 
 export function maybeIdentifierExpressionLiteral(xorNode: TXorNode): string | undefined {
-    const maybeIdentifierExpression: Ast.IdentifierExpression | undefined = maybeUnwrapAstChecked(
+    const maybeIdentifierExpression: Ast.IdentifierExpression | undefined = maybeUnboxAstChecked(
         xorNode,
         Ast.NodeKind.IdentifierExpression,
     );
@@ -257,14 +257,14 @@ export function maybeIdentifierExpressionLiteral(xorNode: TXorNode): string | un
         : identifierExpression.maybeInclusiveConstant.constantKind + identifierExpression.identifier.literal;
 }
 
-export function maybeUnwrapAst(xorNode: TXorNode): Ast.TNode | undefined {
+export function maybeUnboxAst(xorNode: TXorNode): Ast.TNode | undefined {
     return isAstXor(xorNode) ? xorNode.node : undefined;
 }
 
-export function maybeUnwrapAstChecked<T extends Ast.TNode>(
+export function maybeUnboxAstChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): T | undefined {
-    const maybeAstNode: Ast.TNode | undefined = maybeUnwrapAst(xorNode);
+    const maybeAstNode: Ast.TNode | undefined = maybeUnboxAst(xorNode);
     return maybeAstNode && AstUtils.isNodeKind(maybeAstNode, expectedNodeKinds) ? maybeAstNode : undefined;
 }

--- a/src/powerquery-parser/parser/parser/parserUtils.ts
+++ b/src/powerquery-parser/parser/parser/parserUtils.ts
@@ -26,13 +26,13 @@ export function tryParse(parseSettings: ParseSettings, lexerSnapshot: LexerSnaps
     try {
         const root: Ast.TNode = maybeParserEntryPointFn(parseState, parseSettings.parser);
         ParseStateUtils.assertIsDoneParsing(parseState);
-        return ResultUtils.createOk({
+        return ResultUtils.boxOk({
             lexerSnapshot,
             root,
             state: parseState,
         });
     } catch (error) {
-        return ResultUtils.createError(ensureParseError(parseState, error, parseSettings.locale));
+        return ResultUtils.boxError(ensureParseError(parseState, error, parseSettings.locale));
     }
 }
 
@@ -46,7 +46,7 @@ export function tryParseDocument(parseSettings: ParseSettings, lexerSnapshot: Le
     try {
         root = parseSettings.parser.readExpression(expressionDocumentState, parseSettings.parser);
         ParseStateUtils.assertIsDoneParsing(expressionDocumentState);
-        return ResultUtils.createOk({
+        return ResultUtils.boxOk({
             lexerSnapshot,
             root,
             state: expressionDocumentState,
@@ -59,7 +59,7 @@ export function tryParseDocument(parseSettings: ParseSettings, lexerSnapshot: Le
         try {
             root = parseSettings.parser.readSectionDocument(sectionDocumentState, parseSettings.parser);
             ParseStateUtils.assertIsDoneParsing(sectionDocumentState);
-            return ResultUtils.createOk({
+            return ResultUtils.boxOk({
                 lexerSnapshot,
                 root,
                 state: sectionDocumentState,
@@ -76,9 +76,7 @@ export function tryParseDocument(parseSettings: ParseSettings, lexerSnapshot: Le
                 betterParsedError = sectionDocumentError;
             }
 
-            return ResultUtils.createError(
-                ensureParseError(betterParsedState, betterParsedError, parseSettings.locale),
-            );
+            return ResultUtils.boxError(ensureParseError(betterParsedState, betterParsedError, parseSettings.locale));
         }
     }
 }
@@ -140,7 +138,7 @@ export function restoreCheckpoint(state: ParseState, checkpoint: ParseStateCheck
     }
 
     if (checkpoint.maybeContextNodeId) {
-        state.maybeCurrentContextNode = NodeIdMapUtils.assertUnwrapContext(
+        state.maybeCurrentContextNode = NodeIdMapUtils.assertUnboxContext(
             state.contextState.nodeIdMapCollection.contextNodeById,
             checkpoint.maybeContextNodeId,
         );

--- a/src/powerquery-parser/parser/parsers/naive.ts
+++ b/src/powerquery-parser/parser/parsers/naive.ts
@@ -1504,15 +1504,15 @@ function tryReadPrimaryType(state: ParseState, parser: Parser): TriedReadPrimary
         ParseStateUtils.isNextTokenKind(state, Token.TokenKind.LeftParenthesis);
 
     if (ParseStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBracket)) {
-        return ResultUtils.createOk(parser.readRecordType(state, parser));
+        return ResultUtils.boxOk(parser.readRecordType(state, parser));
     } else if (ParseStateUtils.isOnTokenKind(state, Token.TokenKind.LeftBrace)) {
-        return ResultUtils.createOk(parser.readListType(state, parser));
+        return ResultUtils.boxOk(parser.readListType(state, parser));
     } else if (isTableTypeNext) {
-        return ResultUtils.createOk(parser.readTableType(state, parser));
+        return ResultUtils.boxOk(parser.readTableType(state, parser));
     } else if (isFunctionTypeNext) {
-        return ResultUtils.createOk(parser.readFunctionType(state, parser));
+        return ResultUtils.boxOk(parser.readFunctionType(state, parser));
     } else if (ParseStateUtils.isOnConstantKind(state, Constant.LanguageConstantKind.Nullable)) {
-        return ResultUtils.createOk(parser.readNullableType(state, parser));
+        return ResultUtils.boxOk(parser.readNullableType(state, parser));
     } else {
         const checkpoint: ParseStateCheckpoint = parser.createCheckpoint(state);
         const triedReadPrimitiveType: TriedReadPrimaryType = tryReadPrimitiveType(state, parser);
@@ -1720,7 +1720,7 @@ function tryReadPrimitiveType(state: ParseState, parser: Parser): TriedReadPrimi
     );
     if (maybeErr) {
         const error: ParseError.ExpectedAnyTokenKindError = maybeErr;
-        return ResultUtils.createError(error);
+        return ResultUtils.boxError(error);
     }
 
     let primitiveTypeKind: Constant.PrimitiveTypeConstantKind;
@@ -1752,7 +1752,7 @@ function tryReadPrimitiveType(state: ParseState, parser: Parser): TriedReadPrimi
             default:
                 const token: Token.Token = ParseStateUtils.assertGetTokenAt(state, state.tokenIndex);
                 parser.restoreCheckpoint(state, checkpoint);
-                return ResultUtils.createError(
+                return ResultUtils.boxError(
                     new ParseError.InvalidPrimitiveTypeError(
                         state.locale,
                         token,
@@ -1769,7 +1769,7 @@ function tryReadPrimitiveType(state: ParseState, parser: Parser): TriedReadPrimi
     } else {
         const details: {} = { tokenKind: state.maybeCurrentTokenKind };
         parser.restoreCheckpoint(state, checkpoint);
-        return ResultUtils.createError(
+        return ResultUtils.boxError(
             new CommonError.InvariantError(`unknown currentTokenKind, not found in [${expectedTokenKinds}]`, details),
         );
     }
@@ -1781,7 +1781,7 @@ function tryReadPrimitiveType(state: ParseState, parser: Parser): TriedReadPrimi
         primitiveTypeKind,
     };
     ParseStateUtils.endContext(state, astNode);
-    return ResultUtils.createOk(astNode);
+    return ResultUtils.boxOk(astNode);
 }
 
 // -------------------------------------

--- a/src/test/libraryTest/parser/idUtils.ts
+++ b/src/test/libraryTest/parser/idUtils.ts
@@ -54,10 +54,10 @@ function expectLinksMatch(triedLexParse: Task.TriedLexParseTask, expected: Abrid
 
     if (TaskUtils.isParseStageOk(triedLexParse)) {
         nodeIdMapCollection = triedLexParse.nodeIdMapCollection;
-        xorNode = XorNodeUtils.createAstNode(triedLexParse.ast);
+        xorNode = XorNodeUtils.boxAst(triedLexParse.ast);
     } else if (TaskUtils.isParseStageParseError(triedLexParse)) {
         nodeIdMapCollection = triedLexParse.nodeIdMapCollection;
-        xorNode = XorNodeUtils.createContextNode(Assert.asDefined(triedLexParse.error.state.contextState.maybeRoot));
+        xorNode = XorNodeUtils.boxContext(Assert.asDefined(triedLexParse.error.state.contextState.maybeRoot));
     } else {
         throw new Error(`expected TriedLexParse to be Ok`);
     }

--- a/src/test/libraryTest/parser/nodeIdMapUtils.ts
+++ b/src/test/libraryTest/parser/nodeIdMapUtils.ts
@@ -64,10 +64,10 @@ describe("nodeIdMapIterator", () => {
             expect(parameters.length).to.equal(2);
 
             const firstParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.assertUnwrapAst(parameters[0]),
+                XorNodeUtils.asserUnboxAst(parameters[0]),
             );
             const secondParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.assertUnwrapAst(parameters[1]),
+                XorNodeUtils.asserUnboxAst(parameters[1]),
             );
 
             expect(firstParameter.name.literal).to.equal("x");
@@ -96,10 +96,10 @@ describe("nodeIdMapIterator", () => {
             expect(parameters.length).to.equal(2);
 
             const firstParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.assertUnwrapAst(parameters[0]),
+                XorNodeUtils.asserUnboxAst(parameters[0]),
             );
             const secondParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.assertUnwrapAst(parameters[1]),
+                XorNodeUtils.asserUnboxAst(parameters[1]),
             );
 
             expect(firstParameter.name.literal).to.equal("x");


### PR DESCRIPTION
Naming things is hard.

There's a collection of Ast nodes named `TWrapped` which is a node that has constants wrapped around it, such as a `RecordExpression` or `ListExpression`. The XorNode interface is a boxed value, and some helper functions attempt to unbox the value. These followed the naming pattern of `unwrap$NodeKind`.

The naming problem happened when I created an unboxing function for `XorNode<Ast.TWrapped>`, which when following the naming conventions was named `unwrapWrappedContent` which was confusing. I've renamed it to `unboxWrappedContent`. If you can think of a better naming convention let me know.