### PR TITLE
Spelling fix (asser -> assert)

### DIFF
--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
@@ -9,7 +9,7 @@ import { TXorNode, XorNodeKind } from "../xorNode";
 import { maybeXor } from "./commonSelectors";
 
 export function assertUnboxLeftMostLeaf(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode {
-    return XorNodeUtils.asserUnboxAst(
+    return XorNodeUtils.assertUnboxAst(
         Assert.asDefined(
             maybeLeftMostXor(nodeIdMapCollection, nodeId),
             `nodeId does not exist in nodeIdMapCollection`,

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -166,7 +166,7 @@ export function assertIsParameter(xorNode: TXorNode): asserts xorNode is XorNode
     assertIsNodeKind(xorNode, Ast.NodeKind.Parameter);
 }
 
-export function asserUnboxAst(xorNode: TXorNode): Ast.TNode {
+export function assertUnboxAst(xorNode: TXorNode): Ast.TNode {
     assertIsAstXor(xorNode);
     return xorNode.node;
 }
@@ -175,7 +175,7 @@ export function assertUnboxAstChecked<T extends Ast.TNode>(
     xorNode: TXorNode,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): T {
-    const astNode: Ast.TNode = asserUnboxAst(xorNode);
+    const astNode: Ast.TNode = assertUnboxAst(xorNode);
     AstUtils.assertIsNodeKind(astNode, expectedNodeKinds);
     return astNode;
 }

--- a/src/test/libraryTest/parser/nodeIdMapUtils.ts
+++ b/src/test/libraryTest/parser/nodeIdMapUtils.ts
@@ -65,10 +65,10 @@ describe("nodeIdMapIterator", () => {
             expect(parameters.length).to.equal(2);
 
             const firstParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.asserUnboxAst(parameters[0]),
+                XorNodeUtils.assertUnboxAst(parameters[0]),
             );
             const secondParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.asserUnboxAst(parameters[1]),
+                XorNodeUtils.assertUnboxAst(parameters[1]),
             );
 
             expect(firstParameter.name.literal).to.equal("x");
@@ -97,10 +97,10 @@ describe("nodeIdMapIterator", () => {
             expect(parameters.length).to.equal(2);
 
             const firstParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.asserUnboxAst(parameters[0]),
+                XorNodeUtils.assertUnboxAst(parameters[0]),
             );
             const secondParameter: Ast.TParameter = Language.AstUtils.assertAsParameter(
-                XorNodeUtils.asserUnboxAst(parameters[1]),
+                XorNodeUtils.assertUnboxAst(parameters[1]),
             );
 
             expect(firstParameter.name.literal).to.equal("x");


### PR DESCRIPTION
This isn't important enough to create a new version.