### PR TITLE
Removing possibly unneeded spec deviation note

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -8,7 +8,6 @@ There are a few differences between the [Power Query / M Language Specification]
 -   An additional primitive type named `action` exists.
 -   The `field-specification` construct requires an `identifier`. Instead `identifer` is replaced with `generalized-identifier`.
 -   The `type` construct matches either `parenthesized-expression` or `primary-type`. Instead `parenthesized-expression` is replaced with `primary-expression`.
--   The `table-type` construct matches on `row-type`.
 -   An additional match of `primary-expression` is added on the following tokens: `@`, `identifier`, or `left-parenthesis`.
 -   The `identifier` construct was changed so that after a period instead of matching `identifier-start-character` it now matches `identifier-part-character`.
 -   The `generalized-identifier` construct was changed so that `identifier-start-character` was replaced with `identifier-part-character`. It also accepts quoted identifiers.


### PR DESCRIPTION
Currently, in the [spec](https://docs.microsoft.com/en-us/powerquery-m/m-spec-consolidated-grammar#type-expression), `table-type` is defined as follows:
````
table-type:
      "table" row-type
````

Thinking that this aligns with what this deviation note indicates, making it unnecessary as it no longer is a deviation.