### PR TITLE
Fix XorNodeUtils regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.4.14",
+    "version": "0.4.15",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -215,11 +215,16 @@ export function maybeUnboxWrappedContentChecked<C extends Ast.TWrapped["content"
     return maybeXorNode && XorNodeUtils.isNodeKind(maybeXorNode, expectedNodeKinds) ? maybeXorNode : undefined;
 }
 
+export function maybeUnboxWrappedContentIfAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode | undefined {
+    const maybeXorNode: TXorNode | undefined = maybeUnboxWrappedContent(nodeIdMapCollection, nodeId);
+    return maybeXorNode && XorNodeUtils.isAstXor(maybeXorNode) ? maybeXorNode.node : undefined;
+}
+
 export function maybeUnboxWrappedContentIfAstChecked<C extends Ast.TWrapped["content"]>(
     nodeIdMapCollection: Collection,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<C["kind"]> | C["kind"],
 ): C | undefined {
-    const maybeAstNode: Ast.TNode | undefined = maybeUnboxIfAst(nodeIdMapCollection, nodeId);
+    const maybeAstNode: Ast.TNode | undefined = maybeUnboxWrappedContentIfAst(nodeIdMapCollection, nodeId);
     return maybeAstNode && AstUtils.isNodeKind<C>(maybeAstNode, expectedNodeKinds) ? maybeAstNode : undefined;
 }


### PR DESCRIPTION
There was a regression in #274 that was uncaught until I started doing integration testing with the new parser. Honestly this comes from me being lazy. I only confirmed the new parser would allow a build without errors, but didn't validate unit tests as it takes several npm links to do so.

This brings up a good question. I'm trying to think of how I could write a script to make integration testing easier. @KieranBrantnerMagee this might be a good task for our internal issue tracking.