### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 442: Build ID 323627

### DIFF
--- a/src/powerquery-parser/localization/templates/template.bg-BG.json
+++ b/src/powerquery-parser/localization/templates/template.bg-BG.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Запетаята не може да предхожда „in“",
   "error_parse_expectAnyTokenKind_1_other": "Очакваше се да се открие едно от следните, но вместо това се откри {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Очакваше се да се открие едно от следните, но вместо това е достигнат краят на потока: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Очаква се да се намери или {localizedComma}, или {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Очакваше се да се открие генерализиран идентификатор",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Очакваше се да се открие генерализиран идентификатор, но пръв беше достигнат краят на потока",
   "error_parse_expectTokenKind_1_other": "Очакваше се да се намери {expectedTokenKind}, но вместо това се откри {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.ca-ES.json
+++ b/src/powerquery-parser/localization/templates/template.ca-ES.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Una coma no pot anar seguida de la preposició \"in\".",
   "error_parse_expectAnyTokenKind_1_other": "S'esperava trobar un dels tipus següents, però s'ha trobat el valor {foundTokenKind}: {expectedAnyTokenKinds}.",
   "error_parse_expectAnyTokenKind_2_endOfStream": "S'esperava trobar un dels tipus següents, però s'ha arribat al final de flux: {expectedAnyTokenKinds}.",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "S'esperava trobar un {localizedComma} o un {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "S'esperava trobar un identificador generalitzat.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "S'esperava trobar un identificador generalitzat, però s'ha arribat al final de flux.",
   "error_parse_expectTokenKind_1_other": "S'esperava trobar un valor {expectedTokenKind}, però s'ha trobat el valor {foundTokenKind}.",

--- a/src/powerquery-parser/localization/templates/template.da-DK.json
+++ b/src/powerquery-parser/localization/templates/template.da-DK.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Et komma kan ikke komme efter et \"in\"",
   "error_parse_expectAnyTokenKind_1_other": "Forventede at finde en af følgende, men der blev fundet en {foundTokenKind} i stedet: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Forventede at finde en af følgende, men slutningen af streamen blev nået i stedet: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Forventede at finde enten en {localizedComma} eller {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Forventede at finde en generaliseret identifikator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Forventede at finde et generaliseret id, men slutningen af streamen er nået først",
   "error_parse_expectTokenKind_1_other": "Forventede at finde en {expectedTokenKind}, men der blev fundet en {foundTokenKind} i stedet for",

--- a/src/powerquery-parser/localization/templates/template.es-ES.json
+++ b/src/powerquery-parser/localization/templates/template.es-ES.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "No puede haber una coma detrás de \"in\".",
   "error_parse_expectAnyTokenKind_1_other": "Se esperaba encontrar uno de los siguientes elementos, pero se ha encontrado {foundTokenKind} en su lugar: {expectedAnyTokenKinds}.",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Se esperaba encontrar uno de los siguientes elementos, pero se ha alcanzado el fin de flujo en su lugar: {expectedAnyTokenKinds}.",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Se esperaba descubrir {localizedComma} o {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Se esperaba encontrar un identificador generalizado.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Se esperaba encontrar un identificador generalizado, pero se ha alcanzado primero el fin de flujo.",
   "error_parse_expectTokenKind_1_other": "Se esperaba encontrar {expectedTokenKind}, pero se ha encontrado {foundTokenKind} en su lugar.",

--- a/src/powerquery-parser/localization/templates/template.et-EE.json
+++ b/src/powerquery-parser/localization/templates/template.et-EE.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Koma ei saa järgneda sõnale 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Eeldati, et leitakse üks järgmistest, kuid selle asemel leiti {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Eeldati, et leitakse üks järgmistest, kuid selle asemel jõudis kätte voo lõpp: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Eeldati, et leitakse kas {localizedComma} või {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Eeldati, et leitakse üldistatud identifikaator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Eeldati, et leitakse üldistatud identifikaator, kuid esimesena jõudis kätte voo lõpp",
   "error_parse_expectTokenKind_1_other": "Eeldati, et leitakse {expectedTokenKind}, kuid selle asemel leiti {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.fi-FI.json
+++ b/src/powerquery-parser/localization/templates/template.fi-FI.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Kohteen 'in' edellä ei voi olla pilkkua",
   "error_parse_expectAnyTokenKind_1_other": "Odotettiin löytyvän yksi seuraavista, mutta {foundTokenKind} löytyi sen sijaan: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Odotettiin löytyvän yksi seuraavista, mutta sen sijaan saavutettiin tietovirran loppu: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Odotettiin löydettävän joko {localizedComma} tai {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Odotettiin löytyvän yleistunniste",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Odotettiin löytyvän yleistunniste, mutta saavutettiin ensin tietovirran loppu",
   "error_parse_expectTokenKind_1_other": "Odotettiin löytyvän {expectedTokenKind}, mutta sen sijaan löytyi {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.hr-HR.json
+++ b/src/powerquery-parser/localization/templates/template.hr-HR.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Zarez ne može stajati ispred 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Očekuje se da će se pronaći jedna od sljedećih vrijednosti, no umjesto toga pronađena je {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Očekivalo se da će se pronaći nešto od sljedećih podataka, ali je dostignut kraj toka: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Očekuje se da se otkrije {localizedComma} ili {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Očekivalo se da će se pronaći poopćeni identifikator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Očekivalo se da će se pronaći poopćeni identifikator, ali je prije toga dostignut kraj toka",
   "error_parse_expectTokenKind_1_other": "Očekivalo se da će se pronaći {expectedTokenKind}, no umjesto toga je pronađena {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.ja-JP.json
+++ b/src/powerquery-parser/localization/templates/template.ja-JP.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "コンマの後に 'in' を使用することはできません",
   "error_parse_expectAnyTokenKind_1_other": "{expectedAnyTokenKinds} のいずれかが必要ですが、{foundTokenKind} が見つかりました。",
   "error_parse_expectAnyTokenKind_2_endOfStream": "{expectedAnyTokenKinds} のいずれかが必要ですが、ストリームの末尾に到達しました。",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "{localizedComma} または {localizedAlternative} のいずれかが必要です。",
   "error_parse_expectGeneralizedIdentifier_1_other": "一般化された識別子が必要です",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "一般化された識別子が必要ですが、最初にストリームの末尾に到達しました",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} が必要ですが、{foundTokenKind} が見つかりました",

--- a/src/powerquery-parser/localization/templates/template.kk-KZ.json
+++ b/src/powerquery-parser/localization/templates/template.kk-KZ.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Үтір 'in' болмауы керек",
   "error_parse_expectAnyTokenKind_1_other": "Мыналардың біреуін табу күтілді, бірақ оның орнына {foundTokenKind} табылды: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Мыналардың біреуін табу күтілді, бірақ оның орнына ағынның соңына жетті: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "{localizedComma} немесе {localizedAlternative} табу күтілген.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Жалпыланған идентификаторды табу күтілді",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Жалпыланған идентификаторды табу күтілді, бірақ алдымен ағынның соңына жетті",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} табу күтілді, бірақ оның орнына {foundTokenKind} табылды",

--- a/src/powerquery-parser/localization/templates/template.ko-KR.json
+++ b/src/powerquery-parser/localization/templates/template.ko-KR.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "'in' 앞에 쉼표가 올 수 없습니다.",
   "error_parse_expectAnyTokenKind_1_other": "{expectedAnyTokenKinds} 중 하나가 필요하나 대신 {foundTokenKind}이(가) 발견되었습니다.",
   "error_parse_expectAnyTokenKind_2_endOfStream": "{expectedAnyTokenKinds} 중 하나가 필요하나 대신 스트림 끝에 도달했습니다.",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "{localizedComma} 또는 {localizedAlternative}을(를) 찾아야 합니다.",
   "error_parse_expectGeneralizedIdentifier_1_other": "일반화된 식별자가 필요합니다.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "일반화된 식별자가 필요하나 먼저 스트림 끝에 도달했습니다.",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind}이(가) 필요하나 {foundTokenKind}이(가) 발견되었습니다.",

--- a/src/powerquery-parser/localization/templates/template.ms-MY.json
+++ b/src/powerquery-parser/localization/templates/template.ms-MY.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Koma tidak boleh meneruskan 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Dijangka menemui satu daripada yang berikut, tetapi {foundTokenKind} telah ditemui bukannya: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Dijangka menemui satu daripada yang berikut, sebaliknya penghujung strim telah dicapai: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Dijangka menemui sama ada {localizedComma} atau {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Dijangka menemui pengecam umum",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Dijangka menemui pengecam umum sebaliknya penghujung strim telah dicapai dahulu",
   "error_parse_expectTokenKind_1_other": "Dijangka menemui {expectedTokenKind}, tetapi {foundTokenKind} telah ditemui sebaliknya",

--- a/src/powerquery-parser/localization/templates/template.nb-NO.json
+++ b/src/powerquery-parser/localization/templates/template.nb-NO.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Et komma kan ikke komme etter 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Forventet å finne en av følgende, men fant en {foundTokenKind} i stedet: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Forventet å finne en av følgende, men slutten på strømmen ble nådd i stedet: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Forventet å finne en {localizedComma} eller {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Forventet å finne en generalisert identifikator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Forventet å finne en generalisert identifikator, men slutten på strømmen ble nådd først",
   "error_parse_expectTokenKind_1_other": "Forventet å finne en {expectedTokenKind}, men fant en {foundTokenKind} i stedet",

--- a/src/powerquery-parser/localization/templates/template.nl-NL.json
+++ b/src/powerquery-parser/localization/templates/template.nl-NL.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Een komma kan geen 'in' uitvoeren",
   "error_parse_expectAnyTokenKind_1_other": "Er wordt een van de volgende typen tokens verwacht, maar er is een {foundTokenKind} gevonden: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Er wordt een van de volgende typen tokens verwacht, maar end-of-stream is bereikt: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Er wordt een {localizedComma} of {localizedAlternative} verwacht.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Er wordt een gegeneraliseerde id verwacht",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Er wordt een gegeneraliseerde id verwacht, maar end-of-stream is het eerst bereikt",
   "error_parse_expectTokenKind_1_other": "Er wordt een {expectedTokenKind} verwacht, maar er is een {foundTokenKind} gevonden",

--- a/src/powerquery-parser/localization/templates/template.pt-PT.json
+++ b/src/powerquery-parser/localization/templates/template.pt-PT.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Uma vírgula não pode estar depois de um 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Era esperado encontrar um dos seguintes, mas, em vez disso, foi encontrado um {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Era esperado encontrar um dos seguintes, mas, em vez disso, o fim de fluxo foi alcançado: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Era esperado encontrar uma {localizedComma} ou {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Era esperado encontrar um identificador generalizado",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Era esperado encontrar um identificador generalizado, mas, em vez disso, o fim de fluxo foi alcançado primeiro",
   "error_parse_expectTokenKind_1_other": "Era esperado encontrar um {expectedTokenKind}, mas, em vez disso, foi encontrado um {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.ro-RO.json
+++ b/src/powerquery-parser/localization/templates/template.ro-RO.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "O virgulă nu poate preceda un 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Se aștepta una dintre următoarele, dar s-a găsit un tip {foundTokenKind} în schimb: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Se aștepta una dintre următoarele, dar s-a atins sfârșitul de flux în schimb: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Se aștepta o {localizedComma} sau o {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Se aștepta un identificator generalizat",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Se aștepta un identificator generalizat, dar s-a atins sfârșitul de flux mai întâi",
   "error_parse_expectTokenKind_1_other": "Se aștepta tipul {expectedTokenKind}, dar s-a găsit un tip {foundTokenKind} în schimb",

--- a/src/powerquery-parser/localization/templates/template.ru-RU.json
+++ b/src/powerquery-parser/localization/templates/template.ru-RU.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Перед 'in' не может идти запятая.",
   "error_parse_expectAnyTokenKind_1_other": "Обнаружено: {foundTokenKind}. Однако ожидалось что-либо из следующего: {expectedAnyTokenKinds}.",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Достигнут конец потока, но ожидалось что-либо из следующего: {expectedAnyTokenKinds}.",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Ожидалось: {localizedComma} или {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Ожидался общий идентификатор.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Ожидался общий идентификатор, но был достигнут конец потока.",
   "error_parse_expectTokenKind_1_other": "Ожидалось: {expectedTokenKind}. Однако обнаружено: {foundTokenKind}.",

--- a/src/powerquery-parser/localization/templates/template.sl-SI.json
+++ b/src/powerquery-parser/localization/templates/template.sl-SI.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Vejica ne sme biti pred 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Najden je bil žeton {foundTokenKind}, vendar je bilo pričakovano, da bo najden eden od teh žetonov: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Dosežen je bil konec toka, vendar je bilo pričakovano, da bo najden eden od teh žetonov: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Pričakovali smo bodisi {localizedComma} bodisi {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Pričakovano je, da bo najden splošni identifikator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Pričakovano je, da bo najden splošni identifikator, vendar je bil najprej dosežen konec toka",
   "error_parse_expectTokenKind_1_other": "Pričakovano je, da bo najden žeton {expectedTokenKind}, vendar je bil najden žeton {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.sr-Cyrl-RS.json
+++ b/src/powerquery-parser/localization/templates/template.sr-Cyrl-RS.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Зарез не може да дође иза 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Требало је да се пронађе нека од следећих ставки, али је пронађено {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Требало је да се пронађе нека од следећих ставки, али се дошло до краја тока: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Очекује се да пронађе или {localizedComma} или {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Требало је да се пронађе генерализовани идентификатор",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Требало је да се пронађе генерализовани идентификатор, али се прво дошло до краја тока",
   "error_parse_expectTokenKind_1_other": "Требало је да се пронађе {expectedTokenKind}, али је пронађено {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.sr-Latn-RS.json
+++ b/src/powerquery-parser/localization/templates/template.sr-Latn-RS.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Zarez ne može da dođe iza 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Trebalo je da se pronađe neka od sledećih stavki, ali je pronađeno {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Trebalo je da se pronađe neka od sledećih stavki, ali se došlo do kraja toka: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Očekuje se da ćete pronaći {localizedComma} ili {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Trebalo je da se pronađe generalizovani identifikator",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Trebalo je da se pronađe generalizovani identifikator, ali se prvo došlo do kraja toka",
   "error_parse_expectTokenKind_1_other": "Trebalo je da se pronađe {expectedTokenKind}, ali je pronađeno {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.sv-SE.json
+++ b/src/powerquery-parser/localization/templates/template.sv-SE.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Ett kommatecken kan inte komma efter en in",
   "error_parse_expectAnyTokenKind_1_other": "Förväntade hitta ett av följande, men en {foundTokenKind} hittades i stället: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Förväntade hitta ett av följande, men slutet på dataströmmen nåddes i stället: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Antingen {localizedComma} eller {localizedAlternative} förväntades.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Förväntade hitta en generaliserad identifierare",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Förväntade hitta en generaliserad identifierare, men slutet på dataströmmen nåddes först",
   "error_parse_expectTokenKind_1_other": "En {expectedTokenKind} förväntades, men en {foundTokenKind} hittades i stället",

--- a/src/powerquery-parser/localization/templates/template.zh-TW.json
+++ b/src/powerquery-parser/localization/templates/template.zh-TW.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "'in' 前面不能有逗號",
   "error_parse_expectAnyTokenKind_1_other": "應找到下列其中一項，卻找到 {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "應找到下列其中一項，但已達資料流結尾: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "必須有 {localizedComma} 或 {localizedAlternative}。",
   "error_parse_expectGeneralizedIdentifier_1_other": "應找到通用識別項",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "應找到通用識別項，但已先達資料流結尾",
   "error_parse_expectTokenKind_1_other": "應找到 {expectedTokenKind}，卻找到 {foundTokenKind}",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.