### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 442: Build ID 319938

### DIFF
--- a/src/powerquery-parser/localization/templates/template.bg-BG.json
+++ b/src/powerquery-parser/localization/templates/template.bg-BG.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Очакваше се да се открие генерализиран идентификатор, но пръв беше достигнат краят на потока",
   "error_parse_expectTokenKind_1_other": "Очакваше се да се намери {expectedTokenKind}, но вместо това се откри {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Очакваше се да се открие {expectedTokenKind}, но вместо това е достигнат краят на потока",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Клаузата \"catch\" на израза try/catch трябва да бъде последвана от дефиниция на функция с аргументи 0 или 1 и без ограничения на типа",
   "error_parse_invalidPrimitiveType": "Очакваше се да се открие примитивен литерал, но вместо това е открит {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Не може да има задължителен параметър след незадължителен параметър",
   "error_parse_unterminated_sequence_bracket": "Незатворена квадратна скоба",

--- a/src/powerquery-parser/localization/templates/template.ca-ES.json
+++ b/src/powerquery-parser/localization/templates/template.ca-ES.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "S'esperava trobar un identificador generalitzat, però s'ha arribat al final de flux.",
   "error_parse_expectTokenKind_1_other": "S'esperava trobar un valor {expectedTokenKind}, però s'ha trobat el valor {foundTokenKind}.",
   "error_parse_expectTokenKind_2_endOfStream": "S'esperava trobar el valor {expectedTokenKind}, però s'ha arribat al final de flux.",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "La clàusula \"catch\" d'una expressió try/catch ha d'anar seguida d'una definició de funció amb arguments 0 o 1 i sense restriccions de tipus",
   "error_parse_invalidPrimitiveType": "S'esperava trobar un literal primitiu, però s'ha trobat el valor {foundTokenKind}.",
   "error_parse_requiredParameterAfterOptional": "No podeu tenir un paràmetre no opcional després d'un paràmetre opcional.",
   "error_parse_unterminated_sequence_bracket": "Claudàtor sense tancar",

--- a/src/powerquery-parser/localization/templates/template.cs-CZ.json
+++ b/src/powerquery-parser/localization/templates/template.cs-CZ.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Očekávalo se, že se najde zobecněný identifikátor, ale dosáhlo se konce streamu.",
   "error_parse_expectTokenKind_1_other": "Očekávalo se, že se najde hodnota {expectedTokenKind}, ale místo ní se našlo {foundTokenKind}.",
   "error_parse_expectTokenKind_2_endOfStream": "Očekávalo se, že se najde {expectedTokenKind}, ale místo toho se dosáhlo konce streamu.",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Za klauzulí catch výrazu try/catch musí následovat definice funkce s žádným nebo jedním argumentem a bez omezení typu.",
   "error_parse_invalidPrimitiveType": "Očekávalo se, že se najde primitivní literál, ale místo něj se našlo {foundTokenKind}.",
   "error_parse_requiredParameterAfterOptional": "Za volitelným parametrem nemůže následovat povinný parametr.",
   "error_parse_unterminated_sequence_bracket": "Neukončená hranatá závorka",

--- a/src/powerquery-parser/localization/templates/template.da-DK.json
+++ b/src/powerquery-parser/localization/templates/template.da-DK.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Forventede at finde et generaliseret id, men slutningen af streamen er nået først",
   "error_parse_expectTokenKind_1_other": "Forventede at finde en {expectedTokenKind}, men der blev fundet en {foundTokenKind} i stedet for",
   "error_parse_expectTokenKind_2_endOfStream": "Forventede at finde en {expectedTokenKind}, men slutningen af streamen blev nået i stedet for",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "'catch'-parameteren i et try/catch-udtryk skal efterfølges af en funktionsdefinition med 0 eller 1 argumenter og ingen typebegrænsninger.",
   "error_parse_invalidPrimitiveType": "Forventede at finde en primitiv konstant, men der blev fundet en {foundTokenKind} i stedet for",
   "error_parse_requiredParameterAfterOptional": "Du kan ikke have en parameter, som ikke er valgfri, efter en valgfri parameter",
   "error_parse_unterminated_sequence_bracket": "Ikke-afsluttet parentes",

--- a/src/powerquery-parser/localization/templates/template.de-DE.json
+++ b/src/powerquery-parser/localization/templates/template.de-DE.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Es wurde ein generalisierter Bezeichner erwartet, aber vorher wurde das Streamende erreicht.",
   "error_parse_expectTokenKind_1_other": "Erwartet: {expectedTokenKind}, gefunden: {foundTokenKind}.",
   "error_parse_expectTokenKind_2_endOfStream": "Es wurde ein Token vom Typ \"{expectedTokenKind}\" erwartet, aber stattdessen wurde das Streamende erreicht.",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Auf die „catch“-Klausel eines „try/catch“-Ausdrucks muss eine Funktionsdefinition mit 0 oder 1 Argument und ohne Typeinschränkungen folgen.",
   "error_parse_invalidPrimitiveType": "Es wurde ein primitives Literal erwartet, stattdessen jedoch ein Token vom Typ \"{foundTokenKind}\" gefunden.",
   "error_parse_requiredParameterAfterOptional": "Nach einem optionalen Parameter darf kein nicht optionaler Parameter vorhanden sein.",
   "error_parse_unterminated_sequence_bracket": "Nicht abgeschlossene eckige Klammer.",

--- a/src/powerquery-parser/localization/templates/template.el-GR.json
+++ b/src/powerquery-parser/localization/templates/template.el-GR.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Αναμενόταν να βρεθεί ένα γενικό αναγνωριστικό, αλλά έφτασε πρώτα το τέλος της ροής",
   "error_parse_expectTokenKind_1_other": "Αναμενόταν να βρεθεί {expectedTokenKind}, αλλά βρέθηκε {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Αναμενόταν να βρεθεί {expectedTokenKind}, αλλά έφτασε το τέλος της ροής",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Ο όρος 'catch' μιας έκφρασης try/catch πρέπει να ακολουθείται από έναν ορισμό συνάρτησης με 0 ή 1 ορίσματα και χωρίς περιορισμούς τύπου.",
   "error_parse_invalidPrimitiveType": "Αναμενόταν να βρεθεί στοιχειώδης λεκτική σταθερά, αλλά βρέθηκε {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Δεν είναι δυνατή η ύπαρξη μη προαιρετικής παραμέτρου μετά από προαιρετική παράμετρο",
   "error_parse_unterminated_sequence_bracket": "Μη τερματισμένη αγκύλη",

--- a/src/powerquery-parser/localization/templates/template.es-ES.json
+++ b/src/powerquery-parser/localization/templates/template.es-ES.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Se esperaba encontrar un identificador generalizado, pero se ha alcanzado primero el fin de flujo.",
   "error_parse_expectTokenKind_1_other": "Se esperaba encontrar {expectedTokenKind}, pero se ha encontrado {foundTokenKind} en su lugar.",
   "error_parse_expectTokenKind_2_endOfStream": "Se esperaba encontrar {expectedTokenKind}, pero se ha alcanzado el fin de flujo en su lugar.",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "La cláusula “catch” de una expresión try/catch deberá ir seguida de una definición de función con 0 o 1 argumentos y sin restricciones de tipo",
   "error_parse_invalidPrimitiveType": "Se esperaba encontrar un literal primitivo, pero se ha encontrado {foundTokenKind} en su lugar.",
   "error_parse_requiredParameterAfterOptional": "No puede tener un parámetro no opcional tras un parámetro opcional.",
   "error_parse_unterminated_sequence_bracket": "Corchete sin cerrar.",

--- a/src/powerquery-parser/localization/templates/template.et-EE.json
+++ b/src/powerquery-parser/localization/templates/template.et-EE.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Eeldati, et leitakse üldistatud identifikaator, kuid esimesena jõudis kätte voo lõpp",
   "error_parse_expectTokenKind_1_other": "Eeldati, et leitakse {expectedTokenKind}, kuid selle asemel leiti {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Eeldati, et leitakse {expectedTokenKind}, kuid selle asemel jõudis kätte voo lõpp",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Try/catch avaldise „catch“ klauslile peab järgnema funktsiooni definitsioon, millel on 0 või 1 argumenti ja tüübipiirangud puuduvad",
   "error_parse_invalidPrimitiveType": "Eeldati, et leitakse lihtne literaal, kuid selle asemel leiti {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Mittevalikuline parameeter ei saa järgneda valikulisele parameetrile",
   "error_parse_unterminated_sequence_bracket": "Lõpetamata nurksulg",

--- a/src/powerquery-parser/localization/templates/template.eu-ES.json
+++ b/src/powerquery-parser/localization/templates/template.eu-ES.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Identifikatzaile orokor bat espero zen, baina korrontearen amaierara iritsi da",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} bat espero zen, baina {foundTokenKind} bat aurkitu da",
   "error_parse_expectTokenKind_2_endOfStream": "{expectedTokenKind} bat espero zen, baina korrontearen amaierara iritsi da",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "0 edo 1 argumentu duen eta mota-murriztapenik ez duen funtzio-definizio baten aurretik egon behar du \"try/catch\" adierazpeneko \"catch\" klausulak.",
   "error_parse_invalidPrimitiveType": "Jatorrizko balio literal bat espero zen, baina {foundTokenKind} bat aurkitu da",
   "error_parse_requiredParameterAfterOptional": "Ezin duzu idatzi aukerakoa ez den parametrorik aukerako parametro baten ondoren",
   "error_parse_unterminated_sequence_bracket": "Amaitu gabeko kortxetea",

--- a/src/powerquery-parser/localization/templates/template.fi-FI.json
+++ b/src/powerquery-parser/localization/templates/template.fi-FI.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Odotettiin löytyvän yleistunniste, mutta saavutettiin ensin tietovirran loppu",
   "error_parse_expectTokenKind_1_other": "Odotettiin löytyvän {expectedTokenKind}, mutta sen sijaan löytyi {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Odotettiin löytyvän {expectedTokenKind}, mutta sen sijaan saavutettiin tietovirran loppu",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Try/catch-lausekkeen catch-lauseen jälkeen on oltava funktiomääritys, jossa on 0 tai 1 argumenttia eikä tyyppirajoituksia",
   "error_parse_invalidPrimitiveType": "Odotettiin primitiiviliteraalia, mutta sen sijaan löytyi {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Valinnaisen parametrin jälkeen ei voi olla parametria, joka ei ole valinnainen",
   "error_parse_unterminated_sequence_bracket": "Päättämätön hakasulje",

--- a/src/powerquery-parser/localization/templates/template.fr-FR.json
+++ b/src/powerquery-parser/localization/templates/template.fr-FR.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Identificateur généralisé attendu, mais la fin de flux a été atteinte en premier",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} attendu, mais un {foundTokenKind} a été trouvé à la place",
   "error_parse_expectTokenKind_2_endOfStream": "{expectedTokenKind} attendue, mais la fin de flux a été atteinte à la place",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "La clause 'catch' d’une expression try/catch doit être suivie d’une définition de fonction avec 0 ou 1 arguments et aucune contrainte de type",
   "error_parse_invalidPrimitiveType": "Littéral primitif attendu, mais un {foundTokenKind} a été trouvé à la place",
   "error_parse_requiredParameterAfterOptional": "Vous ne pouvez pas avoir un paramètre non facultatif après un paramètre facultatif",
   "error_parse_unterminated_sequence_bracket": "Crochet inachevé",

--- a/src/powerquery-parser/localization/templates/template.gl-ES.json
+++ b/src/powerquery-parser/localization/templates/template.gl-ES.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Esperábase atopar un identificador xeral, pero alcanzouse antes o final do fluxo",
   "error_parse_expectTokenKind_1_other": "Esperábase atopar un {expectedTokenKind}, pero no seu lugar atopouse un {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Esperábase atopar un {expectedTokenKind}, pero no seu lugar alcanzouse o final do fluxo",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "A cláusula \"catch\" dunha expresión try/catch debe ir seguida dunha definición de función con 0 ou 1 argumentos e sen restricións de tipo",
   "error_parse_invalidPrimitiveType": "Esperábase atopar un literal primitivo, pero no seu lugar atopouse un {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Non pode ter un parámetro non opcional despois dun parámetro opcional",
   "error_parse_unterminated_sequence_bracket": "Corchete sen pechar",

--- a/src/powerquery-parser/localization/templates/template.hi-IN.json
+++ b/src/powerquery-parser/localization/templates/template.hi-IN.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "किसी सामान्यीकृत आइडेंटिफ़ायर के मिलने की अपेक्षा थी, लेकिन पहले एंड-ऑफ़-स्ट्रीम तक पहुँच गए",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} के मिलने की अपेक्षा थी, लेकिन इसके बजाय {foundTokenKind} मिला",
   "error_parse_expectTokenKind_2_endOfStream": "{expectedTokenKind} के मिलने की अपेक्षा थी, लेकिन इसके बजाय एंड-ऑफ़-स्ट्रीम तक पहुँच गए",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "आज़माएँ/कैच व्यंजक के 'कैच' क्लॉज़ के बाद 0 या 1 तर्कों के साथ फ़ंक्शन परिभाषा और प्रकार संबंधी बाधाएँ नहीं होनी चाहिए",
   "error_parse_invalidPrimitiveType": "किसी प्रारंभिक अक्षरशः के मिलने की अपेक्षा थी, लेकिन इसके बजाय एक {foundTokenKind} मिला",
   "error_parse_requiredParameterAfterOptional": "कोई वैकल्पिक पैरामीटर के बाद आपके पास कोई गैर-वैकल्पिक पैरामीटर नहीं हो सकता है",
   "error_parse_unterminated_sequence_bracket": "अनिर्धारित कोष्ठक",

--- a/src/powerquery-parser/localization/templates/template.hr-HR.json
+++ b/src/powerquery-parser/localization/templates/template.hr-HR.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Očekivalo se da će se pronaći poopćeni identifikator, ali je prije toga dostignut kraj toka",
   "error_parse_expectTokenKind_1_other": "Očekivalo se da će se pronaći {expectedTokenKind}, no umjesto toga je pronađena {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Očekivalo se da će se pronaći {expectedTokenKind}, ali umjesto toga je dostignut kraj toka",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Iza uvjeta „catch“ izraza try/catch mora slijediti definicija funkcije s argumentima 0 ili 1 i bez ograničenja vrste.",
   "error_parse_invalidPrimitiveType": "Očekivalo se da će se pronaći primitivna doslovna vrijednost, no umjesto toga je pronađen {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Nakon neobaveznog parametra ne može doći parametar koji nije neobavezan",
   "error_parse_unterminated_sequence_bracket": "Nezatvorena uglata zagrada",

--- a/src/powerquery-parser/localization/templates/template.hu-HU.json
+++ b/src/powerquery-parser/localization/templates/template.hu-HU.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "A rendszer egy általánosított azonosító előfordulását várta, de előbb ért a stream végére",
   "error_parse_expectTokenKind_1_other": "A rendszer egy {expectedTokenKind} előfordulását várta, de ehelyett a talált elem {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "A rendszer egy {expectedTokenKind} előfordulását várta, de helyette a stream végére ért",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "A try/catch kifejezés „catch” záradékát 0 vagy 1 argumentummal rendelkező és típusmegkötés nélküli függvénydefiníciónak kell követnie",
   "error_parse_invalidPrimitiveType": "A rendszer egy primitív literál előfordulását várta, de ehelyett a talált elem {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Nem kötelező paraméter után nem állhat kötelező paraméter",
   "error_parse_unterminated_sequence_bracket": "Lezáratlan kapcsos zárójel",

--- a/src/powerquery-parser/localization/templates/template.id-ID.json
+++ b/src/powerquery-parser/localization/templates/template.id-ID.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Diharapkan menemukan pengidentifikasi umum tetapi akhir aliran telah tercapai terlebih dahulu",
   "error_parse_expectTokenKind_1_other": "Diharapkan menemukan {expectedTokenKind}, tetapi {foundTokenKind} ditemukan sebagai gantinya",
   "error_parse_expectTokenKind_2_endOfStream": "Diharapkan menemukan {expectedTokenKind}, tetapi akhir aliran telah tercapai sebagai gantinya",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Klausul 'catch' dari ekspresi try/catch harus diikuti oleh definisi fungsi dengan argumen 0 atau 1 dan tanpa batasan tipe",
   "error_parse_invalidPrimitiveType": "Diharapkan menemukan literal primitif, tetapi {foundTokenKind} ditemukan sebagai gantinya",
   "error_parse_requiredParameterAfterOptional": "Anda tidak dapat memiliki parameter non-opsional setelah parameter opsional",
   "error_parse_unterminated_sequence_bracket": "Kurung siku tidak diakhiri",

--- a/src/powerquery-parser/localization/templates/template.it-IT.json
+++ b/src/powerquery-parser/localization/templates/template.it-IT.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "È previsto un identificatore generalizzato, ma è prima stata raggiunta la fine del flusso",
   "error_parse_expectTokenKind_1_other": "È previsto un elemento {expectedTokenKind}, ma invece è stato trovato {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "È previsto un elemento {expectedTokenKind}, ma invece è stata raggiunta la fine del flusso",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "La clausola 'catch' di un'espressione try/catch deve essere seguita da una definizione di funzione con 0 o 1 argomenti e senza vincoli di tipo.",
   "error_parse_invalidPrimitiveType": "È previsto un valore letterale primitivo, ma invece è stato trovato {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Non è possibile avere un parametro non facoltativo dopo un parametro facoltativo",
   "error_parse_unterminated_sequence_bracket": "Parentesi quadra senza terminazione",

--- a/src/powerquery-parser/localization/templates/template.ja-JP.json
+++ b/src/powerquery-parser/localization/templates/template.ja-JP.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "一般化された識別子が必要ですが、最初にストリームの末尾に到達しました",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} が必要ですが、{foundTokenKind} が見つかりました",
   "error_parse_expectTokenKind_2_endOfStream": "{expectedTokenKind} が必要ですが、ストリームの末尾に到達しました",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "try/catch 式の 'catch' 句の後には、引数が 0 個または 1 個あり、型制約のない関数定義が続く必要があります",
   "error_parse_invalidPrimitiveType": "プリミティブ リテラルが必要ですが、{foundTokenKind} が見つかりました",
   "error_parse_requiredParameterAfterOptional": "省略可能なパラメーターの後に省略不可能なパラメーターを指定することはできません",
   "error_parse_unterminated_sequence_bracket": "角かっこが終了していません",

--- a/src/powerquery-parser/localization/templates/template.kk-KZ.json
+++ b/src/powerquery-parser/localization/templates/template.kk-KZ.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Жалпыланған идентификаторды табу күтілді, бірақ алдымен ағынның соңына жетті",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} табу күтілді, бірақ оның орнына {foundTokenKind} табылды",
   "error_parse_expectTokenKind_2_endOfStream": "{expectedTokenKind} табу күтілді, бірақ оның орнына алдымен ағынның соңына жетті",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "try немесе catch өрнегіндегі \"catch\" сөйлемінен кейін 0 немесе 1 аргументтері бар функция анықтамасы болуы керек және түр шектеулері болмауы керек",
   "error_parse_invalidPrimitiveType": "Примитив литерал табу күтілді, бірақ оның орнына {foundTokenKind} табылды",
   "error_parse_requiredParameterAfterOptional": "Міндетті емес параметрден кейін міндетті параметр болмауы керек",
   "error_parse_unterminated_sequence_bracket": "Аяқталмаған тік жақша",

--- a/src/powerquery-parser/localization/templates/template.ko-KR.json
+++ b/src/powerquery-parser/localization/templates/template.ko-KR.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "일반화된 식별자가 필요하나 먼저 스트림 끝에 도달했습니다.",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind}이(가) 필요하나 {foundTokenKind}이(가) 발견되었습니다.",
   "error_parse_expectTokenKind_2_endOfStream": "{expectedTokenKind}이(가) 필요하나 스트림 끝에 도달했습니다.",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "try/catch 식의 'catch' 절 뒤에는 인수가 0개 또는 1개이고 형식 제약 조건이 없는 함수 정의가 와야 합니다.",
   "error_parse_invalidPrimitiveType": "기본 리터럴이 필요하나 대신 {foundTokenKind}이(가) 발견되었습니다.",
   "error_parse_requiredParameterAfterOptional": "선택적 매개 변수 뒤에는 선택 사항이 아닌 매개 변수를 사용할 수 없습니다.",
   "error_parse_unterminated_sequence_bracket": "종결되지 않은 대괄호",

--- a/src/powerquery-parser/localization/templates/template.lt-LT.json
+++ b/src/powerquery-parser/localization/templates/template.lt-LT.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Tikėtasi rasti apibendrintąjį identifikatorių, bet buvo pasiekta srauto pabaiga",
   "error_parse_expectTokenKind_1_other": "Tikėtasi rasti {expectedTokenKind}, bet buvo rastas {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Tikėtasi rasti {expectedTokenKind}, bet buvo pasiekta srauto pabaiga",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Po try/catch išraiškos sąlygos „catch“ turi būti funkcijos apibrėžimas su 0 arba 1 argumentais ir be tipo apribojimų",
   "error_parse_invalidPrimitiveType": "Tikėtasi rasti paprastą literalą, bet buvo rastas {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Būtinas parametras negali būti nurodytas po pasirenkamo parametro",
   "error_parse_unterminated_sequence_bracket": "Nenustatytas laužtinis skliaustas",

--- a/src/powerquery-parser/localization/templates/template.lv-LV.json
+++ b/src/powerquery-parser/localization/templates/template.lv-LV.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Tika gaidīts, ka tiks atrasts vispārinātais identifikators, bet vispirms tika sasniegtas straumes beigas",
   "error_parse_expectTokenKind_1_other": "Tika gaidīts, ka tiks atrasts: {expectedTokenKind}, bet tā vietā tika atrasts: {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Tika gaidīts, ka tiks atrasts: {expectedTokenKind}, bet tā vietā tika sasniegtas straumes beigas",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Frāzes “try/catch” daļai “catch” ir jāseko funkcijas definīcijai ar 0 vai 1 argumentiem bez tipa ierobežojumiem",
   "error_parse_invalidPrimitiveType": "Tika gaidīts, ka tiks atrasts primitīvs literālis, bet tā vietā tika atrasts: {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Pēc neobligāta parametra nevar būt parametrs, kas nav neobligāts",
   "error_parse_unterminated_sequence_bracket": "Nenoslēgta kvadrātiekava",

--- a/src/powerquery-parser/localization/templates/template.ms-MY.json
+++ b/src/powerquery-parser/localization/templates/template.ms-MY.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Dijangka menemui pengecam umum sebaliknya penghujung strim telah dicapai dahulu",
   "error_parse_expectTokenKind_1_other": "Dijangka menemui {expectedTokenKind}, tetapi {foundTokenKind} telah ditemui sebaliknya",
   "error_parse_expectTokenKind_2_endOfStream": "Dijangka menemui {expectedTokenKind}, sebaliknya penghujung strim telah dicapai",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Fasal 'tangkap' bagi ungkapan cuba/tangkap mesti diikuti oleh definisi fungsi dengan argumen 0 atau 1 dan tiada kekangan jenis",
   "error_parse_invalidPrimitiveType": "Dijangka mencari literal primitif, tetapi {foundTokenKind} telah ditemui sebaliknya",
   "error_parse_requiredParameterAfterOptional": "Anda tidak boleh mempunyai parameter bukan pilihan selepas parameter pilihan",
   "error_parse_unterminated_sequence_bracket": "Kurungan tidak ditamatkan",

--- a/src/powerquery-parser/localization/templates/template.nb-NO.json
+++ b/src/powerquery-parser/localization/templates/template.nb-NO.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Forventet å finne en generalisert identifikator, men slutten på strømmen ble nådd først",
   "error_parse_expectTokenKind_1_other": "Forventet å finne en {expectedTokenKind}, men fant en {foundTokenKind} i stedet",
   "error_parse_expectTokenKind_2_endOfStream": "Forventet å finne en {expectedTokenKind}, men slutten på strømmen ble nådd i stedet",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Catch-setningsdelen i et try/catch-uttrykk må etterfølges av en funksjonsdefinisjon med 0 eller 1 argumenter og ingen typebegrensninger.",
   "error_parse_invalidPrimitiveType": "Forventet å finne en primitiv litteral, men fant en {foundTokenKind} i stedet",
   "error_parse_requiredParameterAfterOptional": "Du kan ikke ha et parameter som ikke er valgfritt etter et valgfritt parameter",
   "error_parse_unterminated_sequence_bracket": "Klamme som ikke er avsluttet",

--- a/src/powerquery-parser/localization/templates/template.nl-NL.json
+++ b/src/powerquery-parser/localization/templates/template.nl-NL.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Er wordt een gegeneraliseerde id verwacht, maar end-of-stream is het eerst bereikt",
   "error_parse_expectTokenKind_1_other": "Er wordt een {expectedTokenKind} verwacht, maar er is een {foundTokenKind} gevonden",
   "error_parse_expectTokenKind_2_endOfStream": "Er wordt een {expectedTokenKind} verwacht, maar end-of-stream is bereikt",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "De component catch van een try/catch-expressie moet worden gevolgd door een functiedefinitie met 0 of 1 argument en geen typebeperkingen",
   "error_parse_invalidPrimitiveType": "Er wordt een primitieve letterlijke waarde verwacht, maar er is een {foundTokenKind} gevonden",
   "error_parse_requiredParameterAfterOptional": "Een niet-optionele parameter kan niet na een optionele parameter worden gebruikt",
   "error_parse_unterminated_sequence_bracket": "Niet-afgesloten vierkante haak",

--- a/src/powerquery-parser/localization/templates/template.pl-PL.json
+++ b/src/powerquery-parser/localization/templates/template.pl-PL.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Oczekiwano identyfikatora uogólnionego, ale osiągnięto wcześniej koniec strumienia",
   "error_parse_expectTokenKind_1_other": "Oczekiwano tokenu {expectedTokenKind}, ale znaleziono token {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Oczekiwano tokenu {expectedTokenKind}, a osiągnięto koniec strumienia",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Po klauzuli „catch” wyrażenia try/catch musi następować definicja funkcji z 0 lub 1 argumentami i bez ograniczeń typów",
   "error_parse_invalidPrimitiveType": "Oczekiwano podstawowego literału, ale znaleziono token {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Nieopcjonalny parametr nie może występować po opcjonalnym parametrze",
   "error_parse_unterminated_sequence_bracket": "Niezakończony nawias kwadratowy",

--- a/src/powerquery-parser/localization/templates/template.pt-BR.json
+++ b/src/powerquery-parser/localization/templates/template.pt-BR.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Esperava-se encontrar um identificador genérico, mas o fim do fluxo foi alcançado primeiro",
   "error_parse_expectTokenKind_1_other": "Esperava-se encontrar um {expectedTokenKind}, porém, um {foundTokenKind} foi encontrado",
   "error_parse_expectTokenKind_2_endOfStream": "Esperava-se encontrar um {expectedTokenKind}, mas o fim do fluxo foi alcançado em vez disso",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "A cláusula 'catch' de uma expressão try/catch deve ser seguida por uma definição de função com 0 ou 1 argumentos e sem restrições de tipo",
   "error_parse_invalidPrimitiveType": "Esperava-se encontrar um literal primitivo, mas um {foundTokenKind} foi encontrado em vez disso",
   "error_parse_requiredParameterAfterOptional": "Não é possível ter um parâmetro não opcional após um parâmetro opcional",
   "error_parse_unterminated_sequence_bracket": "Colchete não terminado",

--- a/src/powerquery-parser/localization/templates/template.pt-PT.json
+++ b/src/powerquery-parser/localization/templates/template.pt-PT.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Era esperado encontrar um identificador generalizado, mas, em vez disso, o fim de fluxo foi alcançado primeiro",
   "error_parse_expectTokenKind_1_other": "Era esperado encontrar um {expectedTokenKind}, mas, em vez disso, foi encontrado um {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Era esperado encontrar um {expectedTokenKind}, mas, em vez disso, foi alcançado o fim de fluxo",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "A cláusula \"catch\" de uma expressão try/catch tem de ser seguida por uma definição de função com 0 ou 1 argumentos e sem restrições de tipo",
   "error_parse_invalidPrimitiveType": "Era esperado encontrar um literal primitivo, mas, em vez disso, foi encontrado um {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Não é possível ter um parâmetro não opcional após um parâmetro opcional",
   "error_parse_unterminated_sequence_bracket": "Parêntese reto não terminado",

--- a/src/powerquery-parser/localization/templates/template.ro-RO.json
+++ b/src/powerquery-parser/localization/templates/template.ro-RO.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Se aștepta un identificator generalizat, dar s-a atins sfârșitul de flux mai întâi",
   "error_parse_expectTokenKind_1_other": "Se aștepta tipul {expectedTokenKind}, dar s-a găsit un tip {foundTokenKind} în schimb",
   "error_parse_expectTokenKind_2_endOfStream": "Se aștepta un tip {expectedTokenKind}, dar s-a atins sfârșitul de flux în schimb",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Clauza „catch” a unei expresii try/catch trebuie să fie urmată de o definiție de funcție cu 0 sau 1 argument și fără restricții de tip.",
   "error_parse_invalidPrimitiveType": "Se aștepta o valoare literală primitivă, dar s-a găsit un tip {foundTokenKind} în schimb",
   "error_parse_requiredParameterAfterOptional": "Nu puteți avea un parametru neopțional după un parametru opțional",
   "error_parse_unterminated_sequence_bracket": "Paranteză dreaptă neterminată",

--- a/src/powerquery-parser/localization/templates/template.ru-RU.json
+++ b/src/powerquery-parser/localization/templates/template.ru-RU.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Ожидался общий идентификатор, но был достигнут конец потока.",
   "error_parse_expectTokenKind_1_other": "Ожидалось: {expectedTokenKind}. Однако обнаружено: {foundTokenKind}.",
   "error_parse_expectTokenKind_2_endOfStream": "Достигнут конец потока, но ожидалось следующее: {expectedTokenKind}.",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "За предложением catch в выражении try или catch должно следовать определение функции с аргументами 0 или 1 и без ограничений типа",
   "error_parse_invalidPrimitiveType": "Ожидался примитивный литерал, но вместо него обнаружено: {foundTokenKind}.",
   "error_parse_requiredParameterAfterOptional": "Обязательный параметр недопустимо указывать после необязательного.",
   "error_parse_unterminated_sequence_bracket": "Не закрыта квадратная скобка.",

--- a/src/powerquery-parser/localization/templates/template.sk-SK.json
+++ b/src/powerquery-parser/localization/templates/template.sk-SK.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Očakávalo sa, že sa nájde zovšeobecnený identifikátor, ale skôr sa dosiahol koniec streamu",
   "error_parse_expectTokenKind_1_other": "Očakávalo sa, že sa nájde hodnota {expectedTokenKind}, ale namiesto toho sa našla hodnota {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Očakávalo sa, že nájde hodnota {expectedTokenKind}, no namiesto toho sa dosiahol koniec streamu",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Za klauzulou catch výrazu try/catch musí nasledovať definícia funkcie s argumentami 0 alebo 1 bez obmedzení akéhokoľvek typu",
   "error_parse_invalidPrimitiveType": "Očakávalo sa, že sa nájde primitívny literál, ale namiesto toho sa našla hodnota {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Za voliteľným parametrom nemôžete mať nevoliteľný parameter",
   "error_parse_unterminated_sequence_bracket": "Neukončená hranatá zátvorka",

--- a/src/powerquery-parser/localization/templates/template.sl-SI.json
+++ b/src/powerquery-parser/localization/templates/template.sl-SI.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Pričakovano je, da bo najden splošni identifikator, vendar je bil najprej dosežen konec toka",
   "error_parse_expectTokenKind_1_other": "Pričakovano je, da bo najden žeton {expectedTokenKind}, vendar je bil najden žeton {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Pričakovano je, da bo najden žeton {expectedTokenKind}, vendar je bil namesto tega dosežen konec toka",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Stavku »catch« ali izrazu »try/catch« mora slediti definicija funkcije z 0 ali 1 argumentom in brez omejitev vrste.",
   "error_parse_invalidPrimitiveType": "Pričakovano je, da bo najden osnovni niz, vendar je bil najden žeton {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Obvezen parameter ne sme biti za izbirnim parametrom",
   "error_parse_unterminated_sequence_bracket": "Nedokončan oglati oklepaj",

--- a/src/powerquery-parser/localization/templates/template.sr-Cyrl-RS.json
+++ b/src/powerquery-parser/localization/templates/template.sr-Cyrl-RS.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Требало је да се пронађе генерализовани идентификатор, али се прво дошло до краја тока",
   "error_parse_expectTokenKind_1_other": "Требало је да се пронађе {expectedTokenKind}, али је пронађено {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Требало је да се пронађе {expectedTokenKind}, али се дошло до краја тока",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Одредба „catch“ израза за try/catch мора бити праћена дефиницијом функције са аргументима 0 или 1 и без ограничења типа.",
   "error_parse_invalidPrimitiveType": "Требало је да се пронађе примитивни литерал, али је пронађено {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Не можете да имате неопционални параметар после опционалног",
   "error_parse_unterminated_sequence_bracket": "Незатворена угласта заграда",

--- a/src/powerquery-parser/localization/templates/template.sr-Latn-RS.json
+++ b/src/powerquery-parser/localization/templates/template.sr-Latn-RS.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Trebalo je da se pronađe generalizovani identifikator, ali se prvo došlo do kraja toka",
   "error_parse_expectTokenKind_1_other": "Trebalo je da se pronađe {expectedTokenKind}, ali je pronađeno {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Trebalo je da se pronađe {expectedTokenKind}, ali se došlo do kraja toka",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Odredba „catch“ izraza za try/catch mora biti praćena definicijom funkcije sa argumentima 0 ili 1 i bez ograničenja tipa.",
   "error_parse_invalidPrimitiveType": "Trebalo je da se pronađe primitivni literal, ali je pronađeno {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Ne možete da imate neopcionalni parametar posle opcionalnog",
   "error_parse_unterminated_sequence_bracket": "Nezatvorena uglasta zagrada",

--- a/src/powerquery-parser/localization/templates/template.sv-SE.json
+++ b/src/powerquery-parser/localization/templates/template.sv-SE.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Förväntade hitta en generaliserad identifierare, men slutet på dataströmmen nåddes först",
   "error_parse_expectTokenKind_1_other": "En {expectedTokenKind} förväntades, men en {foundTokenKind} hittades i stället",
   "error_parse_expectTokenKind_2_endOfStream": "En {expectedTokenKind} förväntades, men slutet på dataströmmen nåddes i stället",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Catch-satsen i ett try/catch-uttryck måste följas av en funktionsdefinition med 0 eller 1 argument och inga typbegränsningar",
   "error_parse_invalidPrimitiveType": "Förväntade hitta en primitiv literal, men en {foundTokenKind} hittades i stället",
   "error_parse_requiredParameterAfterOptional": "Det går inte att ha en icke-valfri parameter efter en valfri parameter",
   "error_parse_unterminated_sequence_bracket": "Oavslutad hakparentes",

--- a/src/powerquery-parser/localization/templates/template.th-TH.json
+++ b/src/powerquery-parser/localization/templates/template.th-TH.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "ต้องการค้นหาตัวระบุทั่วไปแต่ถึงจุดสิ้นสุดของสตรีมก่อน",
   "error_parse_expectTokenKind_1_other": "ต้องการค้นหา {expectedTokenKind} แต่พบ {foundTokenKind} แทน",
   "error_parse_expectTokenKind_2_endOfStream": "ต้องการค้นหา {expectedTokenKind} แต่ถึงจุดสิ้นสุดของสตรีมแทน",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "ส่วนคำสั่ง “catch” ของนิพจน์ try/catch ต้องตามด้วยข้อกำหนดฟังก์ชันที่มีอาร์กิวเมนต์ 0 หรือ 1 และไม่มีข้อจำกัดชนิด",
   "error_parse_invalidPrimitiveType": "ต้องการค้นหาสัญพจน์ดั้งเดิม แต่พบ {foundTokenKind} แทน",
   "error_parse_requiredParameterAfterOptional": "คุณไม่สามารถมีพารามิเตอร์ที่จำเป็นหลังพารามิเตอร์ที่เป็นตัวเลือกได้",
   "error_parse_unterminated_sequence_bracket": "วงเล็บเหลี่ยมที่ไม่มีจุดสิ้นสุด",

--- a/src/powerquery-parser/localization/templates/template.tr-TR.json
+++ b/src/powerquery-parser/localization/templates/template.tr-TR.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Genelleştirilmiş bir tanımlayıcı bulunması bekleniyordu ancak bundan önce akışın sonuna ulaşıldı",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} bulunması bekleniyordu, ancak bunun yerine {foundTokenKind} bulundu",
   "error_parse_expectTokenKind_2_endOfStream": "{expectedTokenKind} bulunması bekleniyordu, ancak bunun yerine akışın sonuna ulaşıldı",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Try/catch ifadesinin 'catch' yan tümcesinden sonra 0 veya 1 bağımsız değişkeni içeren ancak tür kısıtlaması içermeyen bir işlev tanımı gelmelidir",
   "error_parse_invalidPrimitiveType": "Basit bir değişmez değer bulunması bekleniyordu, ancak bunun yerine bir {foundTokenKind} bulundu",
   "error_parse_requiredParameterAfterOptional": "İsteğe bağlı bir parametreden sonra isteğe bağlı olmayan bir parametre gelemez",
   "error_parse_unterminated_sequence_bracket": "Sonlandırılmamış köşeli ayraç",

--- a/src/powerquery-parser/localization/templates/template.uk-UA.json
+++ b/src/powerquery-parser/localization/templates/template.uk-UA.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Очікувалося знайти узагальнений ідентифікатор, але досягнуто кінця потоку",
   "error_parse_expectTokenKind_1_other": "Очікувалося знайти {expectedTokenKind}, але натомість знайдено {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Очікувалося знайти {expectedTokenKind}, але натомість досягнуто кінця потоку",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "У виразі типу \"try/catch\" після речення \"catch\" має бути визначення функції з 0 або 1 аргументом і без обмежень типу",
   "error_parse_invalidPrimitiveType": "Очікувалося знайти простий літерал, але натомість знайдено {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Обов’язковий параметр не може слідувати за необов’язковим",
   "error_parse_unterminated_sequence_bracket": "Незакрита квадратна дужка",

--- a/src/powerquery-parser/localization/templates/template.vi-VN.json
+++ b/src/powerquery-parser/localization/templates/template.vi-VN.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Đã dự kiến tìm thấy mã định danh khái quát nhưng lại đi đến cuối luồng trước",
   "error_parse_expectTokenKind_1_other": "Đã dự kiến tìm thấy {expectedTokenKind} nhưng lại tìm thấy {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "Đã dự kiến tìm thấy {expectedTokenKind} nhưng lại đi đến cuối luồng",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "Theo sau mệnh đề \"catch\" của biểu thức try/catch phải là định nghĩa hàm với các đối số 0 hoặc 1 và không có ràng buộc về kiểu",
   "error_parse_invalidPrimitiveType": "Đã dự kiến sẽ tìm thấy một ký tự gốc nhưng lại tìm thấy {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "Bạn không thể đặt tham số bắt buộc sau tham số tùy chọn",
   "error_parse_unterminated_sequence_bracket": "Dấu ngoặc vuông chưa hoàn thiện",

--- a/src/powerquery-parser/localization/templates/template.zh-CN.json
+++ b/src/powerquery-parser/localization/templates/template.zh-CN.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "应找到通用化标识符，但先到达了流结尾",
   "error_parse_expectTokenKind_1_other": "应找到 {expectedTokenKind}，但找到的却是 {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "应找到 {expectedTokenKind}，但却到达了流结尾",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "try/catch 表达式的 “catch” 子句必须后跟具有 0 或 1 个参数且没有类型约束的函数定义",
   "error_parse_invalidPrimitiveType": "应找到基元文本，但找到的却是 {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "可选参数后面不得有非可选参数",
   "error_parse_unterminated_sequence_bracket": "未终止的方括号",

--- a/src/powerquery-parser/localization/templates/template.zh-TW.json
+++ b/src/powerquery-parser/localization/templates/template.zh-TW.json
@@ -31,7 +31,7 @@
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "應找到通用識別項，但已先達資料流結尾",
   "error_parse_expectTokenKind_1_other": "應找到 {expectedTokenKind}，卻找到 {foundTokenKind}",
   "error_parse_expectTokenKind_2_endOfStream": "應找到 {expectedTokenKind}，但已達資料流結尾",
-  "error_parse_invalidCatchFunction": "The 'catch' clause of a try/catch expression must be followed by a function definition with 0 or 1 arguments and no type constraints",
+  "error_parse_invalidCatchFunction": "try/catch 運算式的 'catch' 子句後面必須接著具有 0 或 1 引數且無類型限制式的函式定義",
   "error_parse_invalidPrimitiveType": "應找到基本常值，卻找到 {foundTokenKind}",
   "error_parse_requiredParameterAfterOptional": "選擇性參數後面不能有非選擇性參數",
   "error_parse_unterminated_sequence_bracket": "未結束的中括號",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.