### PR TITLE
Add NodeIdMapIterator.iterRecordType

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.9.1",
+            "version": "0.9.2",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -150,6 +150,10 @@ export function assertIsRecord(
     assertIsNodeKind(xorNode, [Ast.NodeKind.RecordExpression, Ast.NodeKind.RecordLiteral]);
 }
 
+export function assertIsRecordType(xorNode: TXorNode): asserts xorNode is XorNode<Ast.RecordType> {
+    assertIsNodeKind(xorNode, Ast.NodeKind.RecordType);
+}
+
 export function assertIsFieldSpecificationList(
     xorNode: TXorNode,
 ): asserts xorNode is XorNode<Ast.FieldSpecificationList> {


### PR DESCRIPTION
- Adds the listed helper function
- Pulls in the latest localization changes for non en-US languages