### PR TITLE
Updating spec deviations doc to reflect M grammar change: type supports primary-expression

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -6,7 +6,6 @@ There are a few differences between the [Power Query / M Language Specification]
 
 -   An additional primitive type named `action` exists.
 -   The `field-specification` construct requires an `identifier`. Instead `identifer` is replaced with `generalized-identifier`.
--   The `type` construct matches either `parenthesized-expression` or `primary-type`. Instead `parenthesized-expression` is replaced with `primary-expression`.
 -   An additional match of `primary-expression` is added on the following tokens: `@`, `identifier`, or `left-parenthesis`.
 -   The `identifier` construct was changed so that after a period instead of matching `identifier-start-character` it now matches `identifier-part-character`.
 -   The `generalized-identifier` construct was changed so that `identifier-start-character` was replaced with `identifier-part-character`. It also accepts quoted identifiers.


### PR DESCRIPTION
Believe the line removed by this PR is no longer needed as the M language spec has been updated to reflect this case. 

See: https://github.com/MicrosoftDocs/query-docs/commit/a32faee304a92a3abd107d0bd16cd43ab3f52d10