### PR TITLE
Align identifier Power Query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.6.7",
+    "version": "0.6.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.6.7",
+            "version": "0.6.8",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.6.7",
+    "version": "0.6.8",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/specification.md
+++ b/specification.md
@@ -4,10 +4,11 @@ There are a few differences between the [Power Query / M Language Specification]
 
 ## Where the Power Query parser differs from the specification
 
-* An additional primitive type named `time` exists.
-* An additional primitive type named `action` exists.
-* The `field-specification` construct requires an `identifier`. Instead `identifer` is replaced with `generalized-identifier`.
-* The `type` construct matches either `parenthesized-expression` or `primary-type`. Instead `parenthesized-expression` is replaced with `primary-expression`.
-* The `table-type` construct matches on `row-type`. 
-* An additional match of `primary-expression` is added on the following tokens: `@`, `identifier`, or `left-parenthesis`.
-* The `generalized-identifier` was changed so that `identifier-start-character` was replaced with `identifier-part-character`. It also accepts quoted identifiers.
+-   An additional primitive type named `time` exists.
+-   An additional primitive type named `action` exists.
+-   The `field-specification` construct requires an `identifier`. Instead `identifer` is replaced with `generalized-identifier`.
+-   The `type` construct matches either `parenthesized-expression` or `primary-type`. Instead `parenthesized-expression` is replaced with `primary-expression`.
+-   The `table-type` construct matches on `row-type`.
+-   An additional match of `primary-expression` is added on the following tokens: `@`, `identifier`, or `left-parenthesis`.
+-   The `identifier` construct was changed so that after a period instead of matching `identifier-start-character` it now matches `identifier-part-character`.
+-   The `generalized-identifier` construct was changed so that `identifier-start-character` was replaced with `identifier-part-character`. It also accepts quoted identifiers.

--- a/src/powerquery-parser/language/textUtils.ts
+++ b/src/powerquery-parser/language/textUtils.ts
@@ -87,8 +87,6 @@ export function maybeIdentifierLength(text: string, index: number, allowTrailing
                     if (allowTrailingPeriod && text[index] === "." && text[index + 1] !== ".") {
                         index += 1;
                     }
-
-                    state = IdentifierRegexpState.Start;
                 }
 
                 break;

--- a/src/test/libraryTest/textUtils.ts
+++ b/src/test/libraryTest/textUtils.ts
@@ -20,6 +20,7 @@ describe("TextUtils", () => {
             it(`foo`, () => expect(TextUtils.isRegularIdentifier("foo", false), "should be true").to.be.true);
             it(`foo`, () => expect(TextUtils.isRegularIdentifier("foo", true), "should be true").to.be.true);
             it(`foo.`, () => expect(TextUtils.isRegularIdentifier("foo.", true), "should be true").to.be.true);
+            it(`foo.1`, () => expect(TextUtils.isRegularIdentifier("foo.1", true), "should be true").to.be.true);
 
             it(`foo.bar123`, () =>
                 expect(TextUtils.isRegularIdentifier("foo.bar123", true), "should be true").to.be.true);
@@ -50,6 +51,7 @@ describe("TextUtils", () => {
             it(`#"a""b""c"`, () => expect(TextUtils.isQuotedIdentifier(`#"a""b""c"`), "should be true").to.be.true);
             it(`#"""b""c"`, () => expect(TextUtils.isQuotedIdentifier(`#"""b""c"`), "should be true").to.be.true);
             it(`#"a""b"""`, () => expect(TextUtils.isQuotedIdentifier(`#"a""b"""`), "should be true").to.be.true);
+            it(`#"bar.1"`, () => expect(TextUtils.isQuotedIdentifier(`#"foo"`), "should be true").to.be.true);
         });
 
         describe(`invalid`, () => {


### PR DESCRIPTION
This parser currently parses identifiers as according to the spec, but there's a subtle tweak when compared to the C# parser. This aligns the behavior with C# implementation.