### PR TITLE
Bugfix iterRecordType

### DIFF
--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -407,7 +407,7 @@ export function iterRecordType(
         NodeIdMapUtils.maybeNthChildChecked<Ast.FieldSpecificationList>(
             nodeIdMapCollection,
             recordType.node.id,
-            1,
+            0,
             Ast.NodeKind.FieldSpecificationList,
         );
 


### PR DESCRIPTION
There was a bug in the iterRecordType helper which wasn't caught by tests because I used describe(...) instead of it(...)