### PR TITLE
Add ParseStateUtils.startContextAsParent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.13.1",
+            "version": "0.13.2",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/arrayUtils.ts
+++ b/src/powerquery-parser/common/arrayUtils.ts
@@ -16,15 +16,15 @@ export function all<T>(
     return true;
 }
 
+export function assertGet<T>(collection: ReadonlyArray<T>, index: number, message?: string, details?: object): T {
+    return Assert.asDefined(collection[index], message, details);
+}
+
 export function assertIn<T>(collection: ReadonlyArray<T>, item: T, message?: string, details?: object): number {
     const index: number = collection.indexOf(item);
     Assert.isTrue(index !== -1, message, details ?? { item });
 
     return index;
-}
-
-export function assertGet<T>(collection: ReadonlyArray<T>, index: number, message?: string, details?: object): T {
-    return Assert.asDefined(collection[index], message, details);
 }
 
 export function assertIndexOfPredicate<T>(
@@ -47,6 +47,32 @@ export function assertNonZeroLength<T>(collection: ReadonlyArray<T>, message?: s
             collectionLength: collection.length,
         },
     );
+}
+
+export function assertReplaceAtIndex<T>(collection: ReadonlyArray<T>, value: T, index: number): T[] {
+    Assert.isFalse(index < 0 || index >= collection.length, "index < 0 || index >= collection.length", {
+        index,
+        collectionLength: collection.length,
+    });
+
+    return [...collection.slice(0, index), value, ...collection.slice(index + 1)];
+}
+
+export function assertRemoveFirstInstance<T>(collection: ReadonlyArray<T>, element: T): T[] {
+    return assertRemoveAtIndex(collection, collection.indexOf(element));
+}
+
+export function assertReplaceFirstInstance<T>(collection: ReadonlyArray<T>, oldValue: T, newValue: T): T[] {
+    return assertReplaceAtIndex(collection, newValue, collection.indexOf(oldValue));
+}
+
+export function assertRemoveAtIndex<T>(collection: ReadonlyArray<T>, index: number): T[] {
+    Assert.isFalse(index < 0 || index >= collection.length, "index < 0 || index >= collection.length", {
+        index,
+        collectionLength: collection.length,
+    });
+
+    return [...collection.slice(0, index), ...collection.slice(index + 1)];
 }
 
 export async function mapAsync<T, U>(
@@ -150,32 +176,6 @@ export function isSubset<T>(
 export function range(size: number, startAt: number = 0): ReadonlyArray<number> {
     // tslint:disable-next-line: prefer-array-literal
     return [...Array(size).keys()].map((index: number) => index + startAt);
-}
-
-export function replaceAtIndex<T>(collection: ReadonlyArray<T>, value: T, index: number): T[] {
-    Assert.isFalse(index < 0 || index >= collection.length, "index < 0 || index >= collection.length", {
-        index,
-        collectionLength: collection.length,
-    });
-
-    return [...collection.slice(0, index), value, ...collection.slice(index + 1)];
-}
-
-export function removeFirstInstance<T>(collection: ReadonlyArray<T>, element: T): T[] {
-    return removeAtIndex(collection, collection.indexOf(element));
-}
-
-export function replaceFirstInstance<T>(collection: ReadonlyArray<T>, oldValue: T, newValue: T): T[] {
-    return replaceAtIndex(collection, newValue, collection.indexOf(oldValue));
-}
-
-export function removeAtIndex<T>(collection: ReadonlyArray<T>, index: number): T[] {
-    Assert.isFalse(index < 0 || index >= collection.length, "index < 0 || index >= collection.length", {
-        index,
-        collectionLength: collection.length,
-    });
-
-    return [...collection.slice(0, index), ...collection.slice(index + 1)];
 }
 
 export function split<T>(

--- a/src/powerquery-parser/common/orderedMap.ts
+++ b/src/powerquery-parser/common/orderedMap.ts
@@ -39,7 +39,7 @@ export class OrderedMap<K, V> implements Map<K, V> {
 
     public delete(key: K): boolean {
         if (this.map.delete(key)) {
-            this.order = ArrayUtils.removeFirstInstance(this.order, key);
+            this.order = ArrayUtils.assertRemoveFirstInstance(this.order, key);
 
             return true;
         } else {
@@ -74,7 +74,7 @@ export class OrderedMap<K, V> implements Map<K, V> {
     public set(key: K, value: V, maintainIndex?: boolean): this {
         if (this.has(key)) {
             if (!maintainIndex) {
-                this.order = [...ArrayUtils.removeFirstInstance(this.order, key), key];
+                this.order = [...ArrayUtils.assertRemoveFirstInstance(this.order, key), key];
             }
         } else {
             this.order = [...this.order, key];

--- a/src/powerquery-parser/lexer/lexer.ts
+++ b/src/powerquery-parser/lexer/lexer.ts
@@ -419,7 +419,7 @@ function deleteLine(state: State, lineNumber: number): State {
 
     return {
         ...state,
-        lines: ArrayUtils.removeAtIndex(state.lines, lineNumber),
+        lines: ArrayUtils.assertRemoveAtIndex(state.lines, lineNumber),
     };
 }
 

--- a/src/powerquery-parser/parser/context/contextUtils.ts
+++ b/src/powerquery-parser/parser/context/contextUtils.ts
@@ -4,7 +4,7 @@
 import { ArrayUtils, Assert, CommonError, MapUtils, SetUtils, TypeScriptUtils } from "../../common";
 import { Ast, Token } from "../../language";
 import { NodeIdMap, ParseContext } from "..";
-import { NodeIdMapUtils, TXorNode } from "../nodeIdMap";
+import { NodeIdMapUtils, TXorNode, XorNodeKind } from "../nodeIdMap";
 
 export function assertAsNodeKind<T extends Ast.TNode>(
     node: ParseContext.TNode,
@@ -77,7 +77,7 @@ export function nextAttributeIndex(parentNode: ParseContext.TNode): number {
 
 export function startContext<T extends Ast.TNode>(
     state: ParseContext.State,
-    nodeKind: Ast.NodeKind,
+    nodeKind: T["kind"],
     tokenIndexStart: number,
     tokenStart: Token.Token | undefined,
     parentNode: ParseContext.TNode | undefined,
@@ -120,16 +120,86 @@ export function startContext<T extends Ast.TNode>(
         state.root = contextNode;
     }
 
-    const idsByNodeKind: NodeIdMap.IdsByNodeKind = nodeIdMapCollection.idsByNodeKind;
-    const idsForSpecificNodeKind: Set<number> | undefined = idsByNodeKind.get(nodeKind);
-
-    if (idsForSpecificNodeKind) {
-        idsForSpecificNodeKind.add(nodeId);
-    } else {
-        idsByNodeKind.set(nodeKind, new Set([nodeId]));
-    }
+    trackNodeIdByNodeKind(nodeIdMapCollection.idsByNodeKind, nodeKind, nodeId);
 
     return contextNode;
+}
+
+// Note:
+// This doesn't hold the Id invariant where a parent's Id is always less than its children's Ids.
+// To maintain that invariant the caller needs to also call:
+//  - NodeIdMapUtils.recalculateIds
+//  - NodeIdMapUtils.updateNodeIds
+export function startContextAsParent<T extends Ast.TNode>(
+    state: ParseContext.State,
+    nodeKind: T["kind"],
+    existingNodeId: number,
+    existingNodeTokenStart: Token.Token | undefined,
+): ParseContext.Node<T> {
+    const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
+    const existingNode: TXorNode = NodeIdMapUtils.assertXor(nodeIdMapCollection, existingNodeId);
+
+    let tokenIndexStart: number;
+    let attributeIndex: number | undefined;
+
+    // Update `attributeIndex` as we're inserting a new context as the parent of the existing node.
+    switch (existingNode.kind) {
+        case XorNodeKind.Ast: {
+            tokenIndexStart = existingNode.node.tokenRange.tokenIndexStart;
+            attributeIndex = existingNode.node.attributeIndex;
+
+            const mutableAst: TypeScriptUtils.StripReadonly<Ast.TNode> = existingNode.node;
+            mutableAst.attributeIndex = 0;
+
+            break;
+        }
+
+        case XorNodeKind.Context:
+            tokenIndexStart = existingNode.node.tokenIndexStart;
+            attributeIndex = existingNode.node.attributeIndex;
+
+            existingNode.node.attributeIndex = 0;
+            break;
+
+        default:
+            throw Assert.isNever(existingNode);
+    }
+
+    const newNodeId: number = nextId(state);
+
+    const insertedContext: ParseContext.Node<T> = {
+        id: newNodeId,
+        kind: nodeKind,
+        tokenIndexStart,
+        tokenStart: existingNodeTokenStart,
+        // We want to create a new context containing an existing node,
+        // so attributeCounter must be 1 as it holds the existing node.
+        attributeCounter: 1,
+        isClosed: false,
+        attributeIndex,
+    };
+
+    nodeIdMapCollection.contextNodeById.set(newNodeId, insertedContext);
+    trackNodeIdByNodeKind(nodeIdMapCollection.idsByNodeKind, nodeKind, newNodeId);
+
+    // We have one of two possible states, either:
+    //  1) grandparent <-> new <-> existing
+    //  2) new <-> existing.
+
+    // Scenario (1)
+    const grandparentNodeId: number | undefined = nodeIdMapCollection.parentIdById.get(existingNodeId);
+
+    if (grandparentNodeId) {
+        // Update `grandparent <-> existing` with `grandparent <-> new`
+        removeOrReplaceChildId(nodeIdMapCollection, grandparentNodeId, existingNodeId, newNodeId);
+    }
+
+    // Applicable to Scenario (1) and (2)
+    // Create `new <-> existing`
+    nodeIdMapCollection.parentIdById.set(existingNodeId, newNodeId);
+    nodeIdMapCollection.childIdsById.set(newNodeId, [existingNodeId]);
+
+    return insertedContext;
 }
 
 // Returns the Node's parent context (if one exists).
@@ -253,19 +323,19 @@ export function deleteAst(state: ParseContext.State, nodeId: number, parentWillB
 
 export function deleteContext(state: ParseContext.State, nodeId: number): ParseContext.TNode | undefined {
     const nodeIdMapCollection: NodeIdMap.Collection = state.nodeIdMapCollection;
-
     const childIdsById: NodeIdMap.ChildIdsById = nodeIdMapCollection.childIdsById;
     const contextNodeById: NodeIdMap.ContextNodeById = nodeIdMapCollection.contextNodeById;
     const leafIds: Set<number> = nodeIdMapCollection.leafIds;
     const parentIdById: NodeIdMap.ParentIdById = nodeIdMapCollection.parentIdById;
 
-    const contextNode: ParseContext.TNode | undefined = contextNodeById.get(nodeId);
-
-    if (contextNode === undefined) {
-        throw new CommonError.InvariantError(`failed to deleteContext as the given nodeId isn't a valid context node`, {
+    const contextNode: ParseContext.TNode | undefined = MapUtils.assertGet(
+        contextNodeById,
+        nodeId,
+        `failed to deleteContext as the given nodeId isn't a valid context node`,
+        {
             nodeId,
-        });
-    }
+        },
+    );
 
     const parentId: number | undefined = parentIdById.get(nodeId);
     const childIds: ReadonlyArray<number> | undefined = childIdsById.get(nodeId);
@@ -315,6 +385,16 @@ export function deleteContext(state: ParseContext.State, nodeId: number): ParseC
     return parentId !== undefined ? NodeIdMapUtils.assertContext(nodeIdMapCollection, parentId) : undefined;
 }
 
+function trackNodeIdByNodeKind(idsByNodeKind: NodeIdMap.IdsByNodeKind, nodeKind: Ast.NodeKind, nodeId: number): void {
+    const idsForSpecificNodeKind: Set<number> | undefined = idsByNodeKind.get(nodeKind);
+
+    if (idsForSpecificNodeKind) {
+        idsForSpecificNodeKind.add(nodeId);
+    } else {
+        idsByNodeKind.set(nodeKind, new Set([nodeId]));
+    }
+}
+
 function deleteFromKindMap(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): void {
     const idsByNodeKind: NodeIdMap.IdsByNodeKind = nodeIdMapCollection.idsByNodeKind;
 
@@ -337,6 +417,9 @@ function deleteFromKindMap(nodeIdMapCollection: NodeIdMap.Collection, nodeId: nu
     }
 }
 
+// Asserts `childId` is in the list of children in for `parentId`.
+// Either removes `childId` in its list of children if no `replcementId` is given,
+// else replaces the `childId` with `replacementId`.
 function removeOrReplaceChildId(
     nodeIdMapCollection: NodeIdMap.Collection,
     parentId: number,
@@ -346,36 +429,16 @@ function removeOrReplaceChildId(
     const childIdsById: NodeIdMap.ChildIdsById = nodeIdMapCollection.childIdsById;
     const childIds: ReadonlyArray<number> = NodeIdMapUtils.assertChildIds(childIdsById, parentId);
 
-    const replacementIndex: number = ArrayUtils.assertIn(
-        childIds,
-        childId,
-        `failed to removeOrReplaceChildId as childId isn't a child of parentId`,
-        {
-            childId,
-            parentId,
-        },
-    );
-
-    const beforeChildId: ReadonlyArray<number> = childIds.slice(0, replacementIndex);
-    const afterChildId: ReadonlyArray<number> = childIds.slice(replacementIndex + 1);
-
-    let newChildIds: ReadonlyArray<number> | undefined;
+    let newChildIds: ReadonlyArray<number>;
 
     if (replacementId) {
         nodeIdMapCollection.parentIdById.set(replacementId, parentId);
-
-        if (childIds.length === 1) {
-            newChildIds = [replacementId];
-        } else {
-            newChildIds = [...beforeChildId, replacementId, ...afterChildId];
-        }
-    } else if (childIds.length === 1) {
-        newChildIds = undefined;
+        newChildIds = ArrayUtils.assertReplaceFirstInstance(childIds, childId, replacementId);
     } else {
-        newChildIds = [...beforeChildId, ...afterChildId];
+        newChildIds = ArrayUtils.assertRemoveFirstInstance(childIds, childId);
     }
 
-    if (newChildIds) {
+    if (newChildIds.length) {
         childIdsById.set(parentId, newChildIds);
     } else {
         childIdsById.delete(parentId);

--- a/src/powerquery-parser/parser/parsers/combinatorialParser.ts
+++ b/src/powerquery-parser/parser/parsers/combinatorialParser.ts
@@ -283,8 +283,8 @@ async function readBinOpExpression(
             right,
         } as Ast.TBinOpExpression;
 
-        operators = ArrayUtils.removeAtIndex(operators, minPrecedenceIndex);
-        operatorConstants = ArrayUtils.removeAtIndex(operatorConstants, minPrecedenceIndex);
+        operators = ArrayUtils.assertRemoveAtIndex(operators, minPrecedenceIndex);
+        operatorConstants = ArrayUtils.assertRemoveAtIndex(operatorConstants, minPrecedenceIndex);
 
         expressions = expressions = [
             ...expressions.slice(0, minPrecedenceIndex),
@@ -313,14 +313,17 @@ async function readBinOpExpression(
 
         // All TUnaryExpression and operatorConstants start by being placed under the context node.
         // They need to be removed for deleteContext(placeholderContextId) to succeed.
-        placeholderContextChildren = ArrayUtils.removeFirstInstance(placeholderContextChildren, operatorConstant.id);
+        placeholderContextChildren = ArrayUtils.assertRemoveFirstInstance(
+            placeholderContextChildren,
+            operatorConstant.id,
+        );
 
         if (left.id <= newNodeThreshold) {
-            placeholderContextChildren = ArrayUtils.removeFirstInstance(placeholderContextChildren, left.id);
+            placeholderContextChildren = ArrayUtils.assertRemoveFirstInstance(placeholderContextChildren, left.id);
         }
 
         if (right.id <= newNodeThreshold) {
-            placeholderContextChildren = ArrayUtils.removeFirstInstance(placeholderContextChildren, right.id);
+            placeholderContextChildren = ArrayUtils.assertRemoveFirstInstance(placeholderContextChildren, right.id);
         }
 
         nodeIdMapCollection.childIdsById.set(placeholderContextId, placeholderContextChildren);

--- a/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
+++ b/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ArrayUtils, Assert, CommonError, MapUtils, Result, ResultUtils, TypeScriptUtils } from "../../common";
+import { Assert, CommonError, Result, ResultUtils } from "../../common";
 import { Ast, AstUtils, Constant, ConstantUtils, TextUtils, Token } from "../../language";
 import { Disambiguation, DisambiguationUtils } from "../disambiguation";
-import { NodeIdMap, ParseContext, ParseContextUtils, ParseError } from "..";
+import { ParseContext, ParseContextUtils, ParseError } from "..";
 import { Parser, ParseStateCheckpoint } from "../parser";
 import { ParseState, ParseStateUtils } from "../parseState";
 import { Trace, TraceConstant } from "../../common/trace";
 import { LexerSnapshot } from "../../lexer";
-import { NodeIdMapUtils } from "../nodeIdMap";
 import { TokenKind } from "../../language/token";
 
 const enum NaiveTraceConstant {
@@ -1012,49 +1011,9 @@ export async function readRecursivePrimaryExpression(
     );
 
     state.cancellationToken?.throwIfCancelled();
-    ParseStateUtils.startContext(state, nodeKind);
 
-    const nodeIdMapCollection: NodeIdMap.Collection = state.contextState.nodeIdMapCollection;
+    state.currentContextNode = ParseStateUtils.startContextAsParent(state, nodeKind, head.id, trace.id);
 
-    const currentContextNode: ParseContext.TNode = Assert.asDefined(
-        state.currentContextNode,
-        "state.currentContextNode",
-    );
-
-    // Update parent attributes.
-    const parentOfHeadId: number = MapUtils.assertGet(nodeIdMapCollection.parentIdById, head.id);
-
-    nodeIdMapCollection.childIdsById.set(
-        parentOfHeadId,
-        ArrayUtils.removeFirstInstance(MapUtils.assertGet(nodeIdMapCollection.childIdsById, parentOfHeadId), head.id),
-    );
-
-    nodeIdMapCollection.childIdsById.set(currentContextNode.id, [head.id]);
-    nodeIdMapCollection.parentIdById.set(head.id, currentContextNode.id);
-
-    const newTokenIndexStart: number = head.tokenRange.tokenIndexStart;
-    const mutableContext: TypeScriptUtils.StripReadonly<ParseContext.TNode> = currentContextNode;
-    const mutableHead: TypeScriptUtils.StripReadonly<Ast.TPrimaryExpression> = head;
-
-    // Update token start to match the first parsed node under it, aka the head.
-    mutableContext.tokenStart = state.lexerSnapshot.tokens[newTokenIndexStart];
-    mutableContext.tokenIndexStart = newTokenIndexStart;
-
-    // Update attribute counters.
-    mutableContext.attributeCounter = 1;
-    mutableHead.attributeIndex = 0;
-
-    // Recalculate ids after shuffling things around.
-    const newIdByOldId: ReadonlyMap<number, number> = NodeIdMapUtils.recalculateIds(
-        nodeIdMapCollection,
-        MapUtils.assertGet(nodeIdMapCollection.parentIdById, currentContextNode.id),
-        state.traceManager,
-        trace.id,
-    );
-
-    NodeIdMapUtils.updateNodeIds(nodeIdMapCollection, newIdByOldId, state.traceManager, trace.id);
-
-    // Begin normal parsing.
     const recursiveArrayNodeKind: Ast.NodeKind.ArrayWrapper = Ast.NodeKind.ArrayWrapper;
     ParseStateUtils.startContext(state, recursiveArrayNodeKind);
 


### PR DESCRIPTION
Refactors the one-off work in RecursivePrimaryExpression which inserts a parent context into something re-usable. This will be consumed later in regards to how IsExpression and AsExpression are parsed.