### PR TITLE
Add IdentifierContextKind metadata to Identifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.6.6",
+    "version": "0.6.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.6.6",
+            "version": "0.6.7",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.6.6",
+    "version": "0.6.7",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/language/ast/ast.ts
+++ b/src/powerquery-parser/language/ast/ast.ts
@@ -854,4 +854,12 @@ export interface Identifier extends INode {
     readonly kind: NodeKind.Identifier;
     readonly isLeaf: true;
     readonly literal: string;
+    readonly identifierContextKind: IdentifierContextKind;
+}
+
+export const enum IdentifierContextKind {
+    Key = "Key",
+    Keyword = "Keyword",
+    Parameter = "Parameter",
+    Value = "Value",
 }

--- a/src/powerquery-parser/parser/parser/parser.ts
+++ b/src/powerquery-parser/parser/parser/parser.ts
@@ -90,11 +90,7 @@ export interface Parser {
     readonly readLiteralExpression: (state: ParseState, parser: Parser) => Ast.LiteralExpression;
 
     // 12.2.3.12 Identifier expression
-    readonly readIdentifierExpression: (
-        state: ParseState,
-        parser: Parser,
-        identifierContextKind: Ast.IdentifierContextKind,
-    ) => Ast.IdentifierExpression;
+    readonly readIdentifierExpression: (state: ParseState, parser: Parser) => Ast.IdentifierExpression;
 
     // 12.2.3.14 Parenthesized expression
     readonly readParenthesizedExpression: (state: ParseState, parser: Parser) => Promise<Ast.ParenthesizedExpression>;

--- a/src/powerquery-parser/parser/parser/parser.ts
+++ b/src/powerquery-parser/parser/parser/parser.ts
@@ -33,7 +33,11 @@ export interface Parser {
     readonly restoreCheckpoint: (state: ParseState, checkpoint: ParseStateCheckpoint) => Promise<void>;
 
     // 12.1.6 Identifiers
-    readonly readIdentifier: (state: ParseState, parser: Parser) => Ast.Identifier;
+    readonly readIdentifier: (
+        state: ParseState,
+        parser: Parser,
+        identifierContextKind: Ast.IdentifierContextKind,
+    ) => Ast.Identifier;
     readonly readGeneralizedIdentifier: (state: ParseState, parser: Parser) => Promise<Ast.GeneralizedIdentifier>;
     readonly readKeyword: (state: ParseState, parser: Parser) => Ast.IdentifierExpression;
 
@@ -86,7 +90,11 @@ export interface Parser {
     readonly readLiteralExpression: (state: ParseState, parser: Parser) => Ast.LiteralExpression;
 
     // 12.2.3.12 Identifier expression
-    readonly readIdentifierExpression: (state: ParseState, parser: Parser) => Ast.IdentifierExpression;
+    readonly readIdentifierExpression: (
+        state: ParseState,
+        parser: Parser,
+        identifierContextKind: Ast.IdentifierContextKind,
+    ) => Ast.IdentifierExpression;
 
     // 12.2.3.14 Parenthesized expression
     readonly readParenthesizedExpression: (state: ParseState, parser: Parser) => Promise<Ast.ParenthesizedExpression>;

--- a/src/powerquery-parser/parser/parsers/naive.ts
+++ b/src/powerquery-parser/parser/parsers/naive.ts
@@ -824,7 +824,7 @@ export async function readPrimaryExpression(state: ParseState, parser: Parser): 
         maybeCurrentTokenKind === Token.TokenKind.AtSign || maybeCurrentTokenKind === Token.TokenKind.Identifier;
 
     if (isIdentifierExpressionNext) {
-        primaryExpression = parser.readIdentifierExpression(state, parser, Ast.IdentifierContextKind.Value);
+        primaryExpression = parser.readIdentifierExpression(state, parser);
     } else {
         switch (maybeCurrentTokenKind) {
             case Token.TokenKind.LeftParenthesis:

--- a/src/powerquery-parser/parser/parsers/naive.ts
+++ b/src/powerquery-parser/parser/parsers/naive.ts
@@ -48,7 +48,11 @@ const GeneralizedIdentifierTerminatorTokenKinds: ReadonlyArray<Token.TokenKind> 
 // ---------- 12.1.6 Identifiers ----------
 // ----------------------------------------
 
-export function readIdentifier(state: ParseState, _parser: Parser): Ast.Identifier {
+export function readIdentifier(
+    state: ParseState,
+    _parser: Parser,
+    identifierContextKind: Ast.IdentifierContextKind,
+): Ast.Identifier {
     const nodeKind: Ast.NodeKind.Identifier = Ast.NodeKind.Identifier;
 
     const trace: Trace = state.traceManager.entry(NaiveTraceConstant.Parse, readIdentifier.name, {
@@ -63,6 +67,7 @@ export function readIdentifier(state: ParseState, _parser: Parser): Ast.Identifi
         ...ParseStateUtils.assertGetContextNodeMetadata(state),
         kind: nodeKind,
         isLeaf: true,
+        identifierContextKind,
         literal,
     };
 
@@ -166,6 +171,7 @@ export function readKeyword(state: ParseState, _parser: Parser): Ast.IdentifierE
         ...ParseStateUtils.assertGetContextNodeMetadata(state),
         kind: identifierNodeKind,
         isLeaf: true,
+        identifierContextKind: Ast.IdentifierContextKind.Keyword,
         literal,
     };
 
@@ -281,7 +287,7 @@ export async function readSectionDocument(state: ParseState, parser: Parser): Pr
     let maybeName: Ast.Identifier | undefined;
 
     if (ParseStateUtils.isOnTokenKind(state, Token.TokenKind.Identifier)) {
-        maybeName = parser.readIdentifier(state, parser);
+        maybeName = parser.readIdentifier(state, parser, Ast.IdentifierContextKind.Key);
     } else {
         ParseStateUtils.incrementAttributeCounter(state);
     }
@@ -818,7 +824,7 @@ export async function readPrimaryExpression(state: ParseState, parser: Parser): 
         maybeCurrentTokenKind === Token.TokenKind.AtSign || maybeCurrentTokenKind === Token.TokenKind.Identifier;
 
     if (isIdentifierExpressionNext) {
-        primaryExpression = parser.readIdentifierExpression(state, parser);
+        primaryExpression = parser.readIdentifierExpression(state, parser, Ast.IdentifierContextKind.Value);
     } else {
         switch (maybeCurrentTokenKind) {
             case Token.TokenKind.LeftParenthesis:
@@ -1071,7 +1077,7 @@ export function readIdentifierExpression(state: ParseState, parser: Parser): Ast
     const maybeInclusiveConstant: Ast.IConstant<Constant.MiscConstant.AtSign> | undefined =
         maybeReadTokenKindAsConstant(state, Token.TokenKind.AtSign, Constant.MiscConstant.AtSign);
 
-    const identifier: Ast.Identifier = parser.readIdentifier(state, parser);
+    const identifier: Ast.Identifier = parser.readIdentifier(state, parser, Ast.IdentifierContextKind.Value);
 
     const identifierExpression: Ast.IdentifierExpression = {
         ...ParseStateUtils.assertGetContextNodeMetadata(state),
@@ -2605,7 +2611,7 @@ export async function readIdentifierPairedExpression(
         state,
         Ast.NodeKind.IdentifierPairedExpression,
         // eslint-disable-next-line require-await
-        async () => parser.readIdentifier(state, parser),
+        async () => parser.readIdentifier(state, parser, Ast.IdentifierContextKind.Key),
         async () => await parser.readExpression(state, parser),
     );
 
@@ -2995,7 +3001,7 @@ async function genericReadParameterList<T extends Ast.TParameterType>(
         }
 
         // eslint-disable-next-line no-await-in-loop
-        const name: Ast.Identifier = parser.readIdentifier(state, parser);
+        const name: Ast.Identifier = parser.readIdentifier(state, parser, Ast.IdentifierContextKind.Parameter);
         // eslint-disable-next-line no-await-in-loop
         const maybeParameterType: T = await typeReader();
 

--- a/src/test/libraryTest/parser/error.ts
+++ b/src/test/libraryTest/parser/error.ts
@@ -103,7 +103,7 @@ describe("Parser.Error", () => {
                 parser: RecursiveDescentParser,
                 // eslint-disable-next-line require-await
                 maybeParserEntryPointFn: async (state: ParseState, parser: Parser): Promise<Ast.TNode> =>
-                    parser.readIdentifier(state, parser),
+                    parser.readIdentifier(state, parser, Ast.IdentifierContextKind.Value),
             };
 
             const text: string = "a b";

--- a/src/test/libraryTest/parser/identifierContextKind.ts
+++ b/src/test/libraryTest/parser/identifierContextKind.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { expect } from "chai";
+
+import { NodeIdMap, NodeIdMapUtils, ParseOk } from "../../../powerquery-parser/parser";
+import { Ast } from "../../../powerquery-parser/language";
+import { DefaultSettings } from "../../..";
+import { TestAssertUtils } from "../../testUtils";
+
+function assertGetIdentifierByLiteral(parseOk: ParseOk, identifierLiteral: string): Ast.Identifier {
+    const nodeIdMapCollection: NodeIdMap.Collection = parseOk.state.contextState.nodeIdMapCollection;
+    const matches: Ast.Identifier[] = [];
+
+    for (const identifierId of nodeIdMapCollection.idsByNodeKind.get(Ast.NodeKind.Identifier) ?? []) {
+        const identifier: Ast.Identifier = NodeIdMapUtils.assertUnboxAstChecked(
+            nodeIdMapCollection.astNodeById,
+            identifierId,
+            Ast.NodeKind.Identifier,
+        );
+
+        if (identifier.literal === identifierLiteral) {
+            matches.push(identifier);
+        }
+    }
+
+    if (matches.length === 0) {
+        throw new Error(`could not find the following identifier in the ast: ${identifierLiteral}`);
+    } else if (matches.length === 1) {
+        return matches[0];
+    } else {
+        throw new Error(`found multiple instances of the following identifier: ${identifierLiteral}`);
+    }
+}
+
+function assertIdentifierIsInContext(
+    parseOk: ParseOk,
+    identifierLiteral: string,
+    identifierContextKind: Ast.IdentifierContextKind,
+): void {
+    const identifier: Ast.Identifier = assertGetIdentifierByLiteral(parseOk, identifierLiteral);
+    expect(identifier.identifierContextKind).to.equal(identifierContextKind);
+}
+
+describe("Parser.IdentifierContextKind", () => {
+    it("let foo = 1 in bar", async () => {
+        const parseOk: ParseOk = await TestAssertUtils.assertGetParseOk(DefaultSettings, "let foo = 1 in bar");
+
+        assertIdentifierIsInContext(parseOk, "foo", Ast.IdentifierContextKind.Key);
+        assertIdentifierIsInContext(parseOk, "bar", Ast.IdentifierContextKind.Value);
+    });
+
+    it("let fn = (foo as number) => 1 in 1", async () => {
+        const parseOk: ParseOk = await TestAssertUtils.assertGetParseOk(
+            DefaultSettings,
+            "let fn = (foo as number) => 1 in 1",
+        );
+
+        assertIdentifierIsInContext(parseOk, "fn", Ast.IdentifierContextKind.Key);
+        assertIdentifierIsInContext(parseOk, "foo", Ast.IdentifierContextKind.Parameter);
+    });
+
+    it("let foo = #date in 1", async () => {
+        const parseOk: ParseOk = await TestAssertUtils.assertGetParseOk(DefaultSettings, "let foo = #date in 1");
+
+        assertIdentifierIsInContext(parseOk, "foo", Ast.IdentifierContextKind.Key);
+        assertIdentifierIsInContext(parseOk, "#date", Ast.IdentifierContextKind.Keyword);
+    });
+});


### PR DESCRIPTION
This PR adds a metadata tag to Ast.Identifier which will be consumed downstream in language-services.