### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 442: Build ID 324074

### DIFF
--- a/src/powerquery-parser/localization/templates/template.cs-CZ.json
+++ b/src/powerquery-parser/localization/templates/template.cs-CZ.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Před klíčovým slovem in nemůže být čárka.",
   "error_parse_expectAnyTokenKind_1_other": "Očekávalo se, že se najde jedna z následujících hodnot, ale místo ní se našla hodnota {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Očekávalo se, že se najde jedna z následujících hodnot, ale místo ní se dosáhlo konce streamu: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Očekávalo se, že se najde {localizedComma} nebo {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Očekávalo se, že se najde zobecněný identifikátor.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Očekávalo se, že se najde zobecněný identifikátor, ale dosáhlo se konce streamu.",
   "error_parse_expectTokenKind_1_other": "Očekávalo se, že se najde hodnota {expectedTokenKind}, ale místo ní se našlo {foundTokenKind}.",

--- a/src/powerquery-parser/localization/templates/template.de-DE.json
+++ b/src/powerquery-parser/localization/templates/template.de-DE.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Ein Komma darf nicht vor \"in\" stehen",
   "error_parse_expectAnyTokenKind_1_other": "{foundTokenKind} gefunden, aber eines der folgenden Token erwartet: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Streamende erreicht, aber eines der folgenden Token erwartet: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Es wird erwartet, entweder ein {localizedComma} oder {localizedAlternative} zu finden.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Es wurde ein generalisierter Bezeichner erwartet.",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Es wurde ein generalisierter Bezeichner erwartet, aber vorher wurde das Streamende erreicht.",
   "error_parse_expectTokenKind_1_other": "Erwartet: {expectedTokenKind}, gefunden: {foundTokenKind}.",

--- a/src/powerquery-parser/localization/templates/template.el-GR.json
+++ b/src/powerquery-parser/localization/templates/template.el-GR.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Ένα κόμμα δεν είναι δυνατό να προηγείται ενός 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Αναμενόταν να βρεθεί ένα από τα ακόλουθα, αλλά βρέθηκε {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Αναμενόταν να βρεθεί ένα από τα ακόλουθα, αλλά έφτασε το τέλος της ροής: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Αναμενόταν να βρεθεί είτε {localizedComma} είτε {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Αναμενόταν να βρεθεί ένα γενικό αναγνωριστικό",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Αναμενόταν να βρεθεί ένα γενικό αναγνωριστικό, αλλά έφτασε πρώτα το τέλος της ροής",
   "error_parse_expectTokenKind_1_other": "Αναμενόταν να βρεθεί {expectedTokenKind}, αλλά βρέθηκε {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.eu-ES.json
+++ b/src/powerquery-parser/localization/templates/template.eu-ES.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Ezin da idatzi komarik \"in\" eta gero",
   "error_parse_expectAnyTokenKind_1_other": "Token hauetako bat espero zen, baina {foundTokenKind} bat aurkitu da: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Token hauetako bat espero zen, baina korrontearen amaierara iritsi da: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "{localizedComma} edo {localizedAlternative} balioa aurkitzea espero zen.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Identifikatzaile orokor bat espero zen",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Identifikatzaile orokor bat espero zen, baina korrontearen amaierara iritsi da",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} bat espero zen, baina {foundTokenKind} bat aurkitu da",

--- a/src/powerquery-parser/localization/templates/template.gl-ES.json
+++ b/src/powerquery-parser/localization/templates/template.gl-ES.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Un 'in' non pode ir seguido por unha coma",
   "error_parse_expectAnyTokenKind_1_other": "Atopouse un {foundTokenKind}, cando se esperaba atopar un dos seguintes: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Alcanzouse o final do fluxo cando se esperaba atopar un dos seguintes: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Esperábase atopar unha {localizedComma} ou {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Esperábase atopar un identificador xeral",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Esperábase atopar un identificador xeral, pero alcanzouse antes o final do fluxo",
   "error_parse_expectTokenKind_1_other": "Esperábase atopar un {expectedTokenKind}, pero no seu lugar atopouse un {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.hu-HU.json
+++ b/src/powerquery-parser/localization/templates/template.hu-HU.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Egy „in” típusú művelet nem folytatódhat vesszővel",
   "error_parse_expectAnyTokenKind_1_other": "A rendszer a következők egyikének előfordulását várta, de ehelyett a talált elem {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "A rendszer a következők egyikének előfordulását várta, de ehelyett a stream végére ért: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "A várt érték {localizedComma} vagy {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "A rendszer egy általánosított azonosító előfordulását várta",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "A rendszer egy általánosított azonosító előfordulását várta, de előbb ért a stream végére",
   "error_parse_expectTokenKind_1_other": "A rendszer egy {expectedTokenKind} előfordulását várta, de ehelyett a talált elem {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.id-ID.json
+++ b/src/powerquery-parser/localization/templates/template.id-ID.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Koma tidak dapat memproses 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Diharapkan menemukan salah satu dari berikut, tetapi {foundTokenKind} ditemukan sebagai gantinya: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Diharapkan menemukan salah satu dari berikut ini, tetapi akhir aliran tercapai sebagai gantinya: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Diharapkan menemukan {localizedComma} atau {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Diharapkan menemukan pengidentifikasi umum",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Diharapkan menemukan pengidentifikasi umum tetapi akhir aliran telah tercapai terlebih dahulu",
   "error_parse_expectTokenKind_1_other": "Diharapkan menemukan {expectedTokenKind}, tetapi {foundTokenKind} ditemukan sebagai gantinya",

--- a/src/powerquery-parser/localization/templates/template.lt-LT.json
+++ b/src/powerquery-parser/localization/templates/template.lt-LT.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Prieš 'in' negalima dėti kablelio",
   "error_parse_expectAnyTokenKind_1_other": "Tikėtasi rasti vieną iš toliau pateiktų elementų, bet buvo rastas {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Tikėtasi rasti vieną iš toliau nurodytų elementų, bet buvo pasiekta srauto pabaiga: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Tikėtasi rasti {localizedComma} arba {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Tikėtasi rasti apibendrintąjį identifikatorių",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Tikėtasi rasti apibendrintąjį identifikatorių, bet buvo pasiekta srauto pabaiga",
   "error_parse_expectTokenKind_1_other": "Tikėtasi rasti {expectedTokenKind}, bet buvo rastas {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.lv-LV.json
+++ b/src/powerquery-parser/localization/templates/template.lv-LV.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Aiz komata nevar būt 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Tika gaidīts kāds no tālāk norādītajiem, taču tā vietā tika atrasts {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Tika gaidīts kāds no tālāk norādītajiem, taču tā vietā tika sasniegtas straumes beigas: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Tika gaidīts, ka tiks atrasts {localizedComma} vai {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Tika gaidīts, ka tiks atrasts vispārinātais identifikators",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Tika gaidīts, ka tiks atrasts vispārinātais identifikators, bet vispirms tika sasniegtas straumes beigas",
   "error_parse_expectTokenKind_1_other": "Tika gaidīts, ka tiks atrasts: {expectedTokenKind}, bet tā vietā tika atrasts: {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.pl-PL.json
+++ b/src/powerquery-parser/localization/templates/template.pl-PL.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Przecinek nie może poprzedzać operatora 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Znaleziono token {foundTokenKind}, a oczekiwano jednego z następujących tokenów: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Osiągnięto koniec strumienia, a oczekiwano jednego z następujących tokenów: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Oczekiwano znalezienia {localizedComma} lub {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Oczekiwano identyfikatora uogólnionego",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Oczekiwano identyfikatora uogólnionego, ale osiągnięto wcześniej koniec strumienia",
   "error_parse_expectTokenKind_1_other": "Oczekiwano tokenu {expectedTokenKind}, ale znaleziono token {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.pt-BR.json
+++ b/src/powerquery-parser/localization/templates/template.pt-BR.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Uma vírgula não pode anteceder um 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Esperava-se encontrar um dos seguintes itens, mas um {foundTokenKind} foi encontrado no lugar: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Esperava-se encontrar um dos seguintes itens, mas o fim do fluxo foi atingido em vez disso: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Espera-se localizar um {localizedComma} ou {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Esperava-se encontrar um identificador genérico",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Esperava-se encontrar um identificador genérico, mas o fim do fluxo foi alcançado primeiro",
   "error_parse_expectTokenKind_1_other": "Esperava-se encontrar um {expectedTokenKind}, porém, um {foundTokenKind} foi encontrado",

--- a/src/powerquery-parser/localization/templates/template.sk-SK.json
+++ b/src/powerquery-parser/localization/templates/template.sk-SK.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Pred výrazom in nemôže byť čiarka",
   "error_parse_expectAnyTokenKind_1_other": "Očakávalo sa, že sa nájde niektorá z nasledujúcich hodnôt, ale namiesto toho sa našla hodnota {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Očakávalo sa, že sa nájde niektorá z nasledujúcich hodnôt, ale namiesto toho sa dosiahol koniec streamu: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Očakávalo sa, že sa nájde {localizedComma} alebo {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Očakávalo sa, že sa nájde zovšeobecnený identifikátor",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Očakávalo sa, že sa nájde zovšeobecnený identifikátor, ale skôr sa dosiahol koniec streamu",
   "error_parse_expectTokenKind_1_other": "Očakávalo sa, že sa nájde hodnota {expectedTokenKind}, ale namiesto toho sa našla hodnota {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.th-TH.json
+++ b/src/powerquery-parser/localization/templates/template.th-TH.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "เครื่องหมายจุลภาคไม่สามารถดำเนินการต่อ 'in' ได้",
   "error_parse_expectAnyTokenKind_1_other": "ต้องการค้นหาอย่างใดอย่างหนึ่งต่อไปนี้ แต่พบ {foundTokenKind} แทน: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "ต้องการค้นหาอย่างใดอย่างหนึ่งต่อไปนี้ แต่ถึงจุดสิ้นสุดของสตรีมแทน: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "ต้องการค้นหา {localizedComma} หรือ {localizedAlternative}",
   "error_parse_expectGeneralizedIdentifier_1_other": "ต้องการค้นหาตัวระบุทั่วไป",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "ต้องการค้นหาตัวระบุทั่วไปแต่ถึงจุดสิ้นสุดของสตรีมก่อน",
   "error_parse_expectTokenKind_1_other": "ต้องการค้นหา {expectedTokenKind} แต่พบ {foundTokenKind} แทน",

--- a/src/powerquery-parser/localization/templates/template.uk-UA.json
+++ b/src/powerquery-parser/localization/templates/template.uk-UA.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Кома не може слідувати за 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Очікувалося знайти одне з наведеного нижче, але натомість знайдено {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Очікувалося знайти одне з наведеного нижче, але натомість досягнуто кінця потоку: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Очікувалося знайти {localizedComma} або {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Очікувалося знайти узагальнений ідентифікатор",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Очікувалося знайти узагальнений ідентифікатор, але досягнуто кінця потоку",
   "error_parse_expectTokenKind_1_other": "Очікувалося знайти {expectedTokenKind}, але натомість знайдено {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.vi-VN.json
+++ b/src/powerquery-parser/localization/templates/template.vi-VN.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Dấu phẩy không được đứng trước 'in'",
   "error_parse_expectAnyTokenKind_1_other": "Đã dự kiến tìm thấy một trong các đối tượng sau nhưng lại tìm thấy {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Đã dự kiến tìm thấy một trong các đối tượng sau nhưng lại đi đến cuối luồng: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Dự kiến sẽ tìm thấy một {localizedComma} hoặc {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Đã dự kiến tìm thấy mã định danh khái quát",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Đã dự kiến tìm thấy mã định danh khái quát nhưng lại đi đến cuối luồng trước",
   "error_parse_expectTokenKind_1_other": "Đã dự kiến tìm thấy {expectedTokenKind} nhưng lại tìm thấy {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.zh-CN.json
+++ b/src/powerquery-parser/localization/templates/template.zh-CN.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "逗号无法继续执行 'in'",
   "error_parse_expectAnyTokenKind_1_other": "应找到以下项之一，但找到的却是 {foundTokenKind}: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "应找到以下项之一，但却到达了流结尾: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "应查找 {localizedComma} 或 {localizedAlternative}。",
   "error_parse_expectGeneralizedIdentifier_1_other": "应找到通用化标识符",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "应找到通用化标识符，但先到达了流结尾",
   "error_parse_expectTokenKind_1_other": "应找到 {expectedTokenKind}，但找到的却是 {foundTokenKind}",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.