### PR TITLE
Update AsExpression and IsExpression to match formal spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.13.3",
+    "version": "0.13.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.13.3",
+            "version": "0.13.4",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.13.3",
+    "version": "0.13.4",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/typeScriptTypeUtils.ts
+++ b/src/powerquery-parser/common/typeScriptTypeUtils.ts
@@ -1,13 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export type ExtractFirstGenericType<T> = T extends Generic<infer U> ? U : never;
-
 // removes `readonly` from T's attributes
 export type StripReadonly<T> = { -readonly [K in keyof T]: T[K] };
 
 export function isDefined<T>(x: T | undefined): x is T {
     return x !== undefined;
 }
-
-type Generic<T> = { value: T };

--- a/src/powerquery-parser/common/typeScriptTypeUtils.ts
+++ b/src/powerquery-parser/common/typeScriptTypeUtils.ts
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+export type ExtractFirstGenericType<T> = T extends Generic<infer U> ? U : never;
+
 // removes `readonly` from T's attributes
 export type StripReadonly<T> = { -readonly [K in keyof T]: T[K] };
 
 export function isDefined<T>(x: T | undefined): x is T {
     return x !== undefined;
 }
+
+type Generic<T> = { value: T };

--- a/src/powerquery-parser/language/ast/ast.ts
+++ b/src/powerquery-parser/language/ast/ast.ts
@@ -741,7 +741,7 @@ export type ArithmeticExpression = IBinOpExpression<
 
 export type AsExpression = IBinOpExpression<
     NodeKind.AsExpression,
-    TEqualityExpression,
+    TAsExpression,
     Constant.KeywordConstant.As,
     TNullablePrimitiveType
 >;
@@ -755,7 +755,7 @@ export type EqualityExpression = IBinOpExpression<
 
 export type IsExpression = IBinOpExpression<
     NodeKind.IsExpression,
-    TAsExpression,
+    TIsExpression,
     Constant.KeywordConstant.Is,
     TNullablePrimitiveType
 >;

--- a/src/powerquery-parser/parser/context/contextUtils.ts
+++ b/src/powerquery-parser/parser/context/contextUtils.ts
@@ -332,9 +332,7 @@ export function deleteContext(state: ParseContext.State, nodeId: number): ParseC
         contextNodeById,
         nodeId,
         `failed to deleteContext as the given nodeId isn't a valid context node`,
-        {
-            nodeId,
-        },
+        { nodeId },
     );
 
     const parentId: number | undefined = parentIdById.get(nodeId);

--- a/src/powerquery-parser/parser/parseState/parseStateUtils.ts
+++ b/src/powerquery-parser/parser/parseState/parseStateUtils.ts
@@ -133,7 +133,7 @@ export function endContext<T extends Ast.TNode>(state: ParseState, astNode: T): 
     state.currentContextNode = parentOfContextNode;
 }
 
-export function deleteContext(state: ParseState, nodeId: number | undefined): void {
+export function deleteContext(state: ParseState, nodeId?: number): void {
     if (nodeId === undefined) {
         nodeId = Assert.asDefined(state.currentContextNode, `can't delete a context if one doesn't exist`).id;
     }

--- a/src/powerquery-parser/parser/parsers/combinatorialParser.ts
+++ b/src/powerquery-parser/parser/parsers/combinatorialParser.ts
@@ -50,12 +50,10 @@ export const CombinatorialParser: Parser = {
             correlationId,
         ) as Promise<Ast.TLogicalExpression>,
 
-    readIsExpression: (state: ParseState, parser: Parser, correlationId: number | undefined) =>
-        readBinOpExpression(state, parser, Ast.NodeKind.IsExpression, correlationId) as Promise<Ast.TIsExpression>,
+    readIsExpression: NaiveParseSteps.readIsExpression,
     readNullablePrimitiveType: NaiveParseSteps.readNullablePrimitiveType,
 
-    readAsExpression: (state: ParseState, parser: Parser, correlationId: number | undefined) =>
-        readBinOpExpression(state, parser, Ast.NodeKind.AsExpression, correlationId) as Promise<Ast.TAsExpression>,
+    readAsExpression: NaiveParseSteps.readAsExpression,
 
     readEqualityExpression: (state: ParseState, parser: Parser, correlationId: number | undefined) =>
         readBinOpExpression(
@@ -214,7 +212,7 @@ async function readBinOpExpression(
 
     // There was a single TUnaryExpression, not a TBinOpExpression.
     if (expressions.length === 1) {
-        ParseStateUtils.deleteContext(state, undefined);
+        ParseStateUtils.deleteContext(state);
         trace.exit();
 
         return expressions[0];

--- a/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
+++ b/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
@@ -91,9 +91,7 @@ export async function readGeneralizedIdentifier(
         NaiveTraceConstant.Parse,
         readGeneralizedIdentifier.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     ParseStateUtils.startContext(state, nodeKind);
@@ -441,9 +439,7 @@ export async function readNullCoalescingExpression(
         NaiveTraceConstant.Parse,
         readNullCoalescingExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -567,18 +563,17 @@ export async function readIsExpression(
 
     state.cancellationToken?.throwIfCancelled();
 
-    const isExpression: Ast.TIsExpression = await recursiveReadBinOpExpression<
-        Ast.NodeKind.IsExpression,
-        Ast.TAsExpression,
-        Constant.KeywordConstant.Is,
-        Ast.TNullablePrimitiveType
+    const isExpression: Ast.TIsExpression = await readRecursivelyEitherAsExpressionOrIsExpression<
+        Ast.IsExpression,
+        TokenKind.KeywordIs
     >(
         state,
         Ast.NodeKind.IsExpression,
-        () => parser.readAsExpression(state, parser, trace.id),
-        (currentTokenKind: TokenKind | undefined) =>
-            currentTokenKind === TokenKind.KeywordIs ? Constant.KeywordConstant.Is : undefined,
-        () => parser.readNullablePrimitiveType(state, parser, trace.id),
+        TokenKind.KeywordIs,
+        (correlationId: number | undefined) => parser.readAsExpression(state, parser, correlationId),
+        (tokenKind: TokenKind.KeywordIs, correlationId: number | undefined) =>
+            readTokenKindAsConstant(state, tokenKind, Constant.KeywordConstant.Is, correlationId),
+        (correlationId: number) => parser.readNullablePrimitiveType(state, parser, correlationId),
         trace.id,
     );
 
@@ -597,9 +592,7 @@ export async function readNullablePrimitiveType(
         NaiveTraceConstant.Parse,
         readNullablePrimitiveType.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -638,18 +631,17 @@ export async function readAsExpression(
 
     state.cancellationToken?.throwIfCancelled();
 
-    const asExpression: Ast.TAsExpression = await recursiveReadBinOpExpression<
-        Ast.NodeKind.AsExpression,
-        Ast.TEqualityExpression,
-        Constant.KeywordConstant.As,
-        Ast.TNullablePrimitiveType
+    const asExpression: Ast.TAsExpression = await readRecursivelyEitherAsExpressionOrIsExpression<
+        Ast.AsExpression,
+        TokenKind.KeywordAs
     >(
         state,
         Ast.NodeKind.AsExpression,
-        () => parser.readEqualityExpression(state, parser, trace.id),
-        (currentTokenKind: TokenKind | undefined) =>
-            currentTokenKind === TokenKind.KeywordAs ? Constant.KeywordConstant.As : undefined,
-        () => parser.readNullablePrimitiveType(state, parser, trace.id),
+        TokenKind.KeywordAs,
+        (correlationId: number | undefined) => parser.readEqualityExpression(state, parser, correlationId),
+        (tokenKind: TokenKind.KeywordAs, correlationId: number | undefined) =>
+            readTokenKindAsConstant(state, tokenKind, Constant.KeywordConstant.As, correlationId),
+        (correlationId: number) => parser.readNullablePrimitiveType(state, parser, correlationId),
         trace.id,
     );
 
@@ -671,9 +663,7 @@ export async function readEqualityExpression(
         NaiveTraceConstant.Parse,
         readEqualityExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -710,9 +700,7 @@ export async function readRelationalExpression(
         NaiveTraceConstant.Parse,
         readRelationalExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -749,9 +737,7 @@ export async function readArithmeticExpression(
         NaiveTraceConstant.Parse,
         readArithmeticExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -790,9 +776,7 @@ export async function readMetadataExpression(
         NaiveTraceConstant.Parse,
         readMetadataExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -828,7 +812,7 @@ export async function readMetadataExpression(
 
         return metadataExpression;
     } else {
-        ParseStateUtils.deleteContext(state, undefined);
+        ParseStateUtils.deleteContext(state);
 
         trace.exit({
             [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
@@ -1005,9 +989,7 @@ export async function readRecursivePrimaryExpression(
         NaiveTraceConstant.Parse,
         readRecursivePrimaryExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -1156,9 +1138,7 @@ export function readIdentifierExpression(
         NaiveTraceConstant.Parse,
         readIdentifierExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -1196,9 +1176,7 @@ export async function readParenthesizedExpression(
         NaiveTraceConstant.Parse,
         readParenthesizedExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -1245,9 +1223,7 @@ export function readNotImplementedExpression(
         NaiveTraceConstant.Parse,
         readNotImplementedExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -1410,7 +1386,7 @@ export async function readListItem(
 
         return rangeExpression;
     } else {
-        ParseStateUtils.deleteContext(state, undefined);
+        ParseStateUtils.deleteContext(state);
 
         trace.exit({
             [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
@@ -1479,9 +1455,7 @@ export async function readItemAccessExpression(
         NaiveTraceConstant.Parse,
         readItemAccessExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -1597,9 +1571,7 @@ export async function readFunctionExpression(
         NaiveTraceConstant.Parse,
         readFunctionExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -1674,9 +1646,7 @@ async function readAsNullablePrimitiveType(
         NaiveTraceConstant.Parse,
         readAsNullablePrimitiveType.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -2065,9 +2035,7 @@ export async function readFieldSpecificationList(
         NaiveTraceConstant.Parse,
         readFieldSpecificationList.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -2220,9 +2188,7 @@ async function readFieldTypeSpecification(
         NaiveTraceConstant.Parse,
         readFieldTypeSpecification.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -2255,7 +2221,7 @@ async function readFieldTypeSpecification(
         return fieldTypeSpecification;
     } else {
         ParseStateUtils.incrementAttributeCounter(state);
-        ParseStateUtils.deleteContext(state, undefined);
+        ParseStateUtils.deleteContext(state);
 
         trace.exit({
             [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
@@ -2401,9 +2367,7 @@ export async function readParameterSpecificationList(
         NaiveTraceConstant.Parse,
         readParameterSpecificationList.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -2457,9 +2421,7 @@ export async function readErrorRaisingExpression(
         NaiveTraceConstant.Parse,
         readErrorRaisingExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -2492,9 +2454,7 @@ export async function readErrorHandlingExpression(
         NaiveTraceConstant.Parse,
         readErrorHandlingExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -2649,9 +2609,7 @@ export async function readFieldNamePairedAnyLiterals(
         NaiveTraceConstant.Parse,
         readFieldNamePairedAnyLiterals.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -2904,9 +2862,7 @@ export async function readIdentifierPairedExpressions(
         NaiveTraceConstant.Parse,
         readIdentifierPairedExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -2961,9 +2917,7 @@ export async function readGeneralizedIdentifierPairedExpression(
         NaiveTraceConstant.Parse,
         readGeneralizedIdentifierPairedExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -2991,9 +2945,7 @@ export async function readIdentifierPairedExpression(
         NaiveTraceConstant.Parse,
         readIdentifierPairedExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -3017,6 +2969,88 @@ export async function readIdentifierPairedExpression(
 // ---------- Helper functions (generic read functions) ----------
 // ---------------------------------------------------------------
 
+// We need to be able to parse nested AsExpressions/IsExpressions, such as `1 as number as logical`.
+// If we didn't have to worry about types or keeping our state in order we could use something like:
+//
+// let left = readEqualityExpression();
+// while (currentTokenKind == TokenKind.As)
+// {
+//     const operator Read(TokenKind.As);
+//     const right = ReadNullablePrimitiveType();
+//     left = new BinOp(left, operator, right);
+// }
+// return left;
+//
+// One problem with the pseudo-code above is that we can't know what what we just parsed
+// belongs under another AsExpression/IsExpression until after it's parsed. This means each
+// iteration of the while-loop needs to create a new ParseContext as the parent of
+// the previously parsed node.
+async function readRecursivelyEitherAsExpressionOrIsExpression<
+    Node extends Ast.AsExpression | Ast.IsExpression,
+    OperatorTokenKind extends TokenKind.KeywordAs | TokenKind.KeywordIs,
+>(
+    state: ParseState,
+    nodeKind: Node["kind"],
+    operatorTokenKind: OperatorTokenKind,
+    initialLeftReader: (correlationId: number | undefined) => Promise<Node["left"]>,
+    operatorReader: (
+        operatorTokenKind: OperatorTokenKind,
+        correlationId: number | undefined,
+    ) => Node["operatorConstant"] | undefined,
+    rightReader: (correlationId: number) => Promise<Node["right"]>,
+    correlationId: number | undefined,
+): Promise<Node | Node["left"]> {
+    const trace: Trace = state.traceManager.entry(
+        NaiveTraceConstant.Parse,
+        readRecursivelyEitherAsExpressionOrIsExpression.name,
+        correlationId,
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
+    );
+
+    ParseStateUtils.startContext(state, nodeKind);
+
+    const initialLeft: Node["left"] = await initialLeftReader(trace.id);
+
+    if (state.currentTokenKind !== operatorTokenKind) {
+        ParseStateUtils.deleteContext(state);
+
+        return initialLeft;
+    }
+
+    let left: Node | Node["left"] = initialLeft;
+    let firstIteration: boolean = true;
+
+    while (state.currentTokenKind === operatorTokenKind) {
+        if (!firstIteration) {
+            ParseStateUtils.startContextAsParent(state, nodeKind, left.id, trace.id);
+        }
+
+        const operatorConstant: Node["operatorConstant"] = Assert.asDefined(
+            operatorReader(operatorTokenKind, trace.correlationId),
+        );
+
+        // eslint-disable-next-line no-await-in-loop
+        const right: Node["right"] = await rightReader(trace.id);
+
+        const binOpExpression: Node = {
+            ...ParseStateUtils.assertGetContextNodeMetadata(state),
+            kind: nodeKind,
+            isLeaf: false,
+            left,
+            operatorConstant,
+            right,
+        } as Node;
+
+        left = binOpExpression;
+
+        firstIteration = false;
+    }
+
+    trace.exit();
+
+    return left;
+}
+
 // Given the string `1 + 2 + 3` the function will parse the `1 +`,
 // then pass the remainder of the string `2 + 3` into recursiveReadBinOpExpressionHelper.
 // The helper function is nearly a copy except it replaces Left and leftReader with Right and rightReader.
@@ -3039,9 +3073,7 @@ async function recursiveReadBinOpExpression<
         NaiveTraceConstant.Parse,
         recursiveReadBinOpExpression.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     ParseStateUtils.startContext(state, nodeKind);
@@ -3056,7 +3088,7 @@ async function recursiveReadBinOpExpression<
             [NaiveTraceConstant.IsOperatorPresent]: false,
         });
 
-        ParseStateUtils.deleteContext(state, undefined);
+        ParseStateUtils.deleteContext(state);
 
         return left;
     }
@@ -3111,9 +3143,7 @@ async function recursiveReadBinOpExpressionHelper<
         NaiveTraceConstant.Parse,
         recursiveReadBinOpExpressionHelper.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     ParseStateUtils.startContext(state, nodeKind);
@@ -3122,7 +3152,7 @@ async function recursiveReadBinOpExpressionHelper<
     const operator: OperatorKind | undefined = operatorFrom(state.currentTokenKind);
 
     if (operator === undefined) {
-        ParseStateUtils.deleteContext(state, undefined);
+        ParseStateUtils.deleteContext(state);
 
         trace.exit({
             [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
@@ -3325,9 +3355,7 @@ async function readPairedConstantOrUndefined<
         NaiveTraceConstant.Parse,
         readPairedConstantOrUndefined.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     let pairedConstant: Ast.IPairedConstant<Kind, ConstantKind, Paired> | undefined;
@@ -3365,9 +3393,7 @@ async function genericReadParameterList<T extends Ast.TParameterType>(
         NaiveTraceConstant.Parse,
         genericReadParameterList.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     ParseStateUtils.startContext(state, nodeKind);
@@ -3594,9 +3620,7 @@ export function readClosingTokenKindAsConstant<C extends Constant.TConstant>(
         NaiveTraceConstant.Parse,
         readTokenKindAsConstant.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     const error: ParseError.ExpectedClosingTokenKind | undefined = ParseStateUtils.testClosingTokenKind(
@@ -3635,9 +3659,7 @@ export function readTokenKindAsConstant<C extends Constant.TConstant>(
         NaiveTraceConstant.Parse,
         readTokenKindAsConstant.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     state.cancellationToken?.throwIfCancelled();
@@ -3667,9 +3689,7 @@ function readTokenKindAsConstantInternal<C extends Constant.TConstant>(
         NaiveTraceConstant.Parse,
         readTokenKindAsConstant.name,
         correlationId,
-        {
-            [NaiveTraceConstant.TokenIndex]: state.tokenIndex,
-        },
+        { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
     const error: ParseError.ExpectedTokenKindError | undefined = ParseStateUtils.testIsOnTokenKind(state, tokenKind);

--- a/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
+++ b/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
@@ -3007,32 +3007,19 @@ async function readRecursivelyEitherAsExpressionOrIsExpression<
         { [NaiveTraceConstant.TokenIndex]: state.tokenIndex },
     );
 
-    ParseStateUtils.startContext(state, nodeKind);
-
-    const initialLeft: Node["left"] = await initialLeftReader(trace.id);
-
-    if (state.currentTokenKind !== operatorTokenKind) {
-        ParseStateUtils.deleteContext(state);
-
-        return initialLeft;
-    }
-
-    let left: Node | Node["left"] = initialLeft;
-    let firstIteration: boolean = true;
+    let left: Node | Node["left"] = await initialLeftReader(trace.id);
 
     while (state.currentTokenKind === operatorTokenKind) {
-        if (!firstIteration) {
-            ParseStateUtils.startContextAsParent(state, nodeKind, left.id, trace.id);
-        }
+        ParseStateUtils.startContextAsParent(state, nodeKind, left.id, trace.id);
 
         const operatorConstant: Node["operatorConstant"] = Assert.asDefined(
-            operatorReader(operatorTokenKind, trace.correlationId),
+            operatorReader(operatorTokenKind, trace.id),
         );
 
         // eslint-disable-next-line no-await-in-loop
         const right: Node["right"] = await rightReader(trace.id);
 
-        const binOpExpression: Node = {
+        left = {
             ...ParseStateUtils.assertGetContextNodeMetadata(state),
             kind: nodeKind,
             isLeaf: false,
@@ -3040,10 +3027,6 @@ async function readRecursivelyEitherAsExpressionOrIsExpression<
             operatorConstant,
             right,
         } as Node;
-
-        left = binOpExpression;
-
-        firstIteration = false;
     }
 
     trace.exit();

--- a/src/test/libraryTest/parser/simple.ts
+++ b/src/test/libraryTest/parser/simple.ts
@@ -249,6 +249,18 @@ describe("Parser.AbridgedNode", () => {
             ]);
         });
 
+        it(`1 as number as logical`, async () => {
+            await runAbridgedNodeTest(`1 as number as logical`, [
+                [Ast.NodeKind.AsExpression, undefined],
+                [Ast.NodeKind.AsExpression, 0],
+                [Ast.NodeKind.LiteralExpression, 0],
+                [Ast.NodeKind.Constant, 1],
+                [Ast.NodeKind.PrimitiveType, 2],
+                [Ast.NodeKind.Constant, 1],
+                [Ast.NodeKind.PrimitiveType, 2],
+            ]);
+        });
+
         it(`type function (x as number) as number`, async () => {
             await runAbridgedNodeTest(`type function (x as number) as number`, [
                 [Ast.NodeKind.TypePrimaryType, undefined],


### PR DESCRIPTION
The formal spec for AsExpression and IsExpression changed some time ago. This refactor brings it up to date with that spec.