### PR TITLE
Smarter error reporting for CsvArray termination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.9.4",
+            "version": "0.9.5",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.9.3",
+            "version": "0.9.4",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/localization/localization.ts
+++ b/src/powerquery-parser/localization/localization.ts
@@ -38,6 +38,7 @@ interface ILocalization {
         expectedAnyTokenKinds: ReadonlyArray<Token.TokenKind>,
         maybeFoundToken: TokenWithColumnNumber | undefined,
     ) => string;
+    readonly error_parse_expectCommaOrKind: (templates: ILocalizationTemplates) => string;
     readonly error_parse_expectGeneralizedIdentifier: (
         templates: ILocalizationTemplates,
         maybeFoundToken: TokenWithColumnNumber | undefined,
@@ -344,6 +345,10 @@ export const Localization: ILocalization = {
                 new Map([["expectedAnyTokenKinds", localizedExpectedAnyTokenKinds]]),
             );
         }
+    },
+
+    error_parse_expectCommaOrKind: (_templates: ILocalizationTemplates) => {
+        throw new Error("Function not implemented.");
     },
 
     error_parse_expectGeneralizedIdentifier: (

--- a/src/powerquery-parser/localization/localization.ts
+++ b/src/powerquery-parser/localization/localization.ts
@@ -352,7 +352,7 @@ export const Localization: ILocalization = {
 
     error_parse_expectCommaOrKind: (templates: ILocalizationTemplates, expectedTokenKind: Token.TokenKind) =>
         StringUtils.assertGetFormatted(
-            templates.error_parse_expectedCommaOrTokenKind,
+            templates.error_parse_expectClosingTokenKindOrComma,
             new Map([
                 ["localizedComma", localizeTokenKind(templates, Token.TokenKind.Comma)],
                 ["localizedAlternative", localizeTokenKind(templates, expectedTokenKind)],

--- a/src/powerquery-parser/localization/localization.ts
+++ b/src/powerquery-parser/localization/localization.ts
@@ -38,7 +38,10 @@ interface ILocalization {
         expectedAnyTokenKinds: ReadonlyArray<Token.TokenKind>,
         maybeFoundToken: TokenWithColumnNumber | undefined,
     ) => string;
-    readonly error_parse_expectCommaOrKind: (templates: ILocalizationTemplates) => string;
+    readonly error_parse_expectCommaOrKind: (
+        templates: ILocalizationTemplates,
+        expectedTokenKind: Token.TokenKind,
+    ) => string;
     readonly error_parse_expectGeneralizedIdentifier: (
         templates: ILocalizationTemplates,
         maybeFoundToken: TokenWithColumnNumber | undefined,
@@ -347,9 +350,14 @@ export const Localization: ILocalization = {
         }
     },
 
-    error_parse_expectCommaOrKind: (_templates: ILocalizationTemplates) => {
-        throw new Error("Function not implemented.");
-    },
+    error_parse_expectCommaOrKind: (templates: ILocalizationTemplates, expectedTokenKind: Token.TokenKind) =>
+        StringUtils.assertGetFormatted(
+            templates.error_parse_expectedCommaOrTokenKind,
+            new Map([
+                ["localizedComma", localizeTokenKind(templates, Token.TokenKind.Comma)],
+                ["localizedAlternative", localizeTokenKind(templates, expectedTokenKind)],
+            ]),
+        ),
 
     error_parse_expectGeneralizedIdentifier: (
         templates: ILocalizationTemplates,

--- a/src/powerquery-parser/localization/localization.ts
+++ b/src/powerquery-parser/localization/localization.ts
@@ -352,7 +352,7 @@ export const Localization: ILocalization = {
 
     error_parse_expectCommaOrKind: (templates: ILocalizationTemplates, expectedTokenKind: Token.TokenKind) =>
         StringUtils.assertGetFormatted(
-            templates.error_parse_expectClosingTokenKindOrComma,
+            templates.error_parse_expectedCommaOrTokenKind,
             new Map([
                 ["localizedComma", localizeTokenKind(templates, Token.TokenKind.Comma)],
                 ["localizedAlternative", localizeTokenKind(templates, expectedTokenKind)],

--- a/src/powerquery-parser/localization/templates.ts
+++ b/src/powerquery-parser/localization/templates.ts
@@ -164,6 +164,7 @@ export interface ILocalizationTemplates {
     readonly error_parse_csvContinuation_2_letExpression: string;
     readonly error_parse_expectAnyTokenKind_1_other: string;
     readonly error_parse_expectAnyTokenKind_2_endOfStream: string;
+    readonly error_parse_expectedCommaOrTokenKind: string;
     readonly error_parse_expectGeneralizedIdentifier_1_other: string;
     readonly error_parse_expectGeneralizedIdentifier_2_endOfStream: string;
     readonly error_parse_expectTokenKind_1_other: string;

--- a/src/powerquery-parser/localization/templates.ts
+++ b/src/powerquery-parser/localization/templates.ts
@@ -164,7 +164,7 @@ export interface ILocalizationTemplates {
     readonly error_parse_csvContinuation_2_letExpression: string;
     readonly error_parse_expectAnyTokenKind_1_other: string;
     readonly error_parse_expectAnyTokenKind_2_endOfStream: string;
-    readonly error_parse_expectedCommaOrTokenKind: string;
+    readonly error_parse_expectClosingTokenKindOrComma: string;
     readonly error_parse_expectGeneralizedIdentifier_1_other: string;
     readonly error_parse_expectGeneralizedIdentifier_2_endOfStream: string;
     readonly error_parse_expectTokenKind_1_other: string;

--- a/src/powerquery-parser/localization/templates.ts
+++ b/src/powerquery-parser/localization/templates.ts
@@ -164,7 +164,7 @@ export interface ILocalizationTemplates {
     readonly error_parse_csvContinuation_2_letExpression: string;
     readonly error_parse_expectAnyTokenKind_1_other: string;
     readonly error_parse_expectAnyTokenKind_2_endOfStream: string;
-    readonly error_parse_expectClosingTokenKindOrComma: string;
+    readonly error_parse_expectedCommaOrTokenKind: string;
     readonly error_parse_expectGeneralizedIdentifier_1_other: string;
     readonly error_parse_expectGeneralizedIdentifier_2_endOfStream: string;
     readonly error_parse_expectTokenKind_1_other: string;

--- a/src/powerquery-parser/localization/templates/template.json
+++ b/src/powerquery-parser/localization/templates/template.json
@@ -83,6 +83,9 @@
     "error_parse_expectAnyTokenKind_2_endOfStream": "Expected to find one of the following, but the end-of-stream was reached instead: {expectedAnyTokenKinds}",
     "_error_parse_expectAnyTokenKind_2_endOfStream.comment": "A common parser error where foundTokenKind is a localized tokenKind string. Expected to be user facing.",
 
+    "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+    "_error_parse_expectedCommaOrTokenKind.comment": "A common parser error where the user needs either a comma or a closing token. Expected to be user facing.",
+
     "error_parse_expectGeneralizedIdentifier_1_other": "Expected to find a generalized identifier",
     "_error_parse_expectGeneralizedIdentifier_1_other.comment": "A common parser error. Expected to be user facing.",
 

--- a/src/powerquery-parser/parser/error.ts
+++ b/src/powerquery-parser/parser/error.ts
@@ -10,7 +10,7 @@ export type TParseError = CommonError.CommonError | ParseError;
 
 export type TInnerParseError =
     | ExpectedAnyTokenKindError
-    | ExpectedCommaOrTokenKind
+    | ExpectedClosingTokenKind
     | ExpectedCsvContinuationError
     | ExpectedGeneralizedIdentifierError
     | ExpectedTokenKindError
@@ -66,7 +66,7 @@ export class ExpectedAnyTokenKindError extends Error {
     }
 }
 
-export class ExpectedCommaOrTokenKind extends Error {
+export class ExpectedClosingTokenKind extends Error {
     constructor(
         readonly expectedTokenKind: Token.TokenKind,
         readonly maybeFoundToken: TokenWithColumnNumber | undefined,
@@ -79,7 +79,7 @@ export class ExpectedCommaOrTokenKind extends Error {
             ),
         );
 
-        Object.setPrototypeOf(this, ExpectedCommaOrTokenKind.prototype);
+        Object.setPrototypeOf(this, ExpectedClosingTokenKind.prototype);
     }
 }
 
@@ -195,7 +195,7 @@ export function isTParseError(error: any): error is TParseError {
 export function isTInnerParseError(x: any): x is TInnerParseError {
     return (
         x instanceof ExpectedAnyTokenKindError ||
-        x instanceof ExpectedCommaOrTokenKind ||
+        x instanceof ExpectedClosingTokenKind ||
         x instanceof ExpectedCsvContinuationError ||
         x instanceof ExpectedGeneralizedIdentifierError ||
         x instanceof ExpectedTokenKindError ||
@@ -210,7 +210,7 @@ export function isTInnerParseError(x: any): x is TInnerParseError {
 export function maybeTokenFrom(error: TInnerParseError): Token.Token | undefined {
     if (
         error instanceof ExpectedAnyTokenKindError ||
-        error instanceof ExpectedCommaOrTokenKind ||
+        error instanceof ExpectedClosingTokenKind ||
         error instanceof ExpectedCsvContinuationError ||
         error instanceof ExpectedGeneralizedIdentifierError ||
         error instanceof ExpectedTokenKindError

--- a/src/powerquery-parser/parser/error.ts
+++ b/src/powerquery-parser/parser/error.ts
@@ -13,7 +13,7 @@ export type TInnerParseError =
     | ExpectedCsvContinuationError
     | ExpectedGeneralizedIdentifierError
     | ExpectedTokenKindError
-    | InvalidCatchFunction
+    | InvalidCatchFunctionError
     | InvalidPrimitiveTypeError
     | RequiredParameterAfterOptionalParameterError
     | UnterminatedSequence
@@ -96,14 +96,14 @@ export class ExpectedGeneralizedIdentifierError extends Error {
     }
 }
 
-export class InvalidCatchFunction extends Error {
+export class InvalidCatchFunctionError extends Error {
     constructor(
         readonly startToken: Token.Token,
         readonly positionStart: StringUtils.GraphemePosition,
         locale: string,
     ) {
         super(Localization.error_parse_invalidCatchFunction(LocalizationUtils.getLocalizationTemplates(locale)));
-        Object.setPrototypeOf(this, InvalidCatchFunction.prototype);
+        Object.setPrototypeOf(this, InvalidCatchFunctionError.prototype);
     }
 }
 
@@ -180,7 +180,7 @@ export function isTInnerParseError(x: any): x is TInnerParseError {
         x instanceof ExpectedCsvContinuationError ||
         x instanceof ExpectedGeneralizedIdentifierError ||
         x instanceof ExpectedTokenKindError ||
-        x instanceof InvalidCatchFunction ||
+        x instanceof InvalidCatchFunctionError ||
         x instanceof InvalidPrimitiveTypeError ||
         x instanceof RequiredParameterAfterOptionalParameterError ||
         x instanceof UnterminatedSequence ||

--- a/src/powerquery-parser/parser/error.ts
+++ b/src/powerquery-parser/parser/error.ts
@@ -65,6 +65,18 @@ export class ExpectedAnyTokenKindError extends Error {
     }
 }
 
+export class ExpectedCommaOrKind extends Error {
+    constructor(
+        readonly expectedTokenKind: Token.TokenKind,
+        readonly maybeFoundToken: TokenWithColumnNumber | undefined,
+        locale: string,
+    ) {
+        super(Localization.error_parse_expectCommaOrKind(LocalizationUtils.getLocalizationTemplates(locale)));
+
+        Object.setPrototypeOf(this, ExpectedAnyTokenKindError.prototype);
+    }
+}
+
 export class ExpectedTokenKindError extends Error {
     constructor(
         readonly expectedTokenKind: Token.TokenKind,

--- a/src/powerquery-parser/parser/parseState/parseStateUtils.ts
+++ b/src/powerquery-parser/parser/parseState/parseStateUtils.ts
@@ -279,15 +279,17 @@ export function testCsvContinuationDanglingComma(
 // ---------- Asserts / Tests ----------
 // -------------------------------------
 
-export function testCommaOrTokenKind(
+// This test is run after seeing no additional commas in a CsvArray,
+// when a closing terminator is expected.
+export function testClosingTokenKind(
     state: ParseState,
     expectedTokenKind: Token.TokenKind,
-): ParseError.ExpectedCommaOrTokenKind | undefined {
+): ParseError.ExpectedClosingTokenKind | undefined {
     if (isOnTokenKind(state, expectedTokenKind)) {
         return undefined;
     }
 
-    return new ParseError.ExpectedCommaOrTokenKind(
+    return new ParseError.ExpectedClosingTokenKind(
         expectedTokenKind,
         maybeCurrentTokenWithColumnNumber(state),
         state.locale,

--- a/src/powerquery-parser/parser/parseState/parseStateUtils.ts
+++ b/src/powerquery-parser/parser/parseState/parseStateUtils.ts
@@ -279,6 +279,21 @@ export function testCsvContinuationDanglingComma(
 // ---------- Asserts / Tests ----------
 // -------------------------------------
 
+export function testCommaOrTokenKind(
+    state: ParseState,
+    expectedTokenKind: Token.TokenKind,
+): ParseError.ExpectedCommaOrTokenKind | undefined {
+    if (isOnTokenKind(state, expectedTokenKind)) {
+        return undefined;
+    }
+
+    return new ParseError.ExpectedCommaOrTokenKind(
+        expectedTokenKind,
+        maybeCurrentTokenWithColumnNumber(state),
+        state.locale,
+    );
+}
+
 export function testIsOnTokenKind(
     state: ParseState,
     expectedTokenKind: Token.TokenKind,

--- a/src/powerquery-parser/parser/parsers/naive.ts
+++ b/src/powerquery-parser/parser/parsers/naive.ts
@@ -1935,12 +1935,13 @@ export async function readLetExpression(
             trace.id,
         );
 
-    if (ParseStateUtils.isOnTokenKind(state, Token.TokenKind.Identifier)) {
-        throw new ParseError.ExpectedCommaOrKind(
-            Token.TokenKind.KeywordIn,
-            ParseStateUtils.maybeTokenWithColumnNumber(state, state.tokenIndex),
-            state.locale,
-        );
+    const maybeError: ParseError.ExpectedCommaOrTokenKind | undefined = ParseStateUtils.testCommaOrTokenKind(
+        state,
+        Token.TokenKind.KeywordIn,
+    );
+
+    if (maybeError) {
+        throw maybeError;
     }
 
     const inConstant: Ast.IConstant<Constant.KeywordConstant.In> = readTokenKindAsConstant(

--- a/src/powerquery-parser/parser/parsers/naive.ts
+++ b/src/powerquery-parser/parser/parsers/naive.ts
@@ -1941,6 +1941,11 @@ export async function readLetExpression(
     );
 
     if (maybeError) {
+        trace.exit({
+            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
+            [TraceConstant.IsThrowing]: true,
+        });
+
         throw maybeError;
     }
 

--- a/src/powerquery-parser/parser/parsers/naive.ts
+++ b/src/powerquery-parser/parser/parsers/naive.ts
@@ -2695,7 +2695,7 @@ export async function readErrorHandlingExpression(
             trace.id,
         );
 
-        const maybeError: ParseError.InvalidCatchFunction | undefined = testCatchFunction(
+        const maybeError: ParseError.InvalidCatchFunctionError | undefined = testCatchFunction(
             state,
             catchExpression.paired,
         );
@@ -3971,7 +3971,7 @@ function testCsvContinuationDanglingCommaForParenthesis(
 function testCatchFunction(
     state: ParseState,
     catchFunction: Ast.FunctionExpression,
-): ParseError.InvalidCatchFunction | undefined {
+): ParseError.InvalidCatchFunctionError | undefined {
     const parameters: ReadonlyArray<Ast.ICsv<Ast.IParameter<Ast.AsNullablePrimitiveType | undefined>>> =
         catchFunction.parameters.content.elements;
 
@@ -3984,7 +3984,7 @@ function testCatchFunction(
             state.lexerSnapshot.tokens[catchFunction.tokenRange.tokenIndexStart],
         );
 
-        return new ParseError.InvalidCatchFunction(
+        return new ParseError.InvalidCatchFunctionError(
             tokenStart,
             state.lexerSnapshot.graphemePositionStartFrom(tokenStart),
             state.locale,

--- a/src/powerquery-parser/parser/parsers/naive.ts
+++ b/src/powerquery-parser/parser/parsers/naive.ts
@@ -1935,6 +1935,14 @@ export async function readLetExpression(
             trace.id,
         );
 
+    if (ParseStateUtils.isOnTokenKind(state, Token.TokenKind.Identifier)) {
+        throw new ParseError.ExpectedCommaOrKind(
+            Token.TokenKind.KeywordIn,
+            ParseStateUtils.maybeTokenWithColumnNumber(state, state.tokenIndex),
+            state.locale,
+        );
+    }
+
     const inConstant: Ast.IConstant<Constant.KeywordConstant.In> = readTokenKindAsConstant(
         state,
         Token.TokenKind.KeywordIn,

--- a/src/test/libraryTest/parser/error.ts
+++ b/src/test/libraryTest/parser/error.ts
@@ -129,6 +129,16 @@ describe("Parser.Error", () => {
         );
     });
 
+    it(`Expected Comma for LetExpression`, async () => {
+        const text: string = "let foo = 1 bar = 1 in foo + bar";
+
+        const innerError: ParseError.TInnerParseError = (
+            await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
+        ).innerError;
+
+        expect(innerError instanceof ParseError.ExpectedCommaOrTokenKind).to.equal(true, innerError.message);
+    });
+
     it(`Dangling Comma for ListExpression`, async () => {
         const text: string = "{1, }";
 

--- a/src/test/libraryTest/parser/error.ts
+++ b/src/test/libraryTest/parser/error.ts
@@ -214,7 +214,7 @@ describe("Parser.Error", () => {
             await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
         ).innerError;
 
-        expect(innerError instanceof ParseError.InvalidCatchFunction).to.equal(true, innerError.message);
+        expect(innerError instanceof ParseError.InvalidCatchFunctionError).to.equal(true, innerError.message);
     });
 
     it(`catch doesn't allow return typing`, async () => {
@@ -224,7 +224,7 @@ describe("Parser.Error", () => {
             await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
         ).innerError;
 
-        expect(innerError instanceof ParseError.InvalidCatchFunction).to.equal(true, innerError.message);
+        expect(innerError instanceof ParseError.InvalidCatchFunctionError).to.equal(true, innerError.message);
     });
 
     it(`catch doesn't allow multiple parameters`, async () => {
@@ -234,6 +234,6 @@ describe("Parser.Error", () => {
             await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
         ).innerError;
 
-        expect(innerError instanceof ParseError.InvalidCatchFunction).to.equal(true, innerError.message);
+        expect(innerError instanceof ParseError.InvalidCatchFunctionError).to.equal(true, innerError.message);
     });
 });

--- a/src/test/libraryTest/parser/error.ts
+++ b/src/test/libraryTest/parser/error.ts
@@ -116,125 +116,173 @@ describe("Parser.Error", () => {
         });
     });
 
-    it(`Dangling Comma for LetExpression`, async () => {
-        const text: string = "let a = 1, in 1";
+    describe(`Dangling comma`, () => {
+        it(`LetExpression`, async () => {
+            const text: string = "let a = 1, in 1";
 
-        const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(text);
+            const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(
+                text,
+            );
 
-        expect(continuationError.message).to.equal(
-            Localization.error_parse_csvContinuation(
-                Templates.DefaultTemplates,
-                ParseError.CsvContinuationKind.LetExpression,
-            ),
-        );
+            expect(continuationError.message).to.equal(
+                Localization.error_parse_csvContinuation(
+                    Templates.DefaultTemplates,
+                    ParseError.CsvContinuationKind.LetExpression,
+                ),
+            );
+        });
+
+        it(`ListExpression`, async () => {
+            const text: string = "{1, }";
+
+            const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(
+                text,
+            );
+
+            expect(continuationError.message).to.equal(
+                Localization.error_parse_csvContinuation(
+                    Templates.DefaultTemplates,
+                    ParseError.CsvContinuationKind.DanglingComma,
+                ),
+            );
+        });
+
+        it(`FunctionExpression`, async () => {
+            const text: string = "(a, ) => a";
+
+            const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(
+                text,
+            );
+
+            expect(continuationError.message).to.equal(
+                Localization.error_parse_csvContinuation(
+                    Templates.DefaultTemplates,
+                    ParseError.CsvContinuationKind.DanglingComma,
+                ),
+            );
+        });
+
+        it(`FunctionType`, async () => {
+            const text: string = "type function (a as number, ) as number";
+
+            const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(
+                text,
+            );
+
+            expect(continuationError.message).to.equal(
+                Localization.error_parse_csvContinuation(
+                    Templates.DefaultTemplates,
+                    ParseError.CsvContinuationKind.DanglingComma,
+                ),
+            );
+        });
+
+        it(`RecordExpression`, async () => {
+            const text: string = "[a = 1,]";
+
+            const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(
+                text,
+            );
+
+            expect(continuationError.message).to.equal(
+                Localization.error_parse_csvContinuation(
+                    Templates.DefaultTemplates,
+                    ParseError.CsvContinuationKind.DanglingComma,
+                ),
+            );
+        });
+
+        it(`RecordType`, async () => {
+            const text: string = "type [a = 1,]";
+
+            const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(
+                text,
+            );
+
+            expect(continuationError.message).to.equal(
+                Localization.error_parse_csvContinuation(
+                    Templates.DefaultTemplates,
+                    ParseError.CsvContinuationKind.DanglingComma,
+                ),
+            );
+        });
+
+        it(`TableType`, async () => {
+            const text: string = "type table [a = 1,]";
+
+            const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(
+                text,
+            );
+
+            expect(continuationError.message).to.equal(
+                Localization.error_parse_csvContinuation(
+                    Templates.DefaultTemplates,
+                    ParseError.CsvContinuationKind.DanglingComma,
+                ),
+            );
+        });
     });
 
-    it(`Expected Comma for LetExpression`, async () => {
-        const text: string = "let foo = 1 bar = 1 in foo + bar";
+    describe(`Expected comma`, () => {
+        it(`LetExpression`, async () => {
+            const text: string = "let foo = 1 bar = 1 in foo + bar";
 
-        const innerError: ParseError.TInnerParseError = (
-            await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
-        ).innerError;
+            const innerError: ParseError.TInnerParseError = (
+                await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
+            ).innerError;
 
-        expect(innerError instanceof ParseError.ExpectedCommaOrTokenKind).to.equal(true, innerError.message);
-    });
+            expect(innerError instanceof ParseError.ExpectedClosingTokenKind).to.equal(true, innerError.message);
+        });
 
-    it(`WIP Expected Comma for RecordExpression`, async () => {
-        const text: string = "[foo = 1 bar = 1]";
+        it(`ListExpression`, async () => {
+            const text: string = "{1 2}";
 
-        const innerError: ParseError.TInnerParseError = (
-            await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
-        ).innerError;
+            const innerError: ParseError.TInnerParseError = (
+                await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
+            ).innerError;
 
-        expect(innerError instanceof ParseError.ExpectedCommaOrTokenKind).to.equal(true, innerError.message);
-    });
+            expect(innerError instanceof ParseError.ExpectedClosingTokenKind).to.equal(true, innerError.message);
+        });
 
-    it(`Expected Comma for RecordType`, async () => {
-        const text: string = "type [foo = number bar = number]";
+        it(`RecordExpression`, async () => {
+            const text: string = "[foo = 1 bar = 1]";
 
-        const innerError: ParseError.TInnerParseError = (
-            await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
-        ).innerError;
+            const innerError: ParseError.TInnerParseError = (
+                await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
+            ).innerError;
 
-        expect(innerError instanceof ParseError.ExpectedCommaOrTokenKind).to.equal(true, innerError.message);
-    });
+            expect(innerError instanceof ParseError.ExpectedClosingTokenKind).to.equal(true, innerError.message);
+        });
 
-    it(`Dangling Comma for ListExpression`, async () => {
-        const text: string = "{1, }";
+        it(`RecordLiteral`, async () => {
+            const text: string = "[foo = 1 bar = 2]section baz;";
 
-        const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(text);
+            const innerError: ParseError.TInnerParseError = (
+                await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
+            ).innerError;
 
-        expect(continuationError.message).to.equal(
-            Localization.error_parse_csvContinuation(
-                Templates.DefaultTemplates,
-                ParseError.CsvContinuationKind.DanglingComma,
-            ),
-        );
-    });
+            expect(innerError instanceof ParseError.ExpectedClosingTokenKind).to.equal(true, innerError.message);
+        });
 
-    it(`Dangling Comma for FunctionExpression`, async () => {
-        const text: string = "(a, ) => a";
+        it(`RecordType`, async () => {
+            const text: string = "type [foo = number bar = number]";
 
-        const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(text);
+            const innerError: ParseError.TInnerParseError = (
+                await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
+            ).innerError;
 
-        expect(continuationError.message).to.equal(
-            Localization.error_parse_csvContinuation(
-                Templates.DefaultTemplates,
-                ParseError.CsvContinuationKind.DanglingComma,
-            ),
-        );
-    });
+            expect(innerError instanceof ParseError.ExpectedClosingTokenKind).to.equal(true, innerError.message);
+        });
 
-    it(`Dangling Comma for FunctionType`, async () => {
-        const text: string = "type function (a as number, ) as number";
+        it(`TableType`, async () => {
+            const text: string = "type table [a = 1 b = 2]";
 
-        const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(text);
+            const innerError: ParseError.TInnerParseError = (
+                await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
+            ).innerError;
 
-        expect(continuationError.message).to.equal(
-            Localization.error_parse_csvContinuation(
-                Templates.DefaultTemplates,
-                ParseError.CsvContinuationKind.DanglingComma,
-            ),
-        );
-    });
-
-    it(`Dangling Comma for RecordExpression`, async () => {
-        const text: string = "[a = 1,]";
-
-        const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(text);
-
-        expect(continuationError.message).to.equal(
-            Localization.error_parse_csvContinuation(
-                Templates.DefaultTemplates,
-                ParseError.CsvContinuationKind.DanglingComma,
-            ),
-        );
-    });
-
-    it(`Dangling Comma for RecordType`, async () => {
-        const text: string = "type [a = 1,]";
-
-        const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(text);
-
-        expect(continuationError.message).to.equal(
-            Localization.error_parse_csvContinuation(
-                Templates.DefaultTemplates,
-                ParseError.CsvContinuationKind.DanglingComma,
-            ),
-        );
-    });
-
-    it(`Dangling Comma for TableType`, async () => {
-        const text: string = "type table [a = 1,]";
-
-        const continuationError: ParseError.ExpectedCsvContinuationError = await assertGetCsvContinuationError(text);
-
-        expect(continuationError.message).to.equal(
-            Localization.error_parse_csvContinuation(
-                Templates.DefaultTemplates,
-                ParseError.CsvContinuationKind.DanglingComma,
-            ),
-        );
+            expect(innerError instanceof ParseError.ExpectedClosingTokenKind).to.equal(true, innerError.message);
+        });
     });
 
     it(`catch doesn't allow parameter typing`, async () => {

--- a/src/test/libraryTest/parser/error.ts
+++ b/src/test/libraryTest/parser/error.ts
@@ -139,6 +139,26 @@ describe("Parser.Error", () => {
         expect(innerError instanceof ParseError.ExpectedCommaOrTokenKind).to.equal(true, innerError.message);
     });
 
+    it(`WIP Expected Comma for RecordExpression`, async () => {
+        const text: string = "[foo = 1 bar = 1]";
+
+        const innerError: ParseError.TInnerParseError = (
+            await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
+        ).innerError;
+
+        expect(innerError instanceof ParseError.ExpectedCommaOrTokenKind).to.equal(true, innerError.message);
+    });
+
+    it(`Expected Comma for RecordType`, async () => {
+        const text: string = "type [foo = number bar = number]";
+
+        const innerError: ParseError.TInnerParseError = (
+            await TestAssertUtils.assertGetParseError(DefaultSettingsWithStrict, text)
+        ).innerError;
+
+        expect(innerError instanceof ParseError.ExpectedCommaOrTokenKind).to.equal(true, innerError.message);
+    });
+
     it(`Dangling Comma for ListExpression`, async () => {
         const text: string = "{1, }";
 


### PR DESCRIPTION
Not planning on merging until localization handoff is complete.

* Updated message for scenarios where a CsvArray is terminated. It now suggests a comma could be used as well. For example `let foo = 1 bar = 2 in foo + bar`
* Simplified typing on readKeyValuePair
* Correct the name of the error class InvalidCatchFunction to InvalidCatchFunctionError