### PR TITLE
Add performance-now as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1502,8 +1502,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.4.20",
+    "version": "0.4.21",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",
@@ -27,7 +27,8 @@
     "main": "lib/powerquery-parser/index.js",
     "types": "lib/powerquery-parser/index.d.ts",
     "dependencies": {
-        "grapheme-splitter": "^1.0.4"
+        "grapheme-splitter": "^1.0.4",
+        "performance-now": "^2.1.0"
     },
     "devDependencies": {
         "@types/chai": "^4.3.0",


### PR DESCRIPTION
I added a call to performance.now in a public API (BenchmarkTraceManager/BenchmarkTrace) but didn't mark it as a dependency, but within the repro it passed as it was a dev dependency.