### PR TITLE
Promote TimeNow and CorrelationId out of the JSON blob

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/trace.ts
+++ b/src/powerquery-parser/common/trace.ts
@@ -191,9 +191,7 @@ export class BenchmarkTrace extends Trace {
     }
 
     public override trace(message: string, maybeDetails?: object): void {
-        super.trace(message, {
-            ...maybeDetails,
-        });
+        super.trace(message, maybeDetails);
     }
 }
 


### PR DESCRIPTION
My PBI report for benchmarks runs much quicker if I pull the timeNow and correlationId out of the JSON blob.