### PR TITLE
Split StringUtils into TextUtils+StringUtils

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,15 +9,7 @@
             "request": "launch",
             "name": "Debug Library Tests",
             "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-            "args": [
-                "--inspect",
-                "--colors",
-                "--timeout",
-                "999999",
-                "${workspaceFolder}/lib/test/libraryTest/**/*.js",
-                "-g",
-                "WIP"
-            ],
+            "args": ["--inspect", "--colors", "--timeout", "999999", "${workspaceFolder}/lib/test/libraryTest/**/*.js"],
             "preLaunchTask": "watch",
             "internalConsoleOptions": "openOnSessionStart"
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,15 @@
             "request": "launch",
             "name": "Debug Library Tests",
             "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-            "args": ["--inspect", "--colors", "--timeout", "999999", "${workspaceFolder}/lib/test/libraryTest/**/*.js"],
+            "args": [
+                "--inspect",
+                "--colors",
+                "--timeout",
+                "999999",
+                "${workspaceFolder}/lib/test/libraryTest/**/*.js",
+                "-g",
+                "WIP"
+            ],
             "preLaunchTask": "watch",
             "internalConsoleOptions": "openOnSessionStart"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-parser",
-  "version": "0.4.21",
+  "version": "0.5.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.4.21",
+    "version": "0.5.21",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.5.21",
+    "version": "0.5.22",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/stringUtils.ts
+++ b/src/powerquery-parser/common/stringUtils.ts
@@ -40,6 +40,14 @@ export function assertGetFormatted(template: string, args: Map<string, string>):
     return result;
 }
 
+export function ensureQuoted(text: string): string {
+    if (maybefindQuote(text, 0)) {
+        return text;
+    }
+
+    return `"${text.includes(`"`) ? text.replace(`"`, `""`) : text}"`;
+}
+
 export function columnNumberFrom(text: string, requiredCodeUnit: number): number {
     const graphemes: ReadonlyArray<string> = graphemeSplitter.splitGraphemes(text);
 

--- a/src/powerquery-parser/common/stringUtils.ts
+++ b/src/powerquery-parser/common/stringUtils.ts
@@ -132,7 +132,7 @@ export function maybefindQuote(text: string, indexStart: number): FoundQuote | u
     }
 
     // If no valid end quote was found
-    if (index > textLength) {
+    if (index >= textLength && text[textLength - 1] !== `"`) {
         return undefined;
     }
 

--- a/src/powerquery-parser/language/index.ts
+++ b/src/powerquery-parser/language/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as Comment from "./comment";
+export * as TextUtils from "./textUtils";
 import * as Token from "./token";
 
 export { Comment, Token };

--- a/src/powerquery-parser/language/textUtils.ts
+++ b/src/powerquery-parser/language/textUtils.ts
@@ -11,6 +11,16 @@ export const enum IdentifierKind {
     Regular = "Regular",
 }
 
+export function escape(text: string): string {
+    let result: string = text;
+
+    for (const [regexp, escaped] of UnescapedWhitespaceRegexp) {
+        result = result.replace(regexp, escaped);
+    }
+
+    return result;
+}
+
 export function identifierKind(text: string, allowTrailingPeriod: boolean): IdentifierKind {
     if (isRegularIdentifier(text, allowTrailingPeriod)) {
         return IdentifierKind.Regular;
@@ -150,8 +160,36 @@ export function normalizeIdentifier(text: string): string {
     }
 }
 
+export function unescape(text: string): string {
+    let result: string = text;
+
+    for (const [regexp, literal] of EscapedWhitespaceRegexp) {
+        result = result.replace(regexp, literal);
+    }
+
+    return result;
+}
+
 const enum IdentifierRegexpState {
     Start,
     RegularIdentifier,
     Done,
 }
+
+const EscapedWhitespaceRegexp: ReadonlyArray<[RegExp, string]> = [
+    [/#\(cr,lf\)/gm, "\r\n"],
+    [/#\(cr\)/gm, "\r"],
+    [/#\(lf\)/gm, "\n"],
+    [/#\(tab\)/gm, "\t"],
+    [/""/gm, '"'],
+    [/#\(#\)\(/gm, "#("],
+];
+
+const UnescapedWhitespaceRegexp: ReadonlyArray<[RegExp, string]> = [
+    [/#/gm, "#(#)"],
+    [/\r\n/gm, `#(cr,lf)`],
+    [/\r/gm, `#(cr)`],
+    [/\n/gm, `#(lf)`],
+    [/\t/gm, `#(tab)`],
+    [/"/gm, `""`],
+];

--- a/src/powerquery-parser/language/textUtils.ts
+++ b/src/powerquery-parser/language/textUtils.ts
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Assert, Pattern, StringUtils } from "../common";
+
+export const enum IdentifierKind {
+    Generalized = "Generalized",
+    Invalid = "Invalid",
+    Quote = "Quote",
+    QuoteRequired = "QuoteRequired",
+    Regular = "Regular",
+}
+
+export function identifierKind(text: string, allowTrailingPeriod: boolean): IdentifierKind {
+    if (isRegularIdentifier(text, allowTrailingPeriod)) {
+        return IdentifierKind.Regular;
+    } else if (isQuotedIdentifier(text)) {
+        return isRegularIdentifier(text.slice(2, -1), false) ? IdentifierKind.Quote : IdentifierKind.QuoteRequired;
+    } else if (isGeneralizedIdentifier(text)) {
+        return IdentifierKind.Generalized;
+    } else {
+        return IdentifierKind.Invalid;
+    }
+}
+
+export function isGeneralizedIdentifier(text: string): boolean {
+    return maybeGeneralizedIdentifierLength(text, 0) === text.length;
+}
+
+export function isRegularIdentifier(text: string, allowTrailingPeriod: boolean): boolean {
+    return maybeIdentifierLength(text, 0, allowTrailingPeriod) === text.length;
+}
+
+export function isQuotedIdentifier(text: string): boolean {
+    return maybeQuotedIdentifier(text, 0) !== undefined;
+}
+
+export function maybeIdentifierLength(text: string, index: number, allowTrailingPeriod: boolean): number | undefined {
+    const startingIndex: number = index;
+    const textLength: number = text.length;
+
+    let state: IdentifierRegexpState = IdentifierRegexpState.Start;
+    let maybeMatchLength: number | undefined;
+
+    while (state !== IdentifierRegexpState.Done) {
+        if (index === textLength) {
+            return index - startingIndex;
+        }
+
+        switch (state) {
+            case IdentifierRegexpState.Start:
+                maybeMatchLength = StringUtils.maybeRegexMatchLength(Pattern.IdentifierStartCharacter, text, index);
+
+                if (maybeMatchLength === undefined) {
+                    state = IdentifierRegexpState.Done;
+                } else {
+                    state = IdentifierRegexpState.RegularIdentifier;
+                    index += maybeMatchLength;
+                }
+
+                break;
+
+            case IdentifierRegexpState.RegularIdentifier:
+                // Don't consider `..` or `...` part of an identifier.
+                if (allowTrailingPeriod && text[index] === "." && text[index + 1] !== ".") {
+                    index += 1;
+                }
+
+                maybeMatchLength = StringUtils.maybeRegexMatchLength(Pattern.IdentifierPartCharacters, text, index);
+
+                if (maybeMatchLength === undefined) {
+                    state = IdentifierRegexpState.Done;
+                } else {
+                    index += maybeMatchLength;
+
+                    // Don't consider `..` or `...` part of an identifier.
+                    if (allowTrailingPeriod && text[index] === "." && text[index + 1] !== ".") {
+                        index += 1;
+                    }
+
+                    state = IdentifierRegexpState.Start;
+                }
+
+                break;
+
+            default:
+                throw Assert.isNever(state);
+        }
+    }
+
+    return index !== startingIndex ? index - startingIndex : undefined;
+}
+
+export function maybeGeneralizedIdentifierLength(text: string, index: number): number | undefined {
+    const startingIndex: number = index;
+    const textLength: number = text.length;
+
+    let continueMatching: boolean = true;
+
+    while (continueMatching === true) {
+        const currentChr: string = text[index];
+
+        if (currentChr === " ") {
+            index += 1;
+        } else if (currentChr === ".") {
+            if (text[index - 1] === ".") {
+                continueMatching = false;
+                break;
+            }
+
+            index += 1;
+        } else {
+            const maybeMatchLength: number | undefined = StringUtils.maybeRegexMatchLength(
+                Pattern.IdentifierPartCharacters,
+                text,
+                index,
+            );
+
+            if (maybeMatchLength === undefined) {
+                continueMatching = false;
+                break;
+            }
+
+            index += maybeMatchLength;
+        }
+
+        if (index >= textLength) {
+            continueMatching = false;
+        }
+    }
+
+    return index !== startingIndex ? index - startingIndex : undefined;
+}
+
+export function maybeQuotedIdentifier(text: string, index: number): StringUtils.FoundQuote | undefined {
+    if (text[index] !== "#") {
+        return undefined;
+    }
+
+    return StringUtils.maybefindQuote(text, index + 1);
+}
+
+export function normalizeIdentifier(text: string): string {
+    if (isQuotedIdentifier(text)) {
+        const stripped: string = text.slice(2, -1);
+
+        return isRegularIdentifier(stripped, false) ? stripped : text;
+    } else {
+        return text;
+    }
+}
+
+const enum IdentifierRegexpState {
+    Start,
+    RegularIdentifier,
+    Done,
+}

--- a/src/powerquery-parser/lexer/lexer.ts
+++ b/src/powerquery-parser/lexer/lexer.ts
@@ -14,7 +14,7 @@ import {
     ResultUtils,
     StringUtils,
 } from "../common";
-import { Keyword, Token } from "../language";
+import { Keyword, TextUtils, Token } from "../language";
 import { LexError } from ".";
 import { LexSettings } from "../settings";
 
@@ -1147,7 +1147,7 @@ function maybeIndexOfRegexEnd(pattern: RegExp, text: string, positionStart: numb
 }
 
 function maybeIndexOfIdentifierEnd(text: string, positionStart: number): number | undefined {
-    const maybeLength: number | undefined = StringUtils.maybeIdentifierLength(text, positionStart, true);
+    const maybeLength: number | undefined = TextUtils.maybeIdentifierLength(text, positionStart, true);
 
     return maybeLength !== undefined ? positionStart + maybeLength : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Assert, MapUtils, StringUtils } from "../../common";
+import { Assert, MapUtils } from "../../common";
+import { Ast, TextUtils } from "../../language";
 import { NodeIdMap, NodeIdMapUtils, TXorNode, XorNodeKind, XorNodeUtils } from ".";
-import { Ast } from "../../language";
 import { maybeParameterName } from "./nodeIdMapUtils";
 import { XorNode } from "./xorNode";
 
@@ -367,7 +367,7 @@ export function iterSection(
                 source: XorNodeUtils.boxAst(namePairedExpression),
                 key: namePairedExpression.key,
                 keyLiteral,
-                normalizedKeyLiteral: StringUtils.normalizeIdentifier(keyLiteral),
+                normalizedKeyLiteral: TextUtils.normalizeIdentifier(keyLiteral),
                 maybeValue: XorNodeUtils.boxAst(namePairedExpression.value),
                 pairKind: PairKind.SectionMember,
             };
@@ -424,7 +424,7 @@ export function iterSection(
             source: keyValuePair,
             key,
             keyLiteral,
-            normalizedKeyLiteral: StringUtils.normalizeIdentifier(keyLiteral),
+            normalizedKeyLiteral: TextUtils.normalizeIdentifier(keyLiteral),
             maybeValue: NodeIdMapUtils.maybeNthChild(nodeIdMapCollection, keyValuePairNodeId, 2),
             pairKind: PairKind.SectionMember,
         });
@@ -457,7 +457,7 @@ function iterKeyValuePairs<
             source: keyValuePair,
             key: maybeKey,
             keyLiteral,
-            normalizedKeyLiteral: StringUtils.normalizeIdentifier(keyLiteral),
+            normalizedKeyLiteral: TextUtils.normalizeIdentifier(keyLiteral),
             maybeValue: NodeIdMapUtils.maybeNthChild(nodeIdMapCollection, keyValuePair.node.id, 2),
             pairKind,
         } as KVP);

--- a/src/powerquery-parser/parser/parsers/naive.ts
+++ b/src/powerquery-parser/parser/parsers/naive.ts
@@ -1,17 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-    ArrayUtils,
-    Assert,
-    CommonError,
-    MapUtils,
-    Result,
-    ResultUtils,
-    StringUtils,
-    TypeScriptUtils,
-} from "../../common";
-import { Ast, AstUtils, Constant, ConstantUtils, Token } from "../../language";
+import { ArrayUtils, Assert, CommonError, MapUtils, Result, ResultUtils, TypeScriptUtils } from "../../common";
+import { Ast, AstUtils, Constant, ConstantUtils, TextUtils, Token } from "../../language";
 import { Disambiguation, DisambiguationUtils } from "../disambiguation";
 import { NodeIdMap, ParseContext, ParseContextUtils, ParseError } from "..";
 import { Parser, ParseStateCheckpoint } from "../parser";
@@ -119,9 +110,9 @@ export function readGeneralizedIdentifier(state: ParseState, _parser: Parser): A
     const contiguousIdentifierStartIndex: number = tokens[tokenRangeStartIndex].positionStart.codeUnit;
     const contiguousIdentifierEndIndex: number = tokens[tokenRangeEndIndex - 1].positionEnd.codeUnit;
     const literal: string = lexerSnapshot.text.slice(contiguousIdentifierStartIndex, contiguousIdentifierEndIndex);
-    const literalKind: StringUtils.IdentifierKind = StringUtils.identifierKind(literal, true);
+    const literalKind: TextUtils.IdentifierKind = TextUtils.identifierKind(literal, true);
 
-    if (literalKind === StringUtils.IdentifierKind.Invalid) {
+    if (literalKind === TextUtils.IdentifierKind.Invalid) {
         trace.exit({
             [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
             [TraceConstant.IsThrowing]: true,

--- a/src/test/libraryTest/common/stringUtils.ts
+++ b/src/test/libraryTest/common/stringUtils.ts
@@ -65,7 +65,7 @@ describe("StringUtils", () => {
             const expected: StringUtils.FoundQuote = {
                 indexStart: 1,
                 indexEnd: 3,
-                quoteLength: 3,
+                quoteLength: 2,
             };
 
             expect(actual).to.deep.equal(expected);

--- a/src/test/libraryTest/common/stringUtils.ts
+++ b/src/test/libraryTest/common/stringUtils.ts
@@ -7,43 +7,80 @@ import { expect } from "chai";
 import { StringUtils } from "../../..";
 
 describe("StringUtils", () => {
-    describe(`isRegularIdentifier`, () => {
-        describe(`valid`, () => {
-            it(`foo`, () => expect(StringUtils.isRegularIdentifier("foo", false), "should be true").to.be.true);
-            it(`foo`, () => expect(StringUtils.isRegularIdentifier("foo", true), "should be true").to.be.true);
-            it(`foo.`, () => expect(StringUtils.isRegularIdentifier("foo.", true), "should be true").to.be.true);
+    describe(`maybeFindQuote`, () => {
+        it(`""`, () => {
+            const actual: StringUtils.FoundQuote | undefined = StringUtils.maybefindQuote(`""`, 0);
+
+            const expected: StringUtils.FoundQuote = {
+                indexStart: 0,
+                indexEnd: 2,
+                quoteLength: 2,
+            };
+
+            expect(actual).to.deep.equal(expected);
         });
 
-        describe(`invalid`, () => {
-            it(`foo.`, () => expect(StringUtils.isRegularIdentifier("foo.", false), "should be false").to.be.false);
-        });
-    });
+        it(`""""`, () => {
+            const actual: StringUtils.FoundQuote | undefined = StringUtils.maybefindQuote(`""""`, 0);
 
-    describe(`isGeneralizedIdentifier`, () => {
-        describe(`valid`, () => {
-            it("a", () => expect(StringUtils.isGeneralizedIdentifier("a"), "should be true").to.be.true);
-            it("a.1", () => expect(StringUtils.isGeneralizedIdentifier("a.1"), "should be true").to.be.true);
-            it("a b", () => expect(StringUtils.isGeneralizedIdentifier("a b"), "should be true").to.be.true);
-        });
+            const expected: StringUtils.FoundQuote = {
+                indexStart: 0,
+                indexEnd: 4,
+                quoteLength: 4,
+            };
 
-        describe(`invalid`, () => {
-            it("a..1", () => expect(StringUtils.isGeneralizedIdentifier("a..1"), "should be false").to.be.false);
-        });
-    });
-
-    describe(`isQuotedIdentifier`, () => {
-        describe(`valid`, () => {
-            it(`#"foo"`, () => expect(StringUtils.isQuotedIdentifier(`#"foo"`), "should be true").to.be.true);
-            it(`#""`, () => expect(StringUtils.isQuotedIdentifier(`#""`), "should be true").to.be.true);
-            it(`#""""`, () => expect(StringUtils.isQuotedIdentifier(`#""""`), "should be true").to.be.true);
-            it(`#"a""b""c"`, () => expect(StringUtils.isQuotedIdentifier(`#"a""b""c"`), "should be true").to.be.true);
-            it(`#"""b""c"`, () => expect(StringUtils.isQuotedIdentifier(`#"""b""c"`), "should be true").to.be.true);
-            it(`#"a""b"""`, () => expect(StringUtils.isQuotedIdentifier(`#"a""b"""`), "should be true").to.be.true);
+            expect(actual).to.deep.equal(expected);
         });
 
-        describe(`invalid`, () => {
-            it(`#"`, () => expect(StringUtils.isGeneralizedIdentifier(`#"`), "should be false").to.be.false);
-            it(`""`, () => expect(StringUtils.isGeneralizedIdentifier(`""`), "should be false").to.be.false);
+        it(`"""a"""`, () => {
+            const actual: StringUtils.FoundQuote | undefined = StringUtils.maybefindQuote(`"""a"""`, 0);
+
+            const expected: StringUtils.FoundQuote = {
+                indexStart: 0,
+                indexEnd: 7,
+                quoteLength: 7,
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`"""abc"""`, () => {
+            const actual: StringUtils.FoundQuote | undefined = StringUtils.maybefindQuote(`"""abc"""`, 0);
+
+            const expected: StringUtils.FoundQuote = {
+                indexStart: 0,
+                indexEnd: 9,
+                quoteLength: 9,
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`"`, () => expect(StringUtils.maybefindQuote(`"`, 0)).to.be.undefined);
+        it(`"abc`, () => expect(StringUtils.maybefindQuote(`"abc`, 0)).to.be.undefined);
+
+        it(`_""`, () => {
+            const actual: StringUtils.FoundQuote | undefined = StringUtils.maybefindQuote(`_""`, 1);
+
+            const expected: StringUtils.FoundQuote = {
+                indexStart: 1,
+                indexEnd: 3,
+                quoteLength: 3,
+            };
+
+            expect(actual).to.deep.equal(expected);
+        });
+
+        it(`_"a"`, () => {
+            const actual: StringUtils.FoundQuote | undefined = StringUtils.maybefindQuote(`_"a"`, 1);
+
+            const expected: StringUtils.FoundQuote = {
+                indexStart: 1,
+                indexEnd: 4,
+                quoteLength: 3,
+            };
+
+            expect(actual).to.deep.equal(expected);
         });
     });
 

--- a/src/test/libraryTest/common/stringUtils.ts
+++ b/src/test/libraryTest/common/stringUtils.ts
@@ -7,6 +7,14 @@ import { expect } from "chai";
 import { StringUtils } from "../../..";
 
 describe("StringUtils", () => {
+    describe(`ensureQuoted`, () => {
+        it(``, () => expect(StringUtils.ensureQuoted(``)).to.equal(`""`));
+        it(`a`, () => expect(StringUtils.ensureQuoted(`a`)).to.equal(`"a"`));
+        it(`"`, () => expect(StringUtils.ensureQuoted(`"`)).to.equal(`""""`));
+        it(`""`, () => expect(StringUtils.ensureQuoted(`""`)).to.equal(`""`));
+        it(`"a"`, () => expect(StringUtils.ensureQuoted(`"a"`)).to.equal(`"a"`));
+    });
+
     describe(`maybeFindQuote`, () => {
         it(`""`, () => {
             const actual: StringUtils.FoundQuote | undefined = StringUtils.maybefindQuote(`""`, 0);

--- a/src/test/libraryTest/textUtils.ts
+++ b/src/test/libraryTest/textUtils.ts
@@ -38,7 +38,7 @@ describe("TextUtils", () => {
             it(`#""""`, () => expect(TextUtils.isQuotedIdentifier(`#""""`), "should be true").to.be.true);
             it(`#"a""b""c"`, () => expect(TextUtils.isQuotedIdentifier(`#"a""b""c"`), "should be true").to.be.true);
             it(`#"""b""c"`, () => expect(TextUtils.isQuotedIdentifier(`#"""b""c"`), "should be true").to.be.true);
-            it(`WIP #"a""b"""`, () => expect(TextUtils.isQuotedIdentifier(`#"a""b"""`), "should be true").to.be.true);
+            it(`#"a""b"""`, () => expect(TextUtils.isQuotedIdentifier(`#"a""b"""`), "should be true").to.be.true);
         });
 
         describe(`invalid`, () => {

--- a/src/test/libraryTest/textUtils.ts
+++ b/src/test/libraryTest/textUtils.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { expect } from "chai";
+
+import { TextUtils } from "../../powerquery-parser/language";
+
+describe("TextUtils", () => {
+    describe(`isRegularIdentifier`, () => {
+        describe(`valid`, () => {
+            it(`foo`, () => expect(TextUtils.isRegularIdentifier("foo", false), "should be true").to.be.true);
+            it(`foo`, () => expect(TextUtils.isRegularIdentifier("foo", true), "should be true").to.be.true);
+            it(`foo.`, () => expect(TextUtils.isRegularIdentifier("foo.", true), "should be true").to.be.true);
+        });
+
+        describe(`invalid`, () => {
+            it(`foo.`, () => expect(TextUtils.isRegularIdentifier("foo.", false), "should be false").to.be.false);
+        });
+    });
+
+    describe(`isGeneralizedIdentifier`, () => {
+        describe(`valid`, () => {
+            it("a", () => expect(TextUtils.isGeneralizedIdentifier("a"), "should be true").to.be.true);
+            it("a.1", () => expect(TextUtils.isGeneralizedIdentifier("a.1"), "should be true").to.be.true);
+            it("a b", () => expect(TextUtils.isGeneralizedIdentifier("a b"), "should be true").to.be.true);
+        });
+
+        describe(`invalid`, () => {
+            it("a..1", () => expect(TextUtils.isGeneralizedIdentifier("a..1"), "should be false").to.be.false);
+        });
+    });
+
+    describe(`isQuotedIdentifier`, () => {
+        describe(`valid`, () => {
+            it(`#"foo"`, () => expect(TextUtils.isQuotedIdentifier(`#"foo"`), "should be true").to.be.true);
+            it(`#""`, () => expect(TextUtils.isQuotedIdentifier(`#""`), "should be true").to.be.true);
+            it(`#""""`, () => expect(TextUtils.isQuotedIdentifier(`#""""`), "should be true").to.be.true);
+            it(`#"a""b""c"`, () => expect(TextUtils.isQuotedIdentifier(`#"a""b""c"`), "should be true").to.be.true);
+            it(`#"""b""c"`, () => expect(TextUtils.isQuotedIdentifier(`#"""b""c"`), "should be true").to.be.true);
+            it(`WIP #"a""b"""`, () => expect(TextUtils.isQuotedIdentifier(`#"a""b"""`), "should be true").to.be.true);
+        });
+
+        describe(`invalid`, () => {
+            it(`#"`, () => expect(TextUtils.isGeneralizedIdentifier(`#"`), "should be false").to.be.false);
+            it(`""`, () => expect(TextUtils.isGeneralizedIdentifier(`""`), "should be false").to.be.false);
+        });
+    });
+});

--- a/src/test/libraryTest/textUtils.ts
+++ b/src/test/libraryTest/textUtils.ts
@@ -7,6 +7,14 @@ import { expect } from "chai";
 import { TextUtils } from "../../powerquery-parser/language";
 
 describe("TextUtils", () => {
+    it(`escape`, () => {
+        const unescaped: string = 'Encode \t\t and \r\n and "quotes" but not this #(tab)';
+        const escaped: string = 'Encode #(tab)#(tab) and #(cr,lf) and ""quotes"" but not this #(#)(tab)';
+
+        expect(TextUtils.escape(unescaped)).to.equal(escaped);
+        expect(TextUtils.unescape(escaped)).to.equal(unescaped);
+    });
+
     describe(`isRegularIdentifier`, () => {
         describe(`valid`, () => {
             it(`foo`, () => expect(TextUtils.isRegularIdentifier("foo", false), "should be true").to.be.true);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,23 @@
 {
     "compilerOptions": {
-        "target": "es5",
-        "module": "commonjs",
-        "sourceMap": true,
-        "outDir": "lib",
-        "strict": true,
+        "declaration": true,
         "downlevelIteration": true,
-        "noFallthroughCasesInSwitch": true,
+        "incremental": true,
+        "module": "commonjs",
         "noEmitOnError": true,
+        "noFallthroughCasesInSwitch": true,
         "noImplicitOverride": true,
         "noImplicitReturns": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
-        "declaration": true,
+        "outDir": "lib",
+        "resolveJsonModule": true,
         "rootDir": "src",
-        "incremental": true,
-        "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
-        "resolveJsonModule": true
+        "sourceMap": true,
+        "strict": true,
+        "target": "es5",
+        "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
     },
-    "include": ["src/**/*.ts", "src/powerquery-parser/localization/templates/*.json"],
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules"],
+    "include": ["src/**/*.ts", "src/powerquery-parser/localization/templates/*.json"]
 }


### PR DESCRIPTION
Strings which operate on the Power Query layer are now in `Lanaguage.TextUtils` (eg. `IsQuotedIdentifier`).
String which operate on JavaScript layer are now in `Common.TextUtils` (eg. `maybeNormalizeNumber`).

I'm lazy so I'm not splitting out ensureQuoted, isQuoted, maybeFindQuote additions into its own PR.