### PR TITLE
Make benchmark/nodedump runnable in VSCode debugger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.15.3",
+    "version": "0.15.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.15.3",
+            "version": "0.15.4",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.15.3",
+    "version": "0.15.4",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/parser/parsers/combinatorialParserV2/combineOperatorsAndOperands.ts
+++ b/src/powerquery-parser/parser/parsers/combinatorialParserV2/combineOperatorsAndOperands.ts
@@ -66,10 +66,7 @@ export function combineOperatorsAndOperands(
 
         placeParseContextUnderPlaceholderContext(state, binOpParseContext, placeholderContextNodeId);
 
-        const validator: TValidator = MapUtils.assertGet(
-            ValidatorsByTBinOpExpressionOperator,
-            operatorConstant.constantKind,
-        );
+        const validator: TValidator = validatorForOperator(operatorConstant.constantKind);
 
         if (!validator.validateLeftOperand(left)) {
             setParseStateToNodeStart(state, left);
@@ -262,29 +259,6 @@ const ValidatorForMetadataExpression: Validator<Ast.MetadataExpression> = {
         NaiveParseSteps.readUnaryExpression(state, parser, correlationId),
 };
 
-const ValidatorsByTBinOpExpressionOperator: Map<Constant.TBinOpExpressionOperator, TValidator> = new Map<
-    Constant.TBinOpExpressionOperator,
-    TValidator
->([
-    [Constant.KeywordConstant.Meta, ValidatorForMetadataExpression],
-    [Constant.ArithmeticOperator.Multiplication, ValidatorForEqualityExpressionAndBelow],
-    [Constant.ArithmeticOperator.Division, ValidatorForEqualityExpressionAndBelow],
-    [Constant.ArithmeticOperator.Addition, ValidatorForEqualityExpressionAndBelow],
-    [Constant.ArithmeticOperator.Subtraction, ValidatorForEqualityExpressionAndBelow],
-    [Constant.ArithmeticOperator.And, ValidatorForEqualityExpressionAndBelow],
-    [Constant.RelationalOperator.LessThan, ValidatorForEqualityExpressionAndBelow],
-    [Constant.RelationalOperator.LessThanEqualTo, ValidatorForEqualityExpressionAndBelow],
-    [Constant.RelationalOperator.GreaterThan, ValidatorForEqualityExpressionAndBelow],
-    [Constant.RelationalOperator.GreaterThanEqualTo, ValidatorForEqualityExpressionAndBelow],
-    [Constant.EqualityOperator.EqualTo, ValidatorForEqualityExpressionAndBelow],
-    [Constant.EqualityOperator.NotEqualTo, ValidatorForEqualityExpressionAndBelow],
-    [Constant.KeywordConstant.As, ValidatorForAsExpression],
-    [Constant.KeywordConstant.Is, ValidatorForIsExpression],
-    [Constant.LogicalOperator.And, ValidatorForLogicalAndExpression],
-    [Constant.LogicalOperator.Or, ValidatorForLogicalOrExpression],
-    [Constant.MiscConstant.NullCoalescingOperator, ValidatorForNullCoalescingExpression],
-]);
-
 function addAstAsChild(nodeIdMapCollection: NodeIdMap.Collection, parent: ParseContext.TNode, child: Ast.TNode): void {
     parent.attributeCounter += 1;
 
@@ -367,4 +341,62 @@ function sortByPrecedence(
             return precedenceDelta === 0 ? left.leftOperandIndex - right.leftOperandIndex : precedenceDelta;
         },
     );
+}
+
+function validatorForOperator(operator: Constant.TBinOpExpressionOperator): TValidator {
+    switch (operator) {
+        case Constant.KeywordConstant.Meta:
+            return ValidatorForMetadataExpression;
+
+        case Constant.ArithmeticOperator.Multiplication:
+            return ValidatorForEqualityExpressionAndBelow;
+
+        case Constant.ArithmeticOperator.Division:
+            return ValidatorForEqualityExpressionAndBelow;
+
+        case Constant.ArithmeticOperator.Addition:
+            return ValidatorForEqualityExpressionAndBelow;
+
+        case Constant.ArithmeticOperator.Subtraction:
+            return ValidatorForEqualityExpressionAndBelow;
+
+        case Constant.ArithmeticOperator.And:
+            return ValidatorForEqualityExpressionAndBelow;
+
+        case Constant.RelationalOperator.LessThan:
+            return ValidatorForEqualityExpressionAndBelow;
+
+        case Constant.RelationalOperator.LessThanEqualTo:
+            return ValidatorForEqualityExpressionAndBelow;
+
+        case Constant.RelationalOperator.GreaterThan:
+            return ValidatorForEqualityExpressionAndBelow;
+
+        case Constant.RelationalOperator.GreaterThanEqualTo:
+            return ValidatorForEqualityExpressionAndBelow;
+
+        case Constant.EqualityOperator.EqualTo:
+            return ValidatorForEqualityExpressionAndBelow;
+
+        case Constant.EqualityOperator.NotEqualTo:
+            return ValidatorForEqualityExpressionAndBelow;
+
+        case Constant.KeywordConstant.As:
+            return ValidatorForAsExpression;
+
+        case Constant.KeywordConstant.Is:
+            return ValidatorForIsExpression;
+
+        case Constant.LogicalOperator.And:
+            return ValidatorForLogicalAndExpression;
+
+        case Constant.LogicalOperator.Or:
+            return ValidatorForLogicalOrExpression;
+
+        case Constant.MiscConstant.NullCoalescingOperator:
+            return ValidatorForNullCoalescingExpression;
+
+        default:
+            throw Assert.isNever(operator);
+    }
 }

--- a/src/powerquery-parser/parser/parsers/combinatorialParserV2/readOperatorsAndOperands.ts
+++ b/src/powerquery-parser/parser/parsers/combinatorialParserV2/readOperatorsAndOperands.ts
@@ -41,9 +41,9 @@ export async function readOperatorsAndOperands(
         await parser.readUnaryExpression(state, parser, trace.id),
     ];
 
-    let nextRead: NextOperatorAndOperandRead | undefined = NextOperatorAndOperandReadByTokenKind.get(
-        state.currentTokenKind,
-    );
+    let nextRead: NextOperatorAndOperandRead | undefined = state.currentTokenKind
+        ? nextOperatorAndOperandRead(state.currentTokenKind)
+        : undefined;
 
     while (nextRead) {
         const iterativeParseContext: ParseContext.Node<Ast.TNode> = ParseStateUtils.startContext(
@@ -115,7 +115,7 @@ export async function readOperatorsAndOperands(
 
         // eslint-disable-next-line require-atomic-updates
         state.currentContextNode = initialCurrentContextNode;
-        nextRead = NextOperatorAndOperandReadByTokenKind.get(state.currentTokenKind);
+        nextRead = state.currentTokenKind ? nextOperatorAndOperandRead(state.currentTokenKind) : undefined;
     }
 
     Assert.isTrue(
@@ -154,162 +154,149 @@ interface NextOperatorAndOperandRead {
     readonly operatorConstantKind: Constant.TBinOpExpressionOperator;
 }
 
-const NextOperatorAndOperandReadByTokenKind: ReadonlyMap<Token.TokenKind | undefined, NextOperatorAndOperandRead> =
-    new Map<Token.TokenKind | undefined, NextOperatorAndOperandRead>([
-        [
-            Token.TokenKind.Asterisk,
-            {
+function nextOperatorAndOperandRead(tokenKind: Token.TokenKind): NextOperatorAndOperandRead | undefined {
+    switch (tokenKind) {
+        case Token.TokenKind.Asterisk:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.ArithmeticExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.ArithmeticOperator.Multiplication,
                 operatorTokenKind: Token.TokenKind.Asterisk,
-            },
-        ],
-        [
-            Token.TokenKind.Division,
-            {
+            };
+
+        case Token.TokenKind.Division:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.ArithmeticExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.ArithmeticOperator.Division,
                 operatorTokenKind: Token.TokenKind.Division,
-            },
-        ],
-        [
-            Token.TokenKind.Plus,
-            {
+            };
+
+        case Token.TokenKind.Plus:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.ArithmeticExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.ArithmeticOperator.Addition,
                 operatorTokenKind: Token.TokenKind.Plus,
-            },
-        ],
-        [
-            Token.TokenKind.Minus,
-            {
+            };
+
+        case Token.TokenKind.Minus:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.ArithmeticExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.ArithmeticOperator.Subtraction,
                 operatorTokenKind: Token.TokenKind.Minus,
-            },
-        ],
-        [
-            Token.TokenKind.Ampersand,
-            {
+            };
+
+        case Token.TokenKind.Ampersand:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.ArithmeticExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.ArithmeticOperator.And,
                 operatorTokenKind: Token.TokenKind.Ampersand,
-            },
-        ],
-        [
-            Token.TokenKind.Equal,
-            {
+            };
+
+        case Token.TokenKind.Equal:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.EqualityExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.EqualityOperator.EqualTo,
                 operatorTokenKind: Token.TokenKind.Equal,
-            },
-        ],
-        [
-            Token.TokenKind.NotEqual,
-            {
+            };
+
+        case Token.TokenKind.NotEqual:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.EqualityExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.EqualityOperator.NotEqualTo,
                 operatorTokenKind: Token.TokenKind.NotEqual,
-            },
-        ],
-        [
-            Token.TokenKind.KeywordAnd,
-            {
+            };
+
+        case Token.TokenKind.KeywordAnd:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.LogicalExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.LogicalOperator.And,
                 operatorTokenKind: Token.TokenKind.KeywordAnd,
-            },
-        ],
-        [
-            Token.TokenKind.KeywordOr,
-            {
+            };
+
+        case Token.TokenKind.KeywordOr:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.LogicalExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.LogicalOperator.Or,
                 operatorTokenKind: Token.TokenKind.KeywordOr,
-            },
-        ],
-        [
-            Token.TokenKind.LessThan,
-            {
+            };
+
+        case Token.TokenKind.LessThan:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.RelationalExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.RelationalOperator.LessThan,
                 operatorTokenKind: Token.TokenKind.LessThan,
-            },
-        ],
-        [
-            Token.TokenKind.LessThanEqualTo,
-            {
+            };
+
+        case Token.TokenKind.LessThanEqualTo:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.RelationalExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.RelationalOperator.LessThanEqualTo,
                 operatorTokenKind: Token.TokenKind.LessThanEqualTo,
-            },
-        ],
-        [
-            Token.TokenKind.GreaterThan,
-            {
+            };
+
+        case Token.TokenKind.GreaterThan:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.RelationalExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.RelationalOperator.GreaterThan,
                 operatorTokenKind: Token.TokenKind.GreaterThan,
-            },
-        ],
-        [
-            Token.TokenKind.GreaterThanEqualTo,
-            {
+            };
+
+        case Token.TokenKind.GreaterThanEqualTo:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.RelationalExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.RelationalOperator.GreaterThanEqualTo,
                 operatorTokenKind: Token.TokenKind.GreaterThanEqualTo,
-            },
-        ],
-        [
-            Token.TokenKind.KeywordAs,
-            {
+            };
+
+        case Token.TokenKind.KeywordAs:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.AsExpression,
                 operandNodeKind: Ast.NodeKind.NullablePrimitiveType,
                 operatorConstantKind: Constant.KeywordConstant.As,
                 operatorTokenKind: Token.TokenKind.KeywordAs,
-            },
-        ],
-        [
-            Token.TokenKind.KeywordIs,
-            {
+            };
+
+        case Token.TokenKind.KeywordIs:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.IsExpression,
                 operandNodeKind: Ast.NodeKind.NullablePrimitiveType,
                 operatorConstantKind: Constant.KeywordConstant.Is,
                 operatorTokenKind: Token.TokenKind.KeywordIs,
-            },
-        ],
-        [
-            Token.TokenKind.KeywordMeta,
-            {
+            };
+
+        case Token.TokenKind.KeywordMeta:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.MetadataExpression,
                 operandNodeKind: Ast.NodeKind.UnaryExpression,
                 operatorConstantKind: Constant.KeywordConstant.Meta,
                 operatorTokenKind: Token.TokenKind.KeywordMeta,
-            },
-        ],
-        [
-            Token.TokenKind.NullCoalescingOperator,
-            {
+            };
+
+        case Token.TokenKind.NullCoalescingOperator:
+            return {
                 binOpExpressionNodeKind: Ast.NodeKind.NullCoalescingExpression,
                 operandNodeKind: Ast.NodeKind.LogicalExpression,
                 operatorConstantKind: Constant.MiscConstant.NullCoalescingOperator,
+
                 operatorTokenKind: Token.TokenKind.NullCoalescingOperator,
-            },
-        ],
-    ]);
+            };
+
+        default:
+            return undefined;
+    }
+}
 
 function removeIdFromIdsByNodeKind(idsByNodeKind: IdsByNodeKind, nodeKind: Ast.NodeKind, nodeId: number): void {
     const collection: Set<number> = MapUtils.assertGet(idsByNodeKind, nodeKind);

--- a/src/test/scripts/createBenchmark.ts
+++ b/src/test/scripts/createBenchmark.ts
@@ -14,7 +14,7 @@ import { TestResource } from "../testUtils/resourceUtils";
 const BenchmarkDirectory: string = path.join(__dirname, "benchmark");
 
 // We want to run each file ${IterationsPerFile} times to get a more accurate average duration.
-const IterationsPerFile: number = 100;
+const IterationsPerFile: number = 10;
 // Additionally, we drop the top and bottom ${IterationPercentageDropped}% of
 // durations from iterations to reduce the impact of outliers.
 const IterationPercentageDropped: number = 0.05;
@@ -112,7 +112,10 @@ async function main(): Promise<void> {
         const { fileContents, filePath, resourceName }: TestResource = ArrayUtils.assertGet(resources, resourceIndex);
 
         printText(
-            `Starting resource ${TestUtils.zFill(resourceIndex + 1, numResources)} out of ${numResources}: ${filePath}`,
+            `Starting resource ${TestUtils.zFill(
+                resourceIndex + 1,
+                numResources,
+            )} out of ${numResources}: ${filePath}\n`,
         );
 
         for (const [parserName, parser] of TestConstants.ParserByParserName.entries()) {
@@ -174,6 +177,8 @@ async function main(): Promise<void> {
                 parserName,
                 filePath,
             };
+
+            printText("\n");
 
             const resourceSummaries: ResourceSummary[] = [...(resourceSummariesByParserName.get(parserName) ?? [])];
             resourceSummaries.push(resourceSummary);

--- a/src/test/scripts/createBenchmark.ts
+++ b/src/test/scripts/createBenchmark.ts
@@ -53,6 +53,7 @@ function printText(text: string): void {
     if (process.stdout.isTTY) {
         process.stdout.write(text);
     } else {
+        // Remove trailing newline as console.log already adds one.
         console.log(text.replace(/\n$/, ""));
     }
 }

--- a/src/test/scripts/createNodeDump.ts
+++ b/src/test/scripts/createNodeDump.ts
@@ -49,10 +49,9 @@ async function main(): Promise<void> {
 
         for (const [resource, index] of ArrayUtils.enumerate(resources)) {
             console.log(
-                `Starting ${resource.filePath} using ${parserName} (${TestUtils.zFill(
-                    index + 1,
-                    numResources,
-                )} out of ${numResources})`,
+                `Starting ${TestUtils.zFill(index + 1, numResources)} out of ${numResources} for ${parserName}: ${
+                    resource.filePath
+                }`,
             );
 
             // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
The benchmark/nodeDump work via cmd line but not vscode debugger. Two fixes were needed:
- Change map to function to prevent import race condition
- Conditional usage of `process.stdout.write`