### PR TITLE
Remove unbox prefix on library functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.15.2",
+    "version": "0.15.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.15.2",
+            "version": "0.15.3",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.15.2",
+    "version": "0.15.3",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -5,7 +5,7 @@ import { Ast, Constant, TextUtils } from "../../language";
 import { NodeIdMap, NodeIdMapUtils, TXorNode, XorNodeKind, XorNodeUtils } from ".";
 import { Assert } from "../../common";
 import { IConstant } from "../../language/ast/ast";
-import { unboxIdentifier } from "./nodeIdMapUtils";
+import { parameterIdentifier } from "./nodeIdMapUtils";
 import { XorNode } from "./xorNode";
 
 export type TKeyValuePair = FieldSpecificationKeyValuePair | LetKeyValuePair | RecordKeyValuePair | SectionKeyValuePair;
@@ -186,7 +186,7 @@ export function iterFieldProjection(
 ): ReadonlyArray<TXorNode> {
     XorNodeUtils.assertIsNodeKind(fieldProjection, Ast.NodeKind.FieldProjection);
 
-    const arrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.unboxArrayWrapper(
+    const arrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.arrayWrapperContentXor(
         nodeIdMapCollection,
         fieldProjection.node.id,
     );
@@ -203,7 +203,7 @@ export function iterFieldProjectionNames(
 
     for (const selector of iterFieldProjection(nodeIdMapCollection, fieldProjection)) {
         const identifier: XorNode<Ast.GeneralizedIdentifier> | undefined =
-            NodeIdMapUtils.unboxWrappedContentChecked<Ast.GeneralizedIdentifier>(
+            NodeIdMapUtils.wrappedContentXorChecked<Ast.GeneralizedIdentifier>(
                 nodeIdMapCollection,
                 selector.node.id,
                 Ast.NodeKind.GeneralizedIdentifier,
@@ -252,7 +252,7 @@ export function iterFunctionExpressionParameterNames(
     const result: Ast.Identifier[] = [];
 
     for (const parameter of iterFunctionExpressionParameters(nodeIdMapCollection, functionExpression)) {
-        const name: Ast.Identifier | undefined = unboxIdentifier(nodeIdMapCollection, parameter);
+        const name: Ast.Identifier | undefined = parameterIdentifier(nodeIdMapCollection, parameter);
 
         if (name === undefined) {
             break;
@@ -345,7 +345,7 @@ export function iterLetExpression(
 ): ReadonlyArray<LetKeyValuePair> {
     XorNodeUtils.assertIsNodeKind<Ast.LetExpression>(letExpression, Ast.NodeKind.LetExpression);
 
-    const arrayWrapper: TXorNode | undefined = NodeIdMapUtils.unboxArrayWrapper(
+    const arrayWrapper: TXorNode | undefined = NodeIdMapUtils.arrayWrapperContentXor(
         nodeIdMapCollection,
         letExpression.node.id,
     );
@@ -375,7 +375,7 @@ export function iterRecord(
 ): ReadonlyArray<RecordKeyValuePair> {
     XorNodeUtils.assertIsRecord(record);
 
-    const arrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.unboxArrayWrapper(
+    const arrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.arrayWrapperContentXor(
         nodeIdMapCollection,
         record.node.id,
     );
@@ -530,7 +530,7 @@ function iterArrayWrapperInWrappedContent(
     nodeIdMapCollection: NodeIdMap.Collection,
     xorNode: TXorNode,
 ): ReadonlyArray<TXorNode> {
-    const arrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.unboxArrayWrapper(
+    const arrayWrapper: XorNode<Ast.TArrayWrapper> | undefined = NodeIdMapUtils.arrayWrapperContentXor(
         nodeIdMapCollection,
         xorNode.node.id,
     );

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/childSelectors.ts
@@ -99,10 +99,10 @@ export function assertNthChildContextChecked<T extends Ast.TNode>(
     );
 }
 
-export function assertUnboxArrayWrapperAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TArrayWrapper {
+export function assertArrayWrapperContentAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TArrayWrapper {
     const xorNode: XorNode<Ast.TArrayWrapper> | undefined = Assert.asDefined(
-        unboxArrayWrapper(nodeIdMapCollection, nodeId),
-        "failure in assertUnboxArrayWrapperAst",
+        arrayWrapperContentXor(nodeIdMapCollection, nodeId),
+        "failure in assertArrayWrapperContentAst",
         {
             nodeId,
         },
@@ -190,14 +190,14 @@ export function nthChildContextChecked<T extends Ast.TNode>(
     return contextNode && ParseContextUtils.isNodeKind(contextNode, expectedNodeKinds) ? contextNode : undefined;
 }
 
-export function unboxArrayWrapper(
+export function arrayWrapperContentXor(
     nodeIdMapCollection: Collection,
     nodeId: number,
 ): XorNode<Ast.TArrayWrapper> | undefined {
     return nthChildXorChecked<Ast.TArrayWrapper>(nodeIdMapCollection, nodeId, 1, Ast.NodeKind.ArrayWrapper);
 }
 
-export function unboxWrappedContent(nodeIdMapCollection: Collection, nodeId: number): TXorNode | undefined {
+export function wrappedContentXor(nodeIdMapCollection: Collection, nodeId: number): TXorNode | undefined {
     const wrapperXorNode: TXorNode | undefined = xor(nodeIdMapCollection, nodeId);
 
     if (wrapperXorNode === undefined || !XorNodeUtils.isTWrapped(wrapperXorNode)) {
@@ -207,28 +207,28 @@ export function unboxWrappedContent(nodeIdMapCollection: Collection, nodeId: num
     return nthChildXor(nodeIdMapCollection, nodeId, 1);
 }
 
-export function unboxWrappedContentChecked<C extends Ast.TWrapped["content"]>(
+export function wrappedContentXorChecked<C extends Ast.TWrapped["content"]>(
     nodeIdMapCollection: Collection,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<C["kind"]> | C["kind"],
 ): XorNode<C> | undefined {
-    const xorNode: TXorNode | undefined = unboxWrappedContent(nodeIdMapCollection, nodeId);
+    const xorNode: TXorNode | undefined = wrappedContentXor(nodeIdMapCollection, nodeId);
 
     return xorNode && XorNodeUtils.isNodeKind(xorNode, expectedNodeKinds) ? xorNode : undefined;
 }
 
-export function unboxWrappedContentAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode | undefined {
-    const xorNode: TXorNode | undefined = unboxWrappedContent(nodeIdMapCollection, nodeId);
+export function wrappedContentAst(nodeIdMapCollection: Collection, nodeId: number): Ast.TNode | undefined {
+    const xorNode: TXorNode | undefined = wrappedContentXor(nodeIdMapCollection, nodeId);
 
     return xorNode && XorNodeUtils.isAst(xorNode) ? xorNode.node : undefined;
 }
 
-export function unboxWrappedContentAstChecked<C extends Ast.TWrapped["content"]>(
+export function wrappedContentAstChecked<C extends Ast.TWrapped["content"]>(
     nodeIdMapCollection: Collection,
     nodeId: number,
     expectedNodeKinds: ReadonlyArray<C["kind"]> | C["kind"],
 ): C | undefined {
-    const astNode: Ast.TNode | undefined = unboxWrappedContentAst(nodeIdMapCollection, nodeId);
+    const astNode: Ast.TNode | undefined = wrappedContentAst(nodeIdMapCollection, nodeId);
 
     return astNode && AstUtils.isNodeKind<C>(astNode, expectedNodeKinds) ? astNode : undefined;
 }

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/specializedSelectors.ts
@@ -116,29 +116,6 @@ export function invokeExpressionIdentifier(
     return headXorNode;
 }
 
-// Unboxes the node if it's a identifier
-export function unboxIdentifier(
-    nodeIdMapCollection: NodeIdMap.Collection,
-    functionParameter: TXorNode,
-): Ast.Identifier | undefined {
-    return nthChildAstChecked<Ast.Identifier>(
-        nodeIdMapCollection,
-        functionParameter.node.id,
-        1,
-        Ast.NodeKind.Identifier,
-    );
-}
-
-// Unboxes the identifier literal if it exists.
-export function unboxIdentifierLiteral(
-    nodeIdMapCollection: NodeIdMap.Collection,
-    functionParameter: TXorNode,
-): string | undefined {
-    const identifier: Ast.Identifier | undefined = unboxIdentifier(nodeIdMapCollection, functionParameter);
-
-    return identifier ? identifier.literal : undefined;
-}
-
 // Unboxes the identifier literal for function name if it exists.
 export function invokeExpressionIdentifierLiteral(
     nodeIdMapCollection: NodeIdMap.Collection,
@@ -160,4 +137,27 @@ export function invokeExpressionIdentifierLiteral(
     return identifierExpression.inclusiveConstant === undefined
         ? identifierExpression.identifier.literal
         : identifierExpression.inclusiveConstant.constantKind + identifierExpression.identifier.literal;
+}
+
+// Unboxes the node if it's a identifier
+export function parameterIdentifier(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    functionParameter: TXorNode,
+): Ast.Identifier | undefined {
+    return nthChildAstChecked<Ast.Identifier>(
+        nodeIdMapCollection,
+        functionParameter.node.id,
+        1,
+        Ast.NodeKind.Identifier,
+    );
+}
+
+// Unboxes the identifier literal if it exists.
+export function parameterIdentifierLiteral(
+    nodeIdMapCollection: NodeIdMap.Collection,
+    functionParameter: TXorNode,
+): string | undefined {
+    const identifier: Ast.Identifier | undefined = parameterIdentifier(nodeIdMapCollection, functionParameter);
+
+    return identifier ? identifier.literal : undefined;
 }

--- a/src/test/libraryTest/parser/nodeIdMapUtils.ts
+++ b/src/test/libraryTest/parser/nodeIdMapUtils.ts
@@ -293,7 +293,7 @@ describe(`nodeIdMapUtils`, () => {
         });
     });
 
-    describe("unboxWrappedContent", () => {
+    describe("wrappedContentXor", () => {
         it("Ast", async () => {
             const text: string = `[a = 1]`;
             const parseOk: Task.ParseTaskOk = await TestAssertUtils.assertGetLexParseOk(DefaultSettings, text);

--- a/src/test/libraryTest/parser/nodeIdMapUtils.ts
+++ b/src/test/libraryTest/parser/nodeIdMapUtils.ts
@@ -307,7 +307,7 @@ describe(`nodeIdMapUtils`, () => {
             const recordExpressionNodeId: number = recordExpressionNodeIds.values().next().value;
 
             XorNodeUtils.assertAstChecked(
-                Assert.asDefined(NodeIdMapUtils.unboxWrappedContent(nodeIdMapCollection, recordExpressionNodeId)),
+                Assert.asDefined(NodeIdMapUtils.wrappedContentXor(nodeIdMapCollection, recordExpressionNodeId)),
                 Ast.NodeKind.ArrayWrapper,
             );
         });
@@ -330,7 +330,7 @@ describe(`nodeIdMapUtils`, () => {
             const recordExpressionNodeId: number = recordExpressionNodeIds.values().next().value;
 
             XorNodeUtils.assertAstChecked(
-                Assert.asDefined(NodeIdMapUtils.unboxWrappedContent(nodeIdMapCollection, recordExpressionNodeId)),
+                Assert.asDefined(NodeIdMapUtils.wrappedContentXor(nodeIdMapCollection, recordExpressionNodeId)),
                 Ast.NodeKind.ArrayWrapper,
             );
         });


### PR DESCRIPTION
Most were removed in earlier PRs. This should be the last.