### PR TITLE
`time` is now included in M spec's grammar

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -4,7 +4,6 @@ There are a few differences between the [Power Query / M Language Specification]
 
 ## Where the Power Query parser differs from the specification
 
--   An additional primitive type named `time` exists.
 -   An additional primitive type named `action` exists.
 -   The `field-specification` construct requires an `identifier`. Instead `identifer` is replaced with `generalized-identifier`.
 -   The `type` construct matches either `parenthesized-expression` or `primary-type`. Instead `parenthesized-expression` is replaced with `primary-expression`.


### PR DESCRIPTION
`time` is now listed as a _primitive-type_ under the language grammar's [Type expression](https://docs.microsoft.com/en-us/powerquery-m/m-spec-consolidated-grammar#type-expression) section, so no longer needs to be listed as a deviation from the spec.  