### PR TITLE
LetExpression should allow empty variable list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.15.4",
+    "version": "0.15.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.15.4",
+            "version": "0.15.5",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.15.4",
+    "version": "0.15.5",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
+++ b/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
@@ -1731,7 +1731,7 @@ export async function readLetExpression(
         await parser.readIdentifierPairedExpressions(
             state,
             parser,
-            !ParseStateUtils.isNextTokenKind(state, TokenKind.KeywordIn),
+            !ParseStateUtils.isOnTokenKind(state, TokenKind.KeywordIn),
             ParseStateUtils.testCsvContinuationLetExpression,
             trace.id,
         );

--- a/src/test/libraryTest/parser/simple.ts
+++ b/src/test/libraryTest/parser/simple.ts
@@ -1074,6 +1074,16 @@ describe("Parser.AbridgedNode", () => {
     });
 
     describe(`${Ast.NodeKind.LetExpression}`, () => {
+        it(`let in 1`, async () => {
+            await runAbridgedNodeTest(`let in 1`, [
+                [Ast.NodeKind.LetExpression, undefined],
+                [Ast.NodeKind.Constant, 0],
+                [Ast.NodeKind.ArrayWrapper, 1],
+                [Ast.NodeKind.Constant, 2],
+                [Ast.NodeKind.LiteralExpression, 3],
+            ]);
+        });
+
         it(`let x = 1 in x`, async () => {
             await runAbridgedNodeTest(`let x = 1 in x`, [
                 [Ast.NodeKind.LetExpression, undefined],


### PR DESCRIPTION
Variable lists are optional for LetExpressions, meaning `let in 1` is valid code. I _thought_ this was covered, but it's incorrectly checking nextToken rather than currentToken