### PR TITLE
Rewrite idUtils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.13.0",
+            "version": "0.13.1",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/mapUtils.ts
+++ b/src/powerquery-parser/common/mapUtils.ts
@@ -7,19 +7,45 @@ export function assertDelete<K, V>(map: Map<K, V>, key: K, message?: string, det
     Assert.isTrue(map.delete(key), message ?? `failed to delete, key is absent`, details ?? { key });
 }
 
-export function assertGet<K, V>(map: Map<K, V>, key: K, message?: string, details?: object): V {
+export function assertGet<K, V>(map: Map<K, V> | ReadonlyMap<K, V>, key: K, message?: string, details?: object): V {
     return Assert.asDefined(map.get(key), message ?? `key not found in given map`, details ?? { key });
 }
 
-export function assertIn<K, V>(map: Map<K, V>, key: K, message?: string): void {
+export function assertIn<K, V>(map: Map<K, V> | ReadonlyMap<K, V>, key: K, message?: string): void {
     Assert.isTrue(map.has(key), message ?? `key is absent`, { key });
 }
 
-export function assertNotIn<K, V>(map: Map<K, V>, key: K, message?: string): void {
+export function assertNotIn<K, V>(map: Map<K, V> | ReadonlyMap<K, V>, key: K, message?: string): void {
     Assert.isFalse(map.has(key), message ?? `key is present`, { key });
 }
 
-export function isEqualMap<K, V>(left: Map<K, V>, right: Map<K, V>, comparer: (left: V, right: V) => boolean): boolean {
+export function filter<K, V>(map: Map<K, V> | ReadonlyMap<K, V>, predicate: (key: K, value: V) => boolean): Map<K, V> {
+    const filtered: Map<K, V> = new Map();
+
+    for (const [key, value] of map.entries()) {
+        if (predicate(key, value)) {
+            filtered.set(key, value);
+        }
+    }
+
+    return filtered;
+}
+
+export function hasKeys<K, V>(map: Map<K, V> | ReadonlyMap<K, V>, keys: ReadonlyArray<K>): boolean {
+    for (const key of keys) {
+        if (!map.has(key)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+export function isEqualMap<K, V>(
+    left: Map<K, V> | ReadonlyMap<K, V>,
+    right: Map<K, V> | ReadonlyMap<K, V>,
+    comparer: (left: V, right: V) => boolean,
+): boolean {
     if (left.size !== right.size) {
         return false;
     }
@@ -36,8 +62,8 @@ export function isEqualMap<K, V>(left: Map<K, V>, right: Map<K, V>, comparer: (l
 }
 
 export function isSubsetMap<K, V>(
-    left: Map<K, V>,
-    right: Map<K, V>,
+    left: Map<K, V> | ReadonlyMap<K, V>,
+    right: Map<K, V> | ReadonlyMap<K, V>,
     comparer: (left: V, right: V) => boolean,
 ): boolean {
     if (left.size > right.size) {
@@ -55,11 +81,7 @@ export function isSubsetMap<K, V>(
     return true;
 }
 
-export function hasCollection<K, V>(map: Map<K, V>, keys: ReadonlyArray<K>): boolean {
-    return keys.map((key: K) => map.has(key)).indexOf(false) === -1;
-}
-
-export function pick<K, V>(map: Map<K, V>, keys: ReadonlyArray<K>): Map<K, V> {
+export function pick<K, V>(map: Map<K, V> | ReadonlyMap<K, V>, keys: ReadonlyArray<K>): Map<K, V> {
     const newMap: Map<K, V> = new Map();
 
     for (const key of keys) {

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -494,7 +494,11 @@ export function iterSection(
 function iterKeyValuePairs<
     Key extends Ast.GeneralizedIdentifier | Ast.Identifier,
     KVP extends TKeyValuePair & IKeyValuePair<Key>,
->(nodeIdMapCollection: NodeIdMap.Collection, arrayWrapper: TXorNode, pairKind: KVP["pairKind"]): ReadonlyArray<KVP> {
+>(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    arrayWrapper: TXorNode,
+    pairKind: TKeyValuePair["pairKind"],
+): ReadonlyArray<KVP> {
     const partial: KVP[] = [];
 
     for (const keyValuePair of iterArrayWrapper(nodeIdMapCollection, arrayWrapper)) {

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
@@ -90,6 +90,7 @@ export function updateNodeIds(
     );
 
     applyCollectionDelta(nodeIdMapCollection, newIdByOldId, xorNodes, partialDelta, traceManager, trace.id);
+
     trace.exit();
 }
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
@@ -23,38 +23,38 @@ export function recalculateIds(
     const trace: Trace = traceManager.entry(IdUtilsTraceConstant.IdUtils, recalculateIds.name, correlationId);
 
     const visitedNodeIds: number[] = [];
-    let currentNodeId: number | undefined = nodeId;
-    let nodeIdStack: number[] = [];
+    let currentId: number | undefined = nodeId;
+    let idStack: number[] = [];
 
-    while (currentNodeId) {
-        visitedNodeIds.push(currentNodeId);
+    while (currentId) {
+        visitedNodeIds.push(currentId);
 
         const childIdsOfCurrentNode: ReadonlyArray<number> | undefined =
-            nodeIdMapCollection.childIdsById.get(currentNodeId);
+            nodeIdMapCollection.childIdsById.get(currentId);
 
         if (childIdsOfCurrentNode) {
-            nodeIdStack = nodeIdStack.concat([...childIdsOfCurrentNode].reverse());
+            idStack = idStack.concat([...childIdsOfCurrentNode].reverse());
         }
 
-        currentNodeId = nodeIdStack.pop();
+        currentId = idStack.pop();
     }
 
-    const numNodeIds: number = visitedNodeIds.length;
-    const sortedNodeIds: ReadonlyArray<number> = [...visitedNodeIds].sort();
-    const newNodeIdByOldNodeId: Map<number, number> = new Map();
+    const numIds: number = visitedNodeIds.length;
+    const sortedIds: ReadonlyArray<number> = [...visitedNodeIds].sort();
+    const newIdByOldId: Map<number, number> = new Map();
 
-    for (let index: number = 0; index < numNodeIds; index += 1) {
-        const oldNodeId: number = visitedNodeIds[index];
-        const newNodeId: number = sortedNodeIds[index];
+    for (let index: number = 0; index < numIds; index += 1) {
+        const oldId: number = visitedNodeIds[index];
+        const newId: number = sortedIds[index];
 
-        if (oldNodeId !== newNodeId) {
-            newNodeIdByOldNodeId.set(oldNodeId, newNodeId);
+        if (oldId !== newId) {
+            newIdByOldId.set(oldId, newId);
         }
     }
 
     trace.exit();
 
-    return newNodeIdByOldNodeId;
+    return newIdByOldId;
 }
 
 // Given a mapping of (existingId) => (newId) this mutates the NodeIdMap.Collection and the TXorNodes it holds.
@@ -224,7 +224,7 @@ function applySmallDelta(
         const oldId: number = xorNode.node.id;
         const newId: number = MapUtils.assertGet(newIdByOldId, oldId);
 
-        // First: mutate the TXorNode's Id to their new Id.
+        // First, mutate the TXorNode's Id to their new Id.
         const mutableNode: TypeScriptUtils.StripReadonly<Ast.TNode | ParseContext.TNode> = xorNode.node;
         mutableNode.id = newId;
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
@@ -22,29 +22,29 @@ export function recalculateIds(
 ): ReadonlyMap<number, number> {
     const trace: Trace = traceManager.entry(IdUtilsTraceConstant.IdUtils, recalculateIds.name, correlationId);
 
-    const visitedNodeIds: number[] = [];
+    const encounteredIds: number[] = [];
     let currentId: number | undefined = nodeId;
-    let idStack: number[] = [];
+    let idQueue: number[] = [];
 
     while (currentId) {
-        visitedNodeIds.push(currentId);
+        encounteredIds.push(currentId);
 
         const childIdsOfCurrentNode: ReadonlyArray<number> | undefined =
             nodeIdMapCollection.childIdsById.get(currentId);
 
         if (childIdsOfCurrentNode) {
-            idStack = idStack.concat([...childIdsOfCurrentNode].reverse());
+            idQueue = childIdsOfCurrentNode.concat(idQueue);
         }
 
-        currentId = idStack.pop();
+        currentId = idQueue.shift();
     }
 
-    const numIds: number = visitedNodeIds.length;
-    const sortedIds: ReadonlyArray<number> = [...visitedNodeIds].sort();
+    const numIds: number = encounteredIds.length;
+    const sortedIds: ReadonlyArray<number> = [...encounteredIds].sort();
     const newIdByOldId: Map<number, number> = new Map();
 
     for (let index: number = 0; index < numIds; index += 1) {
-        const oldId: number = visitedNodeIds[index];
+        const oldId: number = encounteredIds[index];
         const newId: number = sortedIds[index];
 
         if (oldId !== newId) {

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
@@ -89,7 +89,7 @@ export function updateNodeIds(
         trace.id,
     );
 
-    applySmallDelta(nodeIdMapCollection, newIdByOldId, xorNodes, partialDelta, traceManager, trace.id);
+    applyCollectionDelta(nodeIdMapCollection, newIdByOldId, xorNodes, partialDelta, traceManager, trace.id);
     trace.exit();
 }
 
@@ -208,7 +208,7 @@ function createDelta(
     return collectionDelta;
 }
 
-function applySmallDelta(
+function applyCollectionDelta(
     nodeIdMapCollection: Collection,
     newIdByOldId: ReadonlyMap<number, number>,
     xorNodes: ReadonlyArray<TXorNode>,
@@ -216,7 +216,7 @@ function applySmallDelta(
     traceManager: TraceManager,
     correlationId: number,
 ): void {
-    const trace: Trace = traceManager.entry(IdUtilsTraceConstant.IdUtils, applySmallDelta.name, correlationId);
+    const trace: Trace = traceManager.entry(IdUtilsTraceConstant.IdUtils, applyCollectionDelta.name, correlationId);
 
     const newNodeIds: Set<number> = new Set<number>(newIdByOldId.values());
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
@@ -75,7 +75,7 @@ export function updateNodeIds(
         return;
     }
 
-    // We'll be iterating over them twice, so grab them once.
+    // We'll be iterating over them twice (creating delta, applying delta) we'll grab them once.
     const xorNodes: ReadonlyArray<TXorNode> = NodeIdMapIterator.assertIterXor(nodeIdMapCollection, [
         ...newIdByOldId.keys(),
     ]);

--- a/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
+++ b/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
@@ -1045,14 +1045,14 @@ export async function readRecursivePrimaryExpression(
     mutableHead.attributeIndex = 0;
 
     // Recalculate ids after shuffling things around.
-    const newNodeIdByOldNodeId: ReadonlyMap<number, number> = NodeIdMapUtils.recalculateIds(
+    const newIdByOldId: ReadonlyMap<number, number> = NodeIdMapUtils.recalculateIds(
         nodeIdMapCollection,
         MapUtils.assertGet(nodeIdMapCollection.parentIdById, currentContextNode.id),
         state.traceManager,
         trace.id,
     );
 
-    NodeIdMapUtils.updateNodeIds(nodeIdMapCollection, newNodeIdByOldNodeId, state.traceManager, trace.id);
+    NodeIdMapUtils.updateNodeIds(nodeIdMapCollection, newIdByOldId, state.traceManager, trace.id);
 
     // Begin normal parsing.
     const recursiveArrayNodeKind: Ast.NodeKind.ArrayWrapper = Ast.NodeKind.ArrayWrapper;

--- a/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
+++ b/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
@@ -1045,12 +1045,9 @@ export async function readRecursivePrimaryExpression(
     mutableHead.attributeIndex = 0;
 
     // Recalculate ids after shuffling things around.
-    const newNodeIdByOldNodeId: Map<number, number> = NodeIdMapUtils.recalculateIds(
+    const newNodeIdByOldNodeId: ReadonlyMap<number, number> = NodeIdMapUtils.recalculateIds(
         nodeIdMapCollection,
-        NodeIdMapUtils.assertXor(
-            nodeIdMapCollection,
-            MapUtils.assertGet(nodeIdMapCollection.parentIdById, currentContextNode.id),
-        ),
+        MapUtils.assertGet(nodeIdMapCollection.parentIdById, currentContextNode.id),
         state.traceManager,
         trace.id,
     );


### PR DESCRIPTION
Updates the file `idUtils` with some new patterns and hardens the validations. Preps the codebase for a follow-up PR which will make the RecursivePrimaryExpression weirdness more re-usable.