### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 442: Build ID 395037

### DIFF
--- a/src/powerquery-parser/localization/templates/template.eu-ES.json
+++ b/src/powerquery-parser/localization/templates/template.eu-ES.json
@@ -1,5 +1,5 @@
 {
-  "error_common_cancellationError": "CancellationError: {reason}",
+  "error_common_cancellationError": "Uzte-errorea: {reason}",
   "error_common_invariantError_1_details": "InvariantError: {invariantBroken} - {details}",
   "error_common_invariantError_2_noDetails": "InvariantError: {invariantBroken}",
   "error_common_unknown": "Errore ezezagun bat aurkitu da. innerError: {innerError}",

--- a/src/powerquery-parser/localization/templates/template.fr-FR.json
+++ b/src/powerquery-parser/localization/templates/template.fr-FR.json
@@ -1,5 +1,5 @@
 {
-  "error_common_cancellationError": "CancellationError: {reason}",
+  "error_common_cancellationError": "CancellationError : {reason}",
   "error_common_invariantError_1_details": "InvariantError : {invariantBroken} - {details}",
   "error_common_invariantError_2_noDetails": "InvariantError : {invariantBroken}",
   "error_common_unknown": "Une erreur inconnue s'est produite, innerError : {innerError}",

--- a/src/powerquery-parser/localization/templates/template.lt-LT.json
+++ b/src/powerquery-parser/localization/templates/template.lt-LT.json
@@ -1,5 +1,5 @@
 {
-  "error_common_cancellationError": "CancellationError: {reason}",
+  "error_common_cancellationError": "Atšaukimo klaida: {reason}",
   "error_common_invariantError_1_details": "InvariantError: {invariantBroken} – {details}",
   "error_common_invariantError_2_noDetails": "InvariantError: {invariantBroken}",
   "error_common_unknown": "Aptikta nežinoma klaida; innerError: {innerError}",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.