### PR TITLE
Simplify exported APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.14.0",
+            "version": "0.15.0",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/arrayUtils.ts
+++ b/src/powerquery-parser/common/arrayUtils.ts
@@ -21,7 +21,7 @@ export function assertGet<T>(collection: ReadonlyArray<T>, index: number, messag
 }
 
 export function assertIncludes<T>(collection: ReadonlyArray<T>, element: T, message?: string, details?: object): void {
-    Assert.asDefined(
+    Assert.isTrue(
         collection.includes(element),
         message ?? "collection.includes(element) failed",
         details ?? { collection, element },
@@ -62,15 +62,6 @@ export function assertRemoveAtIndex<T>(collection: ReadonlyArray<T>, index: numb
     });
 
     return [...collection.slice(0, index), ...collection.slice(index + 1)];
-}
-
-export async function mapAsync<T, U>(
-    collection: ReadonlyArray<T>,
-    map: (value: T) => Promise<U>,
-): Promise<ReadonlyArray<U>> {
-    const tasks: ReadonlyArray<Promise<U>> = collection.map(map);
-
-    return await Promise.all(tasks);
 }
 
 export function concatUnique<T>(left: ReadonlyArray<T>, right: ReadonlyArray<T>): ReadonlyArray<T> {
@@ -114,6 +105,15 @@ export function isSubset<T>(
     }
 
     return true;
+}
+
+export async function mapAsync<T, U>(
+    collection: ReadonlyArray<T>,
+    map: (value: T) => Promise<U>,
+): Promise<ReadonlyArray<U>> {
+    const tasks: ReadonlyArray<Promise<U>> = collection.map(map);
+
+    return await Promise.all(tasks);
 }
 
 export function range(size: number, startAt: number = 0): ReadonlyArray<number> {

--- a/src/powerquery-parser/common/arrayUtils.ts
+++ b/src/powerquery-parser/common/arrayUtils.ts
@@ -20,23 +20,12 @@ export function assertGet<T>(collection: ReadonlyArray<T>, index: number, messag
     return Assert.asDefined(collection[index], message, details);
 }
 
-export function assertIn<T>(collection: ReadonlyArray<T>, item: T, message?: string, details?: object): number {
-    const index: number = collection.indexOf(item);
-    Assert.isTrue(index !== -1, message, details ?? { item });
-
-    return index;
-}
-
-export function assertIndexOfPredicate<T>(
-    collection: ReadonlyArray<T>,
-    predicate: (element: T) => boolean,
-    message?: string,
-    details?: object,
-): number {
-    const index: number = indexOfPredicate(collection, predicate);
-    Assert.isTrue(index !== -1, message, details);
-
-    return index;
+export function assertIncludes<T>(collection: ReadonlyArray<T>, element: T, message?: string, details?: object): void {
+    Assert.asDefined(
+        collection.includes(element),
+        message ?? "collection.includes(element) failed",
+        details ?? { collection, element },
+    );
 }
 
 export function assertNonZeroLength<T>(collection: ReadonlyArray<T>, message?: string, details?: object): void {
@@ -96,54 +85,8 @@ export function concatUnique<T>(left: ReadonlyArray<T>, right: ReadonlyArray<T>)
     return partial;
 }
 
-export function enumerate<T>(collection: ReadonlyArray<T>): ReadonlyArray<[number, T]> {
-    return range(collection.length, 0).map((index: number) => [index, collection[index]]);
-}
-
-export function findReverse<T>(collection: ReadonlyArray<T>, predicate: (t: T) => boolean): T | undefined {
-    const numElements: number = collection.length;
-
-    for (let index: number = numElements - 1; index >= 0; index -= 1) {
-        const element: T = collection[index];
-
-        if (predicate(element)) {
-            return element;
-        }
-    }
-
-    return undefined;
-}
-
-export function includesPredicate<T>(collection: ReadonlyArray<T>, predicate: (element: T) => boolean): boolean {
-    const numElements: number = collection.length;
-
-    for (let index: number = 0; index < numElements; index += 1) {
-        if (predicate(collection[index])) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-export function includesUnique<T>(
-    collection: ReadonlyArray<T>,
-    testValue: T,
-    comparer: (left: T, right: T) => boolean,
-): boolean {
-    return includesPredicate(collection, (collectionItem: T) => comparer(testValue, collectionItem));
-}
-
-export function indexOfPredicate<T>(collection: ReadonlyArray<T>, predicate: (element: T) => boolean): number {
-    const numElements: number = collection.length;
-
-    for (let index: number = 0; index < numElements; index += 1) {
-        if (predicate(collection[index])) {
-            return index;
-        }
-    }
-
-    return -1;
+export function enumerate<T>(collection: ReadonlyArray<T>): ReadonlyArray<[T, number]> {
+    return collection.map((value: T, index: number) => [value, index]);
 }
 
 export function isSubset<T>(
@@ -176,22 +119,4 @@ export function isSubset<T>(
 export function range(size: number, startAt: number = 0): ReadonlyArray<number> {
     // tslint:disable-next-line: prefer-array-literal
     return [...Array(size).keys()].map((index: number) => index + startAt);
-}
-
-export function split<T>(
-    collection: ReadonlyArray<T>,
-    splitter: (value: T) => boolean,
-): [ReadonlyArray<T>, ReadonlyArray<T>] {
-    const left: T[] = [];
-    const right: T[] = [];
-
-    for (const value of collection) {
-        if (splitter(value) === true) {
-            left.push(value);
-        } else {
-            right.push(value);
-        }
-    }
-
-    return [left, right];
 }

--- a/src/powerquery-parser/common/immutableSet.ts
+++ b/src/powerquery-parser/common/immutableSet.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ArrayUtils } from ".";
-
 // TODO: this needs to be benchmarked
 export class ImmutableSet<T> {
     public readonly size: number;
@@ -52,7 +50,13 @@ export class ImmutableSet<T> {
     }
 
     public has(value: T): boolean {
-        return ArrayUtils.includesUnique(this.internalCollection, value, this.comparer);
+        for (const element of this.internalCollection) {
+            if (this.comparer(element, value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public values(): IterableIterator<T> {

--- a/src/powerquery-parser/common/result/resultUtils.ts
+++ b/src/powerquery-parser/common/result/resultUtils.ts
@@ -18,13 +18,13 @@ export function assertIsError<T, E>(result: Result<T, E>): asserts result is Err
     }
 }
 
-export function assertUnboxOk<T, E>(result: Result<T, E>): T {
+export function assertOk<T, E>(result: Result<T, E>): T {
     assertIsOk(result);
 
     return result.value;
 }
 
-export function assertUnboxError<T, E>(result: Result<T, E>): E {
+export function assertError<T, E>(result: Result<T, E>): E {
     assertIsError(result);
 
     return result.error;
@@ -75,10 +75,6 @@ export function isError<T, E>(result: Result<T, E>): result is ErrorResult<E> {
     return result.kind === ResultKind.Error;
 }
 
-export function unboxOrDefault<T, E>(result: Result<T, E>, defaultValue: T): T {
-    if (isOk(result)) {
-        return result.value;
-    } else {
-        return defaultValue;
-    }
+export function okOrDefault<T, E>(result: Result<T, E>, defaultValue: T): T {
+    return isOk(result) ? result.value : defaultValue;
 }

--- a/src/powerquery-parser/language/type/typeUtils/simplify.ts
+++ b/src/powerquery-parser/language/type/typeUtils/simplify.ts
@@ -14,8 +14,8 @@ import {
     TextCategory,
     TypeCategory,
 } from "./categorize";
-import { ArrayUtils, ImmutableSet } from "../../../common";
 import { Trace, TraceManager } from "../../../common/trace";
+import { ImmutableSet } from "../../../common";
 import { isEqualType } from "./isEqualType";
 import { Type } from "..";
 import { TypeUtilsTraceConstant } from "./typeTraceConstant";
@@ -61,7 +61,7 @@ export function simplify(
     ];
 
     for (const flattenedValue of simplifyAnyCategory(categorized.anys)) {
-        if (!ArrayUtils.includesUnique(partial, flattenedValue, isEqualType)) {
+        if (!partial.find((item: Type.TPowerQueryType) => isEqualType(item, flattenedValue))) {
             partial.push(flattenedValue);
         }
     }

--- a/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
@@ -168,13 +168,9 @@ export function typeCheckListWithListType(
     const validArgs: number[] = [];
     const invalidArgs: Map<number, DefinedListMismatch> = new Map();
     const schemaItemType: Type.TPowerQueryType = schemaType.itemType;
-
     const valueElements: ReadonlyArray<Type.TPowerQueryType> = valueType.elements;
-    const numElements: number = valueElements.length;
 
-    for (let index: number = 0; index < numElements; index += 1) {
-        const element: Type.TPowerQueryType = valueElements[index];
-
+    for (const [element, index] of ArrayUtils.enumerate(valueElements)) {
         if (isCompatible(element, schemaItemType, traceManager, trace.id)) {
             validArgs.push(index);
         } else {

--- a/src/powerquery-parser/lexer/lexer.ts
+++ b/src/powerquery-parser/lexer/lexer.ts
@@ -457,13 +457,11 @@ function tokenizedLinesFrom(
     locale: string,
     cancellationToken: ICancellationToken | undefined,
 ): ReadonlyArray<TLine> {
-    const numLines: number = splitLines.length;
     const tokenizedLines: TLine[] = [];
 
-    for (let lineNumber: number = 0; lineNumber < numLines; lineNumber += 1) {
-        const splitLine: SplitLine = splitLines[lineNumber];
+    for (const [splitLine, index] of ArrayUtils.enumerate(splitLines)) {
         const untokenizedLine: UntouchedLine = lineFrom(splitLine.text, splitLine.lineTerminator, previousLineModeEnd);
-        const tokenizedLine: TLine = tokenize(untokenizedLine, lineNumber, locale, cancellationToken);
+        const tokenizedLine: TLine = tokenize(untokenizedLine, index, locale, cancellationToken);
         tokenizedLines.push(tokenizedLine);
         previousLineModeEnd = tokenizedLine.lineModeEnd;
     }

--- a/src/powerquery-parser/lexer/lexerSnapshot.ts
+++ b/src/powerquery-parser/lexer/lexerSnapshot.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Assert, CommonError, ICancellationToken, Result, ResultUtils, StringUtils } from "../common";
+import { ArrayUtils, Assert, CommonError, ICancellationToken, Result, ResultUtils, StringUtils } from "../common";
 import { Comment, Token } from "../language";
 import { Lexer } from "..";
 import { LexError } from ".";
@@ -360,9 +360,7 @@ function flattenLineTokens(state: Lexer.State): FlattenedLines {
     let lineTextOffset: number = 0;
     let flatIndex: number = 0;
 
-    for (let lineNumber: number = 0; lineNumber < numLines; lineNumber += 1) {
-        const line: Lexer.TLine = lines[lineNumber];
-
+    for (const [line, lineNumber] of ArrayUtils.enumerate(lines)) {
         text += line.text;
 
         if (lineNumber !== numLines - 1) {

--- a/src/powerquery-parser/parser/nodeIdMap/ancestryUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/ancestryUtils.ts
@@ -65,7 +65,7 @@ export function assertNthChecked<T extends Ast.TNode>(
     return xorNode;
 }
 
-export function findOfNodeKind<T extends Ast.TNode>(
+export function findNodeKind<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     nodeKind: T["kind"],
 ): XorNode<T> | undefined {
@@ -76,17 +76,6 @@ export function findOfNodeKind<T extends Ast.TNode>(
     }
 
     return node;
-}
-
-export function findOfNodeKindWithIndex<T extends Ast.TNode>(
-    ancestry: ReadonlyArray<TXorNode>,
-    nodeKind: T["kind"],
-): [XorNode<T>, number] | undefined {
-    const index: number | undefined = indexOfNodeKind(ancestry, nodeKind);
-
-    return index !== undefined
-        ? [XorNodeUtils.assertAsNodeKind(Assert.asDefined(ancestry[index]), nodeKind), index]
-        : undefined;
 }
 
 export function indexOfNodeKind<T extends Ast.TNode>(

--- a/src/powerquery-parser/parser/nodeIdMap/ancestryUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/ancestryUtils.ts
@@ -7,7 +7,7 @@ import { Assert } from "../../common";
 import { Ast } from "../../language";
 
 // Builds up an TXorNode path starting from nodeId and goes up to the root of the Ast.
-export function assertGetAncestry(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): ReadonlyArray<TXorNode> {
+export function assertAncestry(nodeIdMapCollection: NodeIdMap.Collection, nodeId: number): ReadonlyArray<TXorNode> {
     const ancestryIds: number[] = [nodeId];
 
     let parentId: number | undefined = nodeIdMapCollection.parentIdById.get(nodeId);
@@ -20,179 +20,52 @@ export function assertGetAncestry(nodeIdMapCollection: NodeIdMap.Collection, nod
     return NodeIdMapIterator.assertIterXor(nodeIdMapCollection, ancestryIds);
 }
 
-export function assertGetLeaf(ancestry: ReadonlyArray<TXorNode>): TXorNode {
-    return assertGetNthXor(ancestry, 0);
+export function assertFirst(ancestry: ReadonlyArray<TXorNode>): TXorNode {
+    return assertNth(ancestry, 0);
 }
 
-export function assertGetLeafChecked<T extends Ast.TNode>(
+export function assertFirstChecked<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): XorNode<T> {
-    const xorNode: TXorNode = assertGetLeaf(ancestry);
+    const xorNode: TXorNode = assertFirst(ancestry);
     XorNodeUtils.assertIsNodeKind(xorNode, expectedNodeKinds);
 
     return xorNode;
 }
 
-export function assertGetRoot(ancestry: ReadonlyArray<TXorNode>): TXorNode {
+export function assertLast(ancestry: ReadonlyArray<TXorNode>): TXorNode {
     Assert.isTrue(ancestry.length > 0, "ancestry.length > 0");
 
-    return assertGetNthXor(ancestry, ancestry.length - 1);
+    return assertNth(ancestry, ancestry.length - 1);
 }
 
-export function assertGetRootChecked<T extends Ast.TNode>(
+export function assertLastChecked<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): XorNode<T> {
-    return assertGetNthXorChecked(ancestry, ancestry.length - 1, expectedNodeKinds);
+    return assertNthChecked(ancestry, ancestry.length - 1, expectedNodeKinds);
 }
 
-export function assertGetNextXor(ancestry: ReadonlyArray<TXorNode>, ancestryIndex: number): TXorNode {
-    return assertGetNthXor(ancestry, ancestryIndex + 1);
-}
-
-export function assertGetNextXorChecked<T extends Ast.TNode>(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): XorNode<T> {
-    return assertGetNthXorChecked(ancestry, ancestryIndex + 1, expectedNodeKinds);
-}
-
-export function assertGetPreviousXor(ancestry: ReadonlyArray<TXorNode>, ancestryIndex: number): TXorNode {
-    return assertGetNthXor(ancestry, ancestryIndex - 1);
-}
-
-export function assertGetPreviousXorChecked<T extends Ast.TNode>(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): XorNode<T> {
-    return assertGetNthXorChecked(ancestry, ancestryIndex - 1, expectedNodeKinds);
-}
-
-export function assertGetNthNextXor(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    offset: number = 1,
-): TXorNode {
-    return assertGetNthXor(ancestry, ancestryIndex + offset);
-}
-
-export function assertGetNthNextXorChecked<T extends Ast.TNode>(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    offset: number = 1,
-    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): XorNode<T> {
-    return assertGetNthXorChecked(ancestry, ancestryIndex + offset, expectedNodeKinds);
-}
-
-export function assertGetNthPreviousXor(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    offset: number = 1,
-): TXorNode {
-    return assertGetNthXor(ancestry, ancestryIndex - offset);
-}
-
-export function assertGetNthPreviousXorChecked<T extends Ast.TNode>(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    offset: number = 1,
-    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): XorNode<T> {
-    return assertGetNthXorChecked(ancestry, ancestryIndex - offset, expectedNodeKinds);
-}
-
-export function assertGetNthXor(ancestry: ReadonlyArray<TXorNode>, ancestryIndex: number): TXorNode {
-    return Assert.asDefined(nthXor(ancestry, ancestryIndex), "ancestryIndex is out of bounds", {
+export function assertNth(ancestry: ReadonlyArray<TXorNode>, ancestryIndex: number): TXorNode {
+    return Assert.asDefined(nth(ancestry, ancestryIndex), "ancestryIndex was out of bounds", {
         ancestryLength: ancestry.length,
         ancestryIndex,
     });
 }
 
-export function assertGetNthXorChecked<T extends Ast.TNode>(
+export function assertNthChecked<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     ancestryIndex: number,
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): XorNode<T> {
-    return assertGetNthXorChecked(ancestry, ancestryIndex, expectedNodeKinds);
+    const xorNode: TXorNode = assertNth(ancestry, ancestryIndex);
+    XorNodeUtils.assertIsNodeKind(xorNode, expectedNodeKinds);
+
+    return xorNode;
 }
 
-export function nthXor(ancestry: ReadonlyArray<TXorNode>, ancestryIndex: number): TXorNode | undefined {
-    return ancestry[ancestryIndex];
-}
-
-export function nthXorChecked<T extends Ast.TNode>(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): XorNode<T> | undefined {
-    const xorNode: TXorNode | undefined = nthXor(ancestry, ancestryIndex);
-
-    return xorNode && XorNodeUtils.isNodeKind(xorNode, expectedNodeKinds) ? xorNode : undefined;
-}
-
-export function nextXor(ancestry: ReadonlyArray<TXorNode>, ancestryIndex: number): TXorNode | undefined {
-    return nthXor(ancestry, ancestryIndex + 1);
-}
-
-export function nextXorChecked<T extends Ast.TNode>(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): XorNode<T> | undefined {
-    return nthXorChecked(ancestry, ancestryIndex + 1, expectedNodeKinds);
-}
-
-export function previousXor(ancestry: ReadonlyArray<TXorNode>, ancestryIndex: number): TXorNode | undefined {
-    return nthXor(ancestry, ancestryIndex - 1);
-}
-
-export function previousXorChecked<T extends Ast.TNode>(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): XorNode<T> | undefined {
-    return nthXorChecked(ancestry, ancestryIndex - 1, expectedNodeKinds);
-}
-
-export function nthNextXor(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    offset: number = 1,
-): TXorNode | undefined {
-    return nthXor(ancestry, ancestryIndex + offset);
-}
-
-export function nthNextXorChecked<T extends Ast.TNode>(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    offset: number = 1,
-    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): XorNode<T> | undefined {
-    return nthXorChecked(ancestry, ancestryIndex + offset, expectedNodeKinds);
-}
-
-export function nthPreviousXor(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    offset: number = 1,
-): TXorNode | undefined {
-    return nthXor(ancestry, ancestryIndex - offset);
-}
-
-export function nthPreviousXorChecked<T extends Ast.TNode>(
-    ancestry: ReadonlyArray<TXorNode>,
-    ancestryIndex: number,
-    offset: number = 1,
-    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
-): XorNode<T> | undefined {
-    return nthXorChecked(ancestry, ancestryIndex - offset, expectedNodeKinds);
-}
-
-export function findXorOfNodeKind<T extends Ast.TNode>(
+export function findOfNodeKind<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     nodeKind: T["kind"],
 ): XorNode<T> | undefined {
@@ -205,7 +78,18 @@ export function findXorOfNodeKind<T extends Ast.TNode>(
     return node;
 }
 
-export function findIndexOfNodeKind<T extends Ast.TNode>(
+export function findOfNodeKindWithIndex<T extends Ast.TNode>(
+    ancestry: ReadonlyArray<TXorNode>,
+    nodeKind: T["kind"],
+): [XorNode<T>, number] | undefined {
+    const index: number | undefined = indexOfNodeKind(ancestry, nodeKind);
+
+    return index !== undefined
+        ? [XorNodeUtils.assertAsNodeKind(Assert.asDefined(ancestry[index]), nodeKind), index]
+        : undefined;
+}
+
+export function indexOfNodeKind<T extends Ast.TNode>(
     ancestry: ReadonlyArray<TXorNode>,
     nodeKind: T["kind"],
 ): number | undefined {
@@ -214,13 +98,16 @@ export function findIndexOfNodeKind<T extends Ast.TNode>(
     return index !== -1 ? index : undefined;
 }
 
-export function findXorAndIndexOfNodeKind<T extends Ast.TNode>(
-    ancestry: ReadonlyArray<TXorNode>,
-    nodeKind: T["kind"],
-): [XorNode<T>, number] | undefined {
-    const index: number | undefined = findIndexOfNodeKind(ancestry, nodeKind);
+export function nth(ancestry: ReadonlyArray<TXorNode>, ancestryIndex: number): TXorNode | undefined {
+    return ancestry[ancestryIndex];
+}
 
-    return index !== undefined
-        ? [XorNodeUtils.assertAsNodeKind(Assert.asDefined(ancestry[index]), nodeKind), index]
-        : undefined;
+export function nthChecked<T extends Ast.TNode>(
+    ancestry: ReadonlyArray<TXorNode>,
+    ancestryIndex: number,
+    expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
+): XorNode<T> | undefined {
+    const xorNode: TXorNode | undefined = nth(ancestry, ancestryIndex);
+
+    return xorNode && XorNodeUtils.isNodeKind(xorNode, expectedNodeKinds) ? xorNode : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
@@ -67,7 +67,6 @@ export function recalculateIds(
         const oldId: number = encounteredIds[index];
         const newId: number = sortedIds[index];
 
-        // [960, 961, 962, 963, 964, 965, 966, 968, 969]
         if (oldId !== newId) {
             newIdByOldId.set(oldId, newId);
         }

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -183,11 +183,16 @@ export function assertIsNodeKind<T extends Ast.TNode>(
     expectedNodeKinds: ReadonlyArray<T["kind"]> | T["kind"],
 ): asserts xorNode is XorNode<T> {
     if (Array.isArray(expectedNodeKinds)) {
-        ArrayUtils.assertIn(expectedNodeKinds, xorNode.node.kind, `incorrect Ast.NodeKind`, {
-            actualNodeKind: xorNode.node.kind,
-            actualNodeId: xorNode.node.id,
+        ArrayUtils.assertIncludes(
             expectedNodeKinds,
-        });
+            xorNode.node.kind,
+            `ArrayUtils.assertIn(expectedNodeKinds, xorNodeKind)`,
+            {
+                actualNodeKind: xorNode.node.kind,
+                actualNodeId: xorNode.node.id,
+                expectedNodeKinds,
+            },
+        );
     } else {
         Assert.isTrue(xorNode.node.kind === expectedNodeKinds, "xorNode.node.kind === expectedNodeKinds", {
             nodeId: xorNode.node.id,

--- a/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/xorNodeUtils.ts
@@ -186,7 +186,7 @@ export function assertIsNodeKind<T extends Ast.TNode>(
         ArrayUtils.assertIncludes(
             expectedNodeKinds,
             xorNode.node.kind,
-            `ArrayUtils.assertIn(expectedNodeKinds, xorNodeKind)`,
+            `ArrayUtils.assertIncludes(expectedNodeKinds, xorNodeKind)`,
             {
                 actualNodeKind: xorNode.node.kind,
                 actualNodeId: xorNode.node.id,

--- a/src/powerquery-parser/parser/parsers/combinatorialParserV2/combineOperatorsAndOperands.ts
+++ b/src/powerquery-parser/parser/parsers/combinatorialParserV2/combineOperatorsAndOperands.ts
@@ -45,11 +45,9 @@ export function combineOperatorsAndOperands(
     const nodeIdMapCollection: NodeIdMap.Collection = state.contextState.nodeIdMapCollection;
     const numOperators: number = sortedOperatorConstants.length;
 
-    for (let index: number = 0; index < numOperators; index += 1) {
-        const { leftOperandIndex, operatorConstant }: PrecedenceSortableOperatorConstant = ArrayUtils.assertGet(
-            sortedOperatorConstants,
-            index,
-        );
+    for (const [precedenceSortableOperatorConstant, index] of ArrayUtils.enumerate(sortedOperatorConstants)) {
+        const { leftOperandIndex, operatorConstant }: PrecedenceSortableOperatorConstant =
+            precedenceSortableOperatorConstant;
 
         const nodeKind: Ast.TBinOpExpressionNodeKind = AstUtils.nodeKindFromTBinOpExpressionOperator(
             operatorConstant.constantKind,

--- a/src/test/scripts/createNodeDump.ts
+++ b/src/test/scripts/createNodeDump.ts
@@ -47,9 +47,7 @@ async function main(): Promise<void> {
 
         const numResources: number = resources.length;
 
-        for (let index: number = 0; index < numResources; index += 1) {
-            const resource: TestResource = ArrayUtils.assertGet(resources, index);
-
+        for (const [resource, index] of ArrayUtils.enumerate(resources)) {
             console.log(
                 `Starting ${resource.filePath} using ${parserName} (${TestUtils.zFill(
                     index + 1,


### PR DESCRIPTION
- Several XUtils files had some exported functions removed
  - AncestryUtils had many functions with nearly duplicate behavior. All but the most basic functions were removed
  - Several functions were no longer being used downstream
- Several XUtils files had their names updated to the modern convention