### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 442: Build ID 322996

### DIFF
--- a/src/powerquery-parser/localization/templates/template.bg-BG.json
+++ b/src/powerquery-parser/localization/templates/template.bg-BG.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Запетаята не може да предхожда „in“",
   "error_parse_expectAnyTokenKind_1_other": "Очакваше се да се открие едно от следните, но вместо това се откри {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Очакваше се да се открие едно от следните, но вместо това е достигнат краят на потока: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Очакваше се да се открие генерализиран идентификатор",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Очакваше се да се открие генерализиран идентификатор, но пръв беше достигнат краят на потока",
   "error_parse_expectTokenKind_1_other": "Очакваше се да се намери {expectedTokenKind}, но вместо това се откри {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.ca-ES.json
+++ b/src/powerquery-parser/localization/templates/template.ca-ES.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Una coma no pot anar seguida de la preposició \"in\".",
   "error_parse_expectAnyTokenKind_1_other": "S'esperava trobar un dels tipus següents, però s'ha trobat el valor {foundTokenKind}: {expectedAnyTokenKinds}.",
   "error_parse_expectAnyTokenKind_2_endOfStream": "S'esperava trobar un dels tipus següents, però s'ha arribat al final de flux: {expectedAnyTokenKinds}.",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "S'esperava trobar un identificador generalitzat.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "S'esperava trobar un identificador generalitzat, però s'ha arribat al final de flux.",
   "error_parse_expectTokenKind_1_other": "S'esperava trobar un valor {expectedTokenKind}, però s'ha trobat el valor {foundTokenKind}.",

--- a/src/powerquery-parser/localization/templates/template.cs-CZ.json
+++ b/src/powerquery-parser/localization/templates/template.cs-CZ.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Před klíčovým slovem in nemůže být čárka.",
   "error_parse_expectAnyTokenKind_1_other": "Očekávalo se, že se najde jedna z následujících hodnot, ale místo ní se našla hodnota {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Očekávalo se, že se najde jedna z následujících hodnot, ale místo ní se dosáhlo konce streamu: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Očekávalo se, že se najde zobecněný identifikátor.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Očekávalo se, že se najde zobecněný identifikátor, ale dosáhlo se konce streamu.",
   "error_parse_expectTokenKind_1_other": "Očekávalo se, že se najde hodnota {expectedTokenKind}, ale místo ní se našlo {foundTokenKind}.",

--- a/src/powerquery-parser/localization/templates/template.da-DK.json
+++ b/src/powerquery-parser/localization/templates/template.da-DK.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Et komma kan ikke komme efter et \"in\"",
   "error_parse_expectAnyTokenKind_1_other": "Forventede at finde en af følgende, men der blev fundet en {foundTokenKind} i stedet: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Forventede at finde en af følgende, men slutningen af streamen blev nået i stedet: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Forventede at finde en generaliseret identifikator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Forventede at finde et generaliseret id, men slutningen af streamen er nået først",
   "error_parse_expectTokenKind_1_other": "Forventede at finde en {expectedTokenKind}, men der blev fundet en {foundTokenKind} i stedet for",

--- a/src/powerquery-parser/localization/templates/template.de-DE.json
+++ b/src/powerquery-parser/localization/templates/template.de-DE.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Ein Komma darf nicht vor \"in\" stehen",
   "error_parse_expectAnyTokenKind_1_other": "{foundTokenKind} gefunden, aber eines der folgenden Token erwartet: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Streamende erreicht, aber eines der folgenden Token erwartet: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Es wurde ein generalisierter Bezeichner erwartet.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Es wurde ein generalisierter Bezeichner erwartet, aber vorher wurde das Streamende erreicht.",
   "error_parse_expectTokenKind_1_other": "Erwartet: {expectedTokenKind}, gefunden: {foundTokenKind}.",

--- a/src/powerquery-parser/localization/templates/template.el-GR.json
+++ b/src/powerquery-parser/localization/templates/template.el-GR.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Ένα κόμμα δεν είναι δυνατό να προηγείται ενός 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Αναμενόταν να βρεθεί ένα από τα ακόλουθα, αλλά βρέθηκε {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Αναμενόταν να βρεθεί ένα από τα ακόλουθα, αλλά έφτασε το τέλος της ροής: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Αναμενόταν να βρεθεί ένα γενικό αναγνωριστικό",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Αναμενόταν να βρεθεί ένα γενικό αναγνωριστικό, αλλά έφτασε πρώτα το τέλος της ροής",
   "error_parse_expectTokenKind_1_other": "Αναμενόταν να βρεθεί {expectedTokenKind}, αλλά βρέθηκε {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.es-ES.json
+++ b/src/powerquery-parser/localization/templates/template.es-ES.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "No puede haber una coma detrás de \"in\".",
   "error_parse_expectAnyTokenKind_1_other": "Se esperaba encontrar uno de los siguientes elementos, pero se ha encontrado {foundTokenKind} en su lugar: {expectedAnyTokenKinds}.",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Se esperaba encontrar uno de los siguientes elementos, pero se ha alcanzado el fin de flujo en su lugar: {expectedAnyTokenKinds}.",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Se esperaba encontrar un identificador generalizado.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Se esperaba encontrar un identificador generalizado, pero se ha alcanzado primero el fin de flujo.",
   "error_parse_expectTokenKind_1_other": "Se esperaba encontrar {expectedTokenKind}, pero se ha encontrado {foundTokenKind} en su lugar.",

--- a/src/powerquery-parser/localization/templates/template.et-EE.json
+++ b/src/powerquery-parser/localization/templates/template.et-EE.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Koma ei saa järgneda sõnale 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Eeldati, et leitakse üks järgmistest, kuid selle asemel leiti {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Eeldati, et leitakse üks järgmistest, kuid selle asemel jõudis kätte voo lõpp: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Eeldati, et leitakse üldistatud identifikaator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Eeldati, et leitakse üldistatud identifikaator, kuid esimesena jõudis kätte voo lõpp",
   "error_parse_expectTokenKind_1_other": "Eeldati, et leitakse {expectedTokenKind}, kuid selle asemel leiti {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.eu-ES.json
+++ b/src/powerquery-parser/localization/templates/template.eu-ES.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Ezin da idatzi komarik \"in\" eta gero",
   "error_parse_expectAnyTokenKind_1_other": "Token hauetako bat espero zen, baina {foundTokenKind} bat aurkitu da: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Token hauetako bat espero zen, baina korrontearen amaierara iritsi da: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Identifikatzaile orokor bat espero zen",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Identifikatzaile orokor bat espero zen, baina korrontearen amaierara iritsi da",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} bat espero zen, baina {foundTokenKind} bat aurkitu da",

--- a/src/powerquery-parser/localization/templates/template.fi-FI.json
+++ b/src/powerquery-parser/localization/templates/template.fi-FI.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Kohteen 'in' edellä ei voi olla pilkkua",
   "error_parse_expectAnyTokenKind_1_other": "Odotettiin löytyvän yksi seuraavista, mutta {foundTokenKind} löytyi sen sijaan: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Odotettiin löytyvän yksi seuraavista, mutta sen sijaan saavutettiin tietovirran loppu: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Odotettiin löytyvän yleistunniste",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Odotettiin löytyvän yleistunniste, mutta saavutettiin ensin tietovirran loppu",
   "error_parse_expectTokenKind_1_other": "Odotettiin löytyvän {expectedTokenKind}, mutta sen sijaan löytyi {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.fr-FR.json
+++ b/src/powerquery-parser/localization/templates/template.fr-FR.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Une virgule ne peut pas suivre un mot clé « in »",
   "error_parse_expectAnyTokenKind_1_other": "L'un des éléments suivants était attendu, mais un {foundTokenKind} a été trouvé à la place : {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "L'un des éléments suivants était attendu, mais la fin de flux a été atteinte à la place : {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Identificateur généralisé attendu",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Identificateur généralisé attendu, mais la fin de flux a été atteinte en premier",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} attendu, mais un {foundTokenKind} a été trouvé à la place",

--- a/src/powerquery-parser/localization/templates/template.gl-ES.json
+++ b/src/powerquery-parser/localization/templates/template.gl-ES.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Un 'in' non pode ir seguido por unha coma",
   "error_parse_expectAnyTokenKind_1_other": "Atopouse un {foundTokenKind}, cando se esperaba atopar un dos seguintes: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Alcanzouse o final do fluxo cando se esperaba atopar un dos seguintes: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Esperábase atopar un identificador xeral",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Esperábase atopar un identificador xeral, pero alcanzouse antes o final do fluxo",
   "error_parse_expectTokenKind_1_other": "Esperábase atopar un {expectedTokenKind}, pero no seu lugar atopouse un {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.hi-IN.json
+++ b/src/powerquery-parser/localization/templates/template.hi-IN.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "एक अल्पविराम 'in' को जारी नहीं रख सकता",
   "error_parse_expectAnyTokenKind_1_other": "निम्न में से किसी एक के मिलने की अपेक्षा थी, लेकिन इसके बजाय एक {foundTokenKind} मिला: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "निम्न में से किसी एक के मिलने की अपेक्षा थी, लेकिन इसके बजाय एंड-ऑफ़-स्ट्रीम तक पहुँच गए: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "एक सामान्यीकृत आइडेंटिफ़ायर के मिलने की अपेक्षा थी",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "किसी सामान्यीकृत आइडेंटिफ़ायर के मिलने की अपेक्षा थी, लेकिन पहले एंड-ऑफ़-स्ट्रीम तक पहुँच गए",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} के मिलने की अपेक्षा थी, लेकिन इसके बजाय {foundTokenKind} मिला",

--- a/src/powerquery-parser/localization/templates/template.hr-HR.json
+++ b/src/powerquery-parser/localization/templates/template.hr-HR.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Zarez ne može stajati ispred 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Očekuje se da će se pronaći jedna od sljedećih vrijednosti, no umjesto toga pronađena je {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Očekivalo se da će se pronaći nešto od sljedećih podataka, ali je dostignut kraj toka: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Očekivalo se da će se pronaći poopćeni identifikator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Očekivalo se da će se pronaći poopćeni identifikator, ali je prije toga dostignut kraj toka",
   "error_parse_expectTokenKind_1_other": "Očekivalo se da će se pronaći {expectedTokenKind}, no umjesto toga je pronađena {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.hu-HU.json
+++ b/src/powerquery-parser/localization/templates/template.hu-HU.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Egy „in” típusú művelet nem folytatódhat vesszővel",
   "error_parse_expectAnyTokenKind_1_other": "A rendszer a következők egyikének előfordulását várta, de ehelyett a talált elem {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "A rendszer a következők egyikének előfordulását várta, de ehelyett a stream végére ért: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "A rendszer egy általánosított azonosító előfordulását várta",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "A rendszer egy általánosított azonosító előfordulását várta, de előbb ért a stream végére",
   "error_parse_expectTokenKind_1_other": "A rendszer egy {expectedTokenKind} előfordulását várta, de ehelyett a talált elem {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.id-ID.json
+++ b/src/powerquery-parser/localization/templates/template.id-ID.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Koma tidak dapat memproses 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Diharapkan menemukan salah satu dari berikut, tetapi {foundTokenKind} ditemukan sebagai gantinya: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Diharapkan menemukan salah satu dari berikut ini, tetapi akhir aliran tercapai sebagai gantinya: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Diharapkan menemukan pengidentifikasi umum",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Diharapkan menemukan pengidentifikasi umum tetapi akhir aliran telah tercapai terlebih dahulu",
   "error_parse_expectTokenKind_1_other": "Diharapkan menemukan {expectedTokenKind}, tetapi {foundTokenKind} ditemukan sebagai gantinya",

--- a/src/powerquery-parser/localization/templates/template.it-IT.json
+++ b/src/powerquery-parser/localization/templates/template.it-IT.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Una virgola non può precedere 'in'",
   "error_parse_expectAnyTokenKind_1_other": "È previsto uno degli elementi seguenti {expectedAnyTokenKinds}, ma invece è stato trovato {foundTokenKind}.",
   "error_parse_expectAnyTokenKind_2_endOfStream": "È previsto uno degli elementi seguenti {expectedAnyTokenKinds}, ma invece è stata raggiunta la fine del flusso",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "È previsto un identificatore generalizzato",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "È previsto un identificatore generalizzato, ma è prima stata raggiunta la fine del flusso",
   "error_parse_expectTokenKind_1_other": "È previsto un elemento {expectedTokenKind}, ma invece è stato trovato {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.ja-JP.json
+++ b/src/powerquery-parser/localization/templates/template.ja-JP.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "コンマの後に 'in' を使用することはできません",
   "error_parse_expectAnyTokenKind_1_other": "{expectedAnyTokenKinds} のいずれかが必要ですが、{foundTokenKind} が見つかりました。",
   "error_parse_expectAnyTokenKind_2_endOfStream": "{expectedAnyTokenKinds} のいずれかが必要ですが、ストリームの末尾に到達しました。",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "一般化された識別子が必要です",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "一般化された識別子が必要ですが、最初にストリームの末尾に到達しました",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} が必要ですが、{foundTokenKind} が見つかりました",

--- a/src/powerquery-parser/localization/templates/template.kk-KZ.json
+++ b/src/powerquery-parser/localization/templates/template.kk-KZ.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Үтір 'in' болмауы керек",
   "error_parse_expectAnyTokenKind_1_other": "Мыналардың біреуін табу күтілді, бірақ оның орнына {foundTokenKind} табылды: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Мыналардың біреуін табу күтілді, бірақ оның орнына ағынның соңына жетті: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Жалпыланған идентификаторды табу күтілді",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Жалпыланған идентификаторды табу күтілді, бірақ алдымен ағынның соңына жетті",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} табу күтілді, бірақ оның орнына {foundTokenKind} табылды",

--- a/src/powerquery-parser/localization/templates/template.ko-KR.json
+++ b/src/powerquery-parser/localization/templates/template.ko-KR.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "'in' 앞에 쉼표가 올 수 없습니다.",
   "error_parse_expectAnyTokenKind_1_other": "{expectedAnyTokenKinds} 중 하나가 필요하나 대신 {foundTokenKind}이(가) 발견되었습니다.",
   "error_parse_expectAnyTokenKind_2_endOfStream": "{expectedAnyTokenKinds} 중 하나가 필요하나 대신 스트림 끝에 도달했습니다.",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "일반화된 식별자가 필요합니다.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "일반화된 식별자가 필요하나 먼저 스트림 끝에 도달했습니다.",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind}이(가) 필요하나 {foundTokenKind}이(가) 발견되었습니다.",

--- a/src/powerquery-parser/localization/templates/template.lt-LT.json
+++ b/src/powerquery-parser/localization/templates/template.lt-LT.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Prieš 'in' negalima dėti kablelio",
   "error_parse_expectAnyTokenKind_1_other": "Tikėtasi rasti vieną iš toliau pateiktų elementų, bet buvo rastas {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Tikėtasi rasti vieną iš toliau nurodytų elementų, bet buvo pasiekta srauto pabaiga: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Tikėtasi rasti apibendrintąjį identifikatorių",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Tikėtasi rasti apibendrintąjį identifikatorių, bet buvo pasiekta srauto pabaiga",
   "error_parse_expectTokenKind_1_other": "Tikėtasi rasti {expectedTokenKind}, bet buvo rastas {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.lv-LV.json
+++ b/src/powerquery-parser/localization/templates/template.lv-LV.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Aiz komata nevar būt 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Tika gaidīts kāds no tālāk norādītajiem, taču tā vietā tika atrasts {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Tika gaidīts kāds no tālāk norādītajiem, taču tā vietā tika sasniegtas straumes beigas: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Tika gaidīts, ka tiks atrasts vispārinātais identifikators",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Tika gaidīts, ka tiks atrasts vispārinātais identifikators, bet vispirms tika sasniegtas straumes beigas",
   "error_parse_expectTokenKind_1_other": "Tika gaidīts, ka tiks atrasts: {expectedTokenKind}, bet tā vietā tika atrasts: {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.ms-MY.json
+++ b/src/powerquery-parser/localization/templates/template.ms-MY.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Koma tidak boleh meneruskan 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Dijangka menemui satu daripada yang berikut, tetapi {foundTokenKind} telah ditemui bukannya: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Dijangka menemui satu daripada yang berikut, sebaliknya penghujung strim telah dicapai: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Dijangka menemui pengecam umum",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Dijangka menemui pengecam umum sebaliknya penghujung strim telah dicapai dahulu",
   "error_parse_expectTokenKind_1_other": "Dijangka menemui {expectedTokenKind}, tetapi {foundTokenKind} telah ditemui sebaliknya",

--- a/src/powerquery-parser/localization/templates/template.nb-NO.json
+++ b/src/powerquery-parser/localization/templates/template.nb-NO.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Et komma kan ikke komme etter 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Forventet å finne en av følgende, men fant en {foundTokenKind} i stedet: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Forventet å finne en av følgende, men slutten på strømmen ble nådd i stedet: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Forventet å finne en generalisert identifikator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Forventet å finne en generalisert identifikator, men slutten på strømmen ble nådd først",
   "error_parse_expectTokenKind_1_other": "Forventet å finne en {expectedTokenKind}, men fant en {foundTokenKind} i stedet",

--- a/src/powerquery-parser/localization/templates/template.nl-NL.json
+++ b/src/powerquery-parser/localization/templates/template.nl-NL.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Een komma kan geen 'in' uitvoeren",
   "error_parse_expectAnyTokenKind_1_other": "Er wordt een van de volgende typen tokens verwacht, maar er is een {foundTokenKind} gevonden: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Er wordt een van de volgende typen tokens verwacht, maar end-of-stream is bereikt: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Er wordt een gegeneraliseerde id verwacht",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Er wordt een gegeneraliseerde id verwacht, maar end-of-stream is het eerst bereikt",
   "error_parse_expectTokenKind_1_other": "Er wordt een {expectedTokenKind} verwacht, maar er is een {foundTokenKind} gevonden",

--- a/src/powerquery-parser/localization/templates/template.pl-PL.json
+++ b/src/powerquery-parser/localization/templates/template.pl-PL.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Przecinek nie może poprzedzać operatora 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Znaleziono token {foundTokenKind}, a oczekiwano jednego z następujących tokenów: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Osiągnięto koniec strumienia, a oczekiwano jednego z następujących tokenów: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Oczekiwano identyfikatora uogólnionego",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Oczekiwano identyfikatora uogólnionego, ale osiągnięto wcześniej koniec strumienia",
   "error_parse_expectTokenKind_1_other": "Oczekiwano tokenu {expectedTokenKind}, ale znaleziono token {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.pt-BR.json
+++ b/src/powerquery-parser/localization/templates/template.pt-BR.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Uma vírgula não pode anteceder um 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Esperava-se encontrar um dos seguintes itens, mas um {foundTokenKind} foi encontrado no lugar: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Esperava-se encontrar um dos seguintes itens, mas o fim do fluxo foi atingido em vez disso: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Esperava-se encontrar um identificador genérico",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Esperava-se encontrar um identificador genérico, mas o fim do fluxo foi alcançado primeiro",
   "error_parse_expectTokenKind_1_other": "Esperava-se encontrar um {expectedTokenKind}, porém, um {foundTokenKind} foi encontrado",

--- a/src/powerquery-parser/localization/templates/template.pt-PT.json
+++ b/src/powerquery-parser/localization/templates/template.pt-PT.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Uma vírgula não pode estar depois de um 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Era esperado encontrar um dos seguintes, mas, em vez disso, foi encontrado um {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Era esperado encontrar um dos seguintes, mas, em vez disso, o fim de fluxo foi alcançado: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Era esperado encontrar um identificador generalizado",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Era esperado encontrar um identificador generalizado, mas, em vez disso, o fim de fluxo foi alcançado primeiro",
   "error_parse_expectTokenKind_1_other": "Era esperado encontrar um {expectedTokenKind}, mas, em vez disso, foi encontrado um {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.ro-RO.json
+++ b/src/powerquery-parser/localization/templates/template.ro-RO.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "O virgulă nu poate preceda un 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Se aștepta una dintre următoarele, dar s-a găsit un tip {foundTokenKind} în schimb: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Se aștepta una dintre următoarele, dar s-a atins sfârșitul de flux în schimb: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Se aștepta un identificator generalizat",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Se aștepta un identificator generalizat, dar s-a atins sfârșitul de flux mai întâi",
   "error_parse_expectTokenKind_1_other": "Se aștepta tipul {expectedTokenKind}, dar s-a găsit un tip {foundTokenKind} în schimb",

--- a/src/powerquery-parser/localization/templates/template.ru-RU.json
+++ b/src/powerquery-parser/localization/templates/template.ru-RU.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Перед 'in' не может идти запятая.",
   "error_parse_expectAnyTokenKind_1_other": "Обнаружено: {foundTokenKind}. Однако ожидалось что-либо из следующего: {expectedAnyTokenKinds}.",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Достигнут конец потока, но ожидалось что-либо из следующего: {expectedAnyTokenKinds}.",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Ожидался общий идентификатор.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Ожидался общий идентификатор, но был достигнут конец потока.",
   "error_parse_expectTokenKind_1_other": "Ожидалось: {expectedTokenKind}. Однако обнаружено: {foundTokenKind}.",

--- a/src/powerquery-parser/localization/templates/template.sk-SK.json
+++ b/src/powerquery-parser/localization/templates/template.sk-SK.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Pred výrazom in nemôže byť čiarka",
   "error_parse_expectAnyTokenKind_1_other": "Očakávalo sa, že sa nájde niektorá z nasledujúcich hodnôt, ale namiesto toho sa našla hodnota {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Očakávalo sa, že sa nájde niektorá z nasledujúcich hodnôt, ale namiesto toho sa dosiahol koniec streamu: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Očakávalo sa, že sa nájde zovšeobecnený identifikátor",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Očakávalo sa, že sa nájde zovšeobecnený identifikátor, ale skôr sa dosiahol koniec streamu",
   "error_parse_expectTokenKind_1_other": "Očakávalo sa, že sa nájde hodnota {expectedTokenKind}, ale namiesto toho sa našla hodnota {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.sl-SI.json
+++ b/src/powerquery-parser/localization/templates/template.sl-SI.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Vejica ne sme biti pred 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Najden je bil žeton {foundTokenKind}, vendar je bilo pričakovano, da bo najden eden od teh žetonov: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Dosežen je bil konec toka, vendar je bilo pričakovano, da bo najden eden od teh žetonov: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Pričakovano je, da bo najden splošni identifikator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Pričakovano je, da bo najden splošni identifikator, vendar je bil najprej dosežen konec toka",
   "error_parse_expectTokenKind_1_other": "Pričakovano je, da bo najden žeton {expectedTokenKind}, vendar je bil najden žeton {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.sr-Cyrl-RS.json
+++ b/src/powerquery-parser/localization/templates/template.sr-Cyrl-RS.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Зарез не може да дође иза 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Требало је да се пронађе нека од следећих ставки, али је пронађено {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Требало је да се пронађе нека од следећих ставки, али се дошло до краја тока: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Требало је да се пронађе генерализовани идентификатор",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Требало је да се пронађе генерализовани идентификатор, али се прво дошло до краја тока",
   "error_parse_expectTokenKind_1_other": "Требало је да се пронађе {expectedTokenKind}, али је пронађено {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.sr-Latn-RS.json
+++ b/src/powerquery-parser/localization/templates/template.sr-Latn-RS.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Zarez ne može da dođe iza 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Trebalo je da se pronađe neka od sledećih stavki, ali je pronađeno {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Trebalo je da se pronađe neka od sledećih stavki, ali se došlo do kraja toka: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Trebalo je da se pronađe generalizovani identifikator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Trebalo je da se pronađe generalizovani identifikator, ali se prvo došlo do kraja toka",
   "error_parse_expectTokenKind_1_other": "Trebalo je da se pronađe {expectedTokenKind}, ali je pronađeno {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.sv-SE.json
+++ b/src/powerquery-parser/localization/templates/template.sv-SE.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Ett kommatecken kan inte komma efter en in",
   "error_parse_expectAnyTokenKind_1_other": "Förväntade hitta ett av följande, men en {foundTokenKind} hittades i stället: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Förväntade hitta ett av följande, men slutet på dataströmmen nåddes i stället: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Förväntade hitta en generaliserad identifierare",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Förväntade hitta en generaliserad identifierare, men slutet på dataströmmen nåddes först",
   "error_parse_expectTokenKind_1_other": "En {expectedTokenKind} förväntades, men en {foundTokenKind} hittades i stället",

--- a/src/powerquery-parser/localization/templates/template.th-TH.json
+++ b/src/powerquery-parser/localization/templates/template.th-TH.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "เครื่องหมายจุลภาคไม่สามารถดำเนินการต่อ 'in' ได้",
   "error_parse_expectAnyTokenKind_1_other": "ต้องการค้นหาอย่างใดอย่างหนึ่งต่อไปนี้ แต่พบ {foundTokenKind} แทน: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "ต้องการค้นหาอย่างใดอย่างหนึ่งต่อไปนี้ แต่ถึงจุดสิ้นสุดของสตรีมแทน: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "ต้องการค้นหาตัวระบุทั่วไป",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "ต้องการค้นหาตัวระบุทั่วไปแต่ถึงจุดสิ้นสุดของสตรีมก่อน",
   "error_parse_expectTokenKind_1_other": "ต้องการค้นหา {expectedTokenKind} แต่พบ {foundTokenKind} แทน",

--- a/src/powerquery-parser/localization/templates/template.tr-TR.json
+++ b/src/powerquery-parser/localization/templates/template.tr-TR.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Virgülün arkasından 'in' gelemez",
   "error_parse_expectAnyTokenKind_1_other": "Şunlardan birinin bulunması bekleniyordu, ancak bunun yerine bir {foundTokenKind} bulundu: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Şunlardan birinin bulunması bekleniyordu ancak bunun yerine akışın sonuna ulaşıldı: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Genelleştirilmiş bir tanımlayıcı bulunması bekleniyordu",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Genelleştirilmiş bir tanımlayıcı bulunması bekleniyordu ancak bundan önce akışın sonuna ulaşıldı",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} bulunması bekleniyordu, ancak bunun yerine {foundTokenKind} bulundu",

--- a/src/powerquery-parser/localization/templates/template.uk-UA.json
+++ b/src/powerquery-parser/localization/templates/template.uk-UA.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Кома не може слідувати за 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Очікувалося знайти одне з наведеного нижче, але натомість знайдено {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Очікувалося знайти одне з наведеного нижче, але натомість досягнуто кінця потоку: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Очікувалося знайти узагальнений ідентифікатор",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Очікувалося знайти узагальнений ідентифікатор, але досягнуто кінця потоку",
   "error_parse_expectTokenKind_1_other": "Очікувалося знайти {expectedTokenKind}, але натомість знайдено {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.vi-VN.json
+++ b/src/powerquery-parser/localization/templates/template.vi-VN.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Dấu phẩy không được đứng trước 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Đã dự kiến tìm thấy một trong các đối tượng sau nhưng lại tìm thấy {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Đã dự kiến tìm thấy một trong các đối tượng sau nhưng lại đi đến cuối luồng: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Đã dự kiến tìm thấy mã định danh khái quát",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Đã dự kiến tìm thấy mã định danh khái quát nhưng lại đi đến cuối luồng trước",
   "error_parse_expectTokenKind_1_other": "Đã dự kiến tìm thấy {expectedTokenKind} nhưng lại tìm thấy {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.zh-CN.json
+++ b/src/powerquery-parser/localization/templates/template.zh-CN.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "逗号无法继续执行 'in'",
   "error_parse_expectAnyTokenKind_1_other": "应找到以下项之一，但找到的却是 {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "应找到以下项之一，但却到达了流结尾: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "应找到通用化标识符",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "应找到通用化标识符，但先到达了流结尾",
   "error_parse_expectTokenKind_1_other": "应找到 {expectedTokenKind}，但找到的却是 {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.zh-TW.json
+++ b/src/powerquery-parser/localization/templates/template.zh-TW.json
@@ -27,6 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "'in' 前面不能有逗號",
   "error_parse_expectAnyTokenKind_1_other": "應找到下列其中一項，卻找到 {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "應找到下列其中一項，但已達資料流結尾: {expectedAnyTokenKinds}",
+  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "應找到通用識別項",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "應找到通用識別項，但已先達資料流結尾",
   "error_parse_expectTokenKind_1_other": "應找到 {expectedTokenKind}，卻找到 {foundTokenKind}",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.