### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 442: Build ID 324395

### DIFF
--- a/src/powerquery-parser/localization/templates/template.fr-FR.json
+++ b/src/powerquery-parser/localization/templates/template.fr-FR.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Une virgule ne peut pas suivre un mot clé « in »",
   "error_parse_expectAnyTokenKind_1_other": "L'un des éléments suivants était attendu, mais un {foundTokenKind} a été trouvé à la place : {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "L'un des éléments suivants était attendu, mais la fin de flux a été atteinte à la place : {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Un {localizedComma} ou un {localizedAlternative} est attendu.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Identificateur généralisé attendu",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Identificateur généralisé attendu, mais la fin de flux a été atteinte en premier",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} attendu, mais un {foundTokenKind} a été trouvé à la place",

--- a/src/powerquery-parser/localization/templates/template.hi-IN.json
+++ b/src/powerquery-parser/localization/templates/template.hi-IN.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "एक अल्पविराम 'in' को जारी नहीं रख सकता",
   "error_parse_expectAnyTokenKind_1_other": "निम्न में से किसी एक के मिलने की अपेक्षा थी, लेकिन इसके बजाय एक {foundTokenKind} मिला: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "निम्न में से किसी एक के मिलने की अपेक्षा थी, लेकिन इसके बजाय एंड-ऑफ़-स्ट्रीम तक पहुँच गए: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "{localizedComma} या {localizedAlternative} मिलने की अपेक्षा की जाती है.",
   "error_parse_expectGeneralizedIdentifier_1_other": "एक सामान्यीकृत आइडेंटिफ़ायर के मिलने की अपेक्षा थी",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "किसी सामान्यीकृत आइडेंटिफ़ायर के मिलने की अपेक्षा थी, लेकिन पहले एंड-ऑफ़-स्ट्रीम तक पहुँच गए",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} के मिलने की अपेक्षा थी, लेकिन इसके बजाय {foundTokenKind} मिला",

--- a/src/powerquery-parser/localization/templates/template.it-IT.json
+++ b/src/powerquery-parser/localization/templates/template.it-IT.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Una virgola non può precedere 'in'",
   "error_parse_expectAnyTokenKind_1_other": "È previsto uno degli elementi seguenti {expectedAnyTokenKinds}, ma invece è stato trovato {foundTokenKind}.",
   "error_parse_expectAnyTokenKind_2_endOfStream": "È previsto uno degli elementi seguenti {expectedAnyTokenKinds}, ma invece è stata raggiunta la fine del flusso",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "È prevista una {localizedComma} o un {localizedAlternative}.",
   "error_parse_expectGeneralizedIdentifier_1_other": "È previsto un identificatore generalizzato",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "È previsto un identificatore generalizzato, ma è prima stata raggiunta la fine del flusso",
   "error_parse_expectTokenKind_1_other": "È previsto un elemento {expectedTokenKind}, ma invece è stato trovato {foundTokenKind}",

--- a/src/powerquery-parser/localization/templates/template.tr-TR.json
+++ b/src/powerquery-parser/localization/templates/template.tr-TR.json
@@ -27,7 +27,7 @@
   "error_parse_csvContinuation_2_letExpression": "Virgülün arkasından 'in' gelemez",
   "error_parse_expectAnyTokenKind_1_other": "Şunlardan birinin bulunması bekleniyordu, ancak bunun yerine bir {foundTokenKind} bulundu: {expectedAnyTokenKinds}",
   "error_parse_expectAnyTokenKind_2_endOfStream": "Şunlardan birinin bulunması bekleniyordu ancak bunun yerine akışın sonuna ulaşıldı: {expectedAnyTokenKinds}",
-  "error_parse_expectedCommaOrTokenKind": "Expected to find either a {localizedComma} or {localizedAlternative}.",
+  "error_parse_expectedCommaOrTokenKind": "Bir {localizedComma} veya {localizedAlternative} bulunması bekleniyor.",
   "error_parse_expectGeneralizedIdentifier_1_other": "Genelleştirilmiş bir tanımlayıcı bulunması bekleniyordu",
   "error_parse_expectGeneralizedIdentifier_2_endOfStream": "Genelleştirilmiş bir tanımlayıcı bulunması bekleniyordu ancak bundan önce akışın sonuna ulaşıldı",
   "error_parse_expectTokenKind_1_other": "{expectedTokenKind} bulunması bekleniyordu, ancak bunun yerine {foundTokenKind} bulundu",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.