### PR TITLE
Fix bugs found during codebase audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.18.6",
+    "version": "0.19.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.18.6",
+            "version": "0.19.0",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.18.6",
+    "version": "0.19.0",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/immutableSet.ts
+++ b/src/powerquery-parser/common/immutableSet.ts
@@ -34,8 +34,8 @@ export class ImmutableSet<T> {
         return result;
     }
 
-    public clear(): void {
-        this.internalCollection = [];
+    public clear(): ImmutableSet<T> {
+        return new ImmutableSet([], this.comparer);
     }
 
     public delete(value: T): ImmutableSet<T> {

--- a/src/powerquery-parser/common/orderedMap.ts
+++ b/src/powerquery-parser/common/orderedMap.ts
@@ -35,11 +35,13 @@ export class OrderedMap<K, V> implements Map<K, V> {
     public clear(): void {
         this.map.clear();
         this.order = [];
+        this.size = 0;
     }
 
     public delete(key: K): boolean {
         if (this.map.delete(key)) {
             this.order = ArrayUtils.assertRemoveFirstInstance(this.order, key);
+            this.size -= 1;
 
             return true;
         } else {
@@ -68,7 +70,7 @@ export class OrderedMap<K, V> implements Map<K, V> {
     }
 
     public keys(): IterableIterator<K> {
-        return this.map.keys();
+        return this.order[Symbol.iterator]();
     }
 
     public set(key: K, value: V, maintainIndex?: boolean): this {
@@ -78,6 +80,7 @@ export class OrderedMap<K, V> implements Map<K, V> {
             }
         } else {
             this.order = [...this.order, key];
+            this.size += 1;
         }
 
         this.map.set(key, value);

--- a/src/powerquery-parser/common/traversal.ts
+++ b/src/powerquery-parser/common/traversal.ts
@@ -162,22 +162,33 @@ async function traverseRecursion<State extends ITraversalState<ResultType>, Resu
         correlationId,
     );
 
-    state.cancellationToken?.throwIfCancelled();
+    try {
+        state.cancellationToken?.throwIfCancelled();
 
-    if (isEarlyExit && (await isEarlyExit(state, node, trace.id))) {
-        return;
-    } else if (strategy === VisitNodeStrategy.BreadthFirst) {
-        await visitNode(state, node, trace.id);
+        if (isEarlyExit && (await isEarlyExit(state, node, trace.id))) {
+            return;
+        } else if (strategy === VisitNodeStrategy.BreadthFirst) {
+            await visitNode(state, node, trace.id);
+        }
+
+        for (const child of await visitOrderQueue(state, node, nodesById)) {
+            // eslint-disable-next-line no-await-in-loop
+            await traverseRecursion(
+                state,
+                nodesById,
+                child,
+                strategy,
+                visitNode,
+                visitOrderQueue,
+                isEarlyExit,
+                trace.id,
+            );
+        }
+
+        if (strategy === VisitNodeStrategy.DepthFirst) {
+            await visitNode(state, node, trace.id);
+        }
+    } finally {
+        trace.exit();
     }
-
-    for (const child of await visitOrderQueue(state, node, nodesById)) {
-        // eslint-disable-next-line no-await-in-loop
-        await traverseRecursion(state, nodesById, child, strategy, visitNode, visitOrderQueue, isEarlyExit, trace.id);
-    }
-
-    if (strategy === VisitNodeStrategy.DepthFirst) {
-        await visitNode(state, node, trace.id);
-    }
-
-    trace.exit();
 }

--- a/src/powerquery-parser/language/ast/astUtils/astUtils.ts
+++ b/src/powerquery-parser/language/ast/astUtils/astUtils.ts
@@ -107,7 +107,7 @@ export function isTRecursivePrimaryExpression(node: Ast.TNode): node is Ast.TRec
     return Ast.NodeKindsForTRecursivePrimaryExpression.has(node.kind);
 }
 
-export function isTRelationalExpression(node: Ast.TNode): node is Ast.TEqualityExpression {
+export function isTRelationalExpression(node: Ast.TNode): node is Ast.TRelationalExpression {
     return Ast.NodeKindsForTRelationalExpression.has(node.kind);
 }
 

--- a/src/powerquery-parser/language/type/type.ts
+++ b/src/powerquery-parser/language/type/type.ts
@@ -143,6 +143,8 @@ export enum TypeKind {
     Unknown = "Unknown",
 }
 
+// Intentionally limited to official Power Query types.
+// Excludes internal-only TypeKinds (None, NotApplicable, Unknown).
 export const TypeKinds: ReadonlyArray<TypeKind> = [
     TypeKind.Action,
     TypeKind.Any,

--- a/src/powerquery-parser/lexer/lexer.ts
+++ b/src/powerquery-parser/lexer/lexer.ts
@@ -22,9 +22,9 @@ import { LexSettings } from "./lexSettings";
 // Lexer functions will return a new state object.
 // Call LexerSnapshot.tryFrom to perform a final validation pass before freezing the State.
 
-// The lexer is mostly functional in nature with a few throws to make error propegation easier.
+// The lexer is mostly functional in nature with a few throws to make error propagation easier.
 //
-// To accomodate being consumed by a VSCode extension the lexer is designed to be line aware.
+// To accommodate being consumed by a VSCode extension the lexer is designed to be line aware.
 // Users who don't care about line awareness and simply want a complete lex pass
 // can call Lexer.stateFrom using a multiline blob.
 //
@@ -238,7 +238,7 @@ interface LineModeAlteringRead {
 }
 
 // Attributes can't be readOnly.
-// In `updateRange` text is updated by adding existing existing lines as a suffix/prefix.
+// In `updateRange` text is updated by adding existing lines as a suffix/prefix.
 // In `splitOnLineTerminators` lineTerminator is updated as the last must have no terminator, eg. ""
 interface SplitLine {
     text: string;
@@ -486,7 +486,6 @@ function retokenizeLines(state: State, lineNumber: number, previousLineModeEnd: 
     const retokenizedLines: TLine[] = [];
 
     if (previousLineModeEnd !== lines[lineNumber].lineModeStart) {
-        const offsetLineNumber: number = lineNumber;
         let currentLine: TLine | undefined = lines[lineNumber];
 
         while (currentLine) {
@@ -497,7 +496,7 @@ function retokenizeLines(state: State, lineNumber: number, previousLineModeEnd: 
 
                 const retokenizedLine: TLine = tokenize(
                     untokenizedLine,
-                    offsetLineNumber,
+                    lineNumber,
                     state.locale,
                     state.cancellationToken,
                 );

--- a/src/powerquery-parser/lexer/lexerSnapshot.ts
+++ b/src/powerquery-parser/lexer/lexerSnapshot.ts
@@ -295,6 +295,7 @@ function createPrecedingDirectivesByLineNumber(
         }
 
         const lineNumber: number = comment.positionStart.lineNumber;
+
         const previousDirectives: ReadonlyArray<Comment.TDirective> | undefined =
             precedingDirectivesByLineNumber.get(lineNumber);
 

--- a/src/powerquery-parser/localization/locale.ts
+++ b/src/powerquery-parser/localization/locale.ts
@@ -3,7 +3,7 @@
 
 export enum Locale {
     bg_BG = "bg-BG",
-    ca_EZ = "ca-EZ",
+    ca_ES = "ca-ES",
     cs_CZ = "cs-CZ",
     da_DK = "da-DK",
     de_DE = "de-DE",

--- a/src/powerquery-parser/localization/localization.ts
+++ b/src/powerquery-parser/localization/localization.ts
@@ -120,7 +120,7 @@ export function localizeTokenKind(localizationTemplates: ILocalizationTemplates,
         case Token.TokenKind.KeywordHashSections:
             return localizationTemplates.tokenKind_keywordHashSections;
         case Token.TokenKind.KeywordHashShared:
-            return localizationTemplates.tokenKind_keywordShared;
+            return localizationTemplates.tokenKind_keywordHashShared;
         case Token.TokenKind.KeywordHashTable:
             return localizationTemplates.tokenKind_keywordHashTable;
         case Token.TokenKind.KeywordHashTime:
@@ -136,7 +136,7 @@ export function localizeTokenKind(localizationTemplates: ILocalizationTemplates,
         case Token.TokenKind.KeywordMeta:
             return localizationTemplates.tokenKind_keywordMeta;
         case Token.TokenKind.KeywordNot:
-            return localizationTemplates.tokenKind_notEqual;
+            return localizationTemplates.tokenKind_keywordNot;
         case Token.TokenKind.KeywordOr:
             return localizationTemplates.tokenKind_keywordOr;
         case Token.TokenKind.KeywordOtherwise:

--- a/src/powerquery-parser/localization/templates.ts
+++ b/src/powerquery-parser/localization/templates.ts
@@ -92,7 +92,7 @@ export {
 
 export const TemplatesByLocale: Map<string, ILocalizationTemplates> = new Map([
     [Locale.bg_BG.toLowerCase(), bg_BG],
-    [Locale.ca_EZ.toLowerCase(), ca_ES],
+    [Locale.ca_ES.toLowerCase(), ca_ES],
     [Locale.cs_CZ.toLowerCase(), cs_CZ],
     [Locale.da_DK.toLowerCase(), da_DK],
     [Locale.de_DE.toLowerCase(), de_DE],

--- a/src/powerquery-parser/parser/context/contextUtils.ts
+++ b/src/powerquery-parser/parser/context/contextUtils.ts
@@ -284,7 +284,7 @@ export function deleteAst(state: ParseContext.State, nodeId: number, parentWillB
     // Not a leaf node.
     Assert.isUndefined(
         childIds,
-        `failed to deleteAst as the given nodeId has one ore more children which must be deleted first`,
+        `failed to deleteAst as the given nodeId has one or more children which must be deleted first`,
         {
             nodeId,
             childIds,
@@ -410,7 +410,7 @@ function deleteFromKindMap(nodeIdMapCollection: NodeIdMap.Collection, nodeId: nu
 }
 
 // Asserts `childId` is in the list of children in for `parentId`.
-// Either removes `childId` in its list of children if no `replcementId` is given,
+// Either removes `childId` from its list of children if no `replacementId` is given,
 // else replaces the `childId` with `replacementId`.
 function removeOrReplaceChildId(
     nodeIdMapCollection: NodeIdMap.Collection,

--- a/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
+++ b/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
@@ -410,7 +410,7 @@ async function thoroughReadAmbiguous<T extends TAmbiguousBracketNode | TAmbiguou
     }
 }
 
-// Converts BracketDisambiguation into its corrosponding read function.
+// Converts BracketDisambiguation into its corresponding read function.
 function bracketDisambiguationParseFunctions(
     parser: Parser,
     allowedVariants: ReadonlyArray<BracketDisambiguation>,

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
@@ -31,7 +31,7 @@ export function recalculateAndUpdateIds(
 }
 
 // Builds up a list of all nodeIds under the given nodeId (including itself),
-// then creates a Map<oldId, newId> such that the Ids are in a BFS ordering.
+// then creates a Map<oldId, newId> such that the Ids are in a DFS ordering.
 // Does not include nodeIds which remain unchanged.
 export function recalculateIds(
     nodeIdMapCollection: NodeIdMap.Collection,

--- a/src/powerquery-parser/task/taskUtils.ts
+++ b/src/powerquery-parser/task/taskUtils.ts
@@ -44,7 +44,7 @@ export function assertIsLexStageOk(task: TTask): asserts task is LexTaskOk {
             expectedResultKind: ResultKind.Ok,
             expectedTaskStage: TaskStage.Lex,
             actualResultKind: task.resultKind,
-            acutalTaskStage: task.stage,
+            actualTaskStage: task.stage,
         });
     }
 }
@@ -55,7 +55,7 @@ export function assertIsLexStageError(task: TTask): asserts task is LexTaskError
             expectedResultKind: ResultKind.Error,
             expectedTaskStage: TaskStage.Lex,
             actualResultKind: task.resultKind,
-            acutalTaskStage: task.stage,
+            actualTaskStage: task.stage,
         });
     }
 }
@@ -73,7 +73,7 @@ export function assertIsParseStage(task: TTask): asserts task is TriedParseTask 
     if (!isParseStage(task)) {
         throw new CommonError.InvariantError(`assert failed, expected a different task stage kind`, {
             expectedTaskStage: TaskStage.Parse,
-            acutalTaskStage: task.stage,
+            actualTaskStage: task.stage,
         });
     }
 }
@@ -84,7 +84,7 @@ export function assertIsParseStageOk(task: TTask): asserts task is ParseTaskOk {
             expectedResultKind: ResultKind.Ok,
             expectedTaskStage: TaskStage.Parse,
             actualResultKind: task.resultKind,
-            acutalTaskStage: task.stage,
+            actualTaskStage: task.stage,
         });
     }
 }
@@ -95,7 +95,7 @@ export function assertIsParseStageError(task: TTask): asserts task is ParseTaskP
             expectedResultKind: ResultKind.Error,
             expectedTaskStage: TaskStage.Parse,
             actualResultKind: task.resultKind,
-            acutalTaskStage: task.stage,
+            actualTaskStage: task.stage,
         });
     }
 }
@@ -107,7 +107,7 @@ export function assertIsParseStageCommonError(task: TTask): asserts task is Pars
             expectedTaskStage: TaskStage.Parse,
             expectedIsCommonError: true,
             actualResultKind: task.resultKind,
-            acutalTaskStage: task.stage,
+            actualTaskStage: task.stage,
             actualIsCommonError: isParseStageError(task) ? task.isCommonError : undefined,
         });
     }
@@ -120,7 +120,7 @@ export function assertIsParseStageParseError(task: TTask): asserts task is Parse
             expectedTaskStage: TaskStage.Parse,
             expectedIsCommonError: true,
             actualResultKind: task.resultKind,
-            acutalTaskStage: task.stage,
+            actualTaskStage: task.stage,
             actualIsCommonError: isParseStageError(task) ? task.isCommonError : undefined,
         });
     }

--- a/src/test/libraryTest/common/immutableSet.test.ts
+++ b/src/test/libraryTest/common/immutableSet.test.ts
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { expect } from "chai";
+
+import { ImmutableSet } from "../../../powerquery-parser/common/immutableSet";
+
+describe("ImmutableSet", () => {
+    describe("constructor", () => {
+        it("empty when no iterable provided", () => {
+            const set: ImmutableSet<number> = new ImmutableSet();
+            expect(set.size).to.equal(0);
+            expect([...set.values()]).to.deep.equal([]);
+        });
+
+        it("from array", () => {
+            const set: ImmutableSet<number> = new ImmutableSet([1, 2, 3]);
+            expect(set.size).to.equal(3);
+            expect(set.has(1)).to.equal(true);
+            expect(set.has(2)).to.equal(true);
+            expect(set.has(3)).to.equal(true);
+        });
+
+        it("from Set", () => {
+            const set: ImmutableSet<string> = new ImmutableSet(new Set(["a", "b"]));
+            expect(set.size).to.equal(2);
+            expect(set.has("a")).to.equal(true);
+            expect(set.has("b")).to.equal(true);
+        });
+
+        it("with custom comparer", () => {
+            const caseInsensitive: (a: string, b: string) => boolean = (a: string, b: string) =>
+                a.toLowerCase() === b.toLowerCase();
+
+            const set: ImmutableSet<string> = new ImmutableSet(["Hello"], caseInsensitive);
+            expect(set.has("hello")).to.equal(true);
+            expect(set.has("HELLO")).to.equal(true);
+        });
+    });
+
+    describe("has", () => {
+        it("returns true for existing value", () => {
+            const set: ImmutableSet<number> = new ImmutableSet([10, 20]);
+            expect(set.has(10)).to.equal(true);
+        });
+
+        it("returns false for missing value", () => {
+            const set: ImmutableSet<number> = new ImmutableSet([10, 20]);
+            expect(set.has(99)).to.equal(false);
+        });
+
+        it("returns false on empty set", () => {
+            const set: ImmutableSet<number> = new ImmutableSet();
+            expect(set.has(1)).to.equal(false);
+        });
+    });
+
+    describe("add", () => {
+        it("returns a new set containing the value", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1]);
+            const result: ImmutableSet<number> = original.add(2);
+            expect(result.size).to.equal(2);
+            expect(result.has(2)).to.equal(true);
+        });
+
+        it("does not mutate the original", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1]);
+            original.add(2);
+            expect(original.size).to.equal(1);
+            expect(original.has(2)).to.equal(false);
+        });
+
+        it("returns same instance when value already exists", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1, 2]);
+            const result: ImmutableSet<number> = original.add(1);
+            expect(result).to.equal(original);
+        });
+
+        it("respects custom comparer for duplicate detection", () => {
+            const caseInsensitive: (a: string, b: string) => boolean = (a: string, b: string) =>
+                a.toLowerCase() === b.toLowerCase();
+
+            const set: ImmutableSet<string> = new ImmutableSet(["Hello"], caseInsensitive);
+            const result: ImmutableSet<string> = set.add("hello");
+            expect(result).to.equal(set);
+        });
+    });
+
+    describe("addMany", () => {
+        it("adds multiple new values", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1]);
+            const result: ImmutableSet<number> = original.addMany([2, 3, 4]);
+            expect(result.size).to.equal(4);
+            expect(result.has(2)).to.equal(true);
+            expect(result.has(4)).to.equal(true);
+        });
+
+        it("does not mutate the original", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1]);
+            original.addMany([2, 3]);
+            expect(original.size).to.equal(1);
+        });
+
+        it("skips values that already exist", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1, 2]);
+            const result: ImmutableSet<number> = original.addMany([2, 3]);
+            expect(result.size).to.equal(3);
+        });
+
+        it("returns same instance when all values already exist", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1, 2]);
+            const result: ImmutableSet<number> = original.addMany([1, 2]);
+            expect(result).to.equal(original);
+        });
+    });
+
+    describe("delete", () => {
+        it("returns a new set without the value", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1, 2, 3]);
+            const result: ImmutableSet<number> = original.delete(2);
+            expect(result.size).to.equal(2);
+            expect(result.has(2)).to.equal(false);
+            expect(result.has(1)).to.equal(true);
+            expect(result.has(3)).to.equal(true);
+        });
+
+        it("does not mutate the original", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1, 2]);
+            original.delete(1);
+            expect(original.size).to.equal(2);
+            expect(original.has(1)).to.equal(true);
+        });
+
+        it("returns same instance when value does not exist", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1, 2]);
+            const result: ImmutableSet<number> = original.delete(99);
+            expect(result).to.equal(original);
+        });
+
+        it("respects custom comparer", () => {
+            const caseInsensitive: (a: string, b: string) => boolean = (a: string, b: string) =>
+                a.toLowerCase() === b.toLowerCase();
+
+            const set: ImmutableSet<string> = new ImmutableSet(["Hello", "World"], caseInsensitive);
+            const result: ImmutableSet<string> = set.delete("hello");
+            expect(result.size).to.equal(1);
+            expect(result.has("Hello")).to.equal(false);
+            expect(result.has("World")).to.equal(true);
+        });
+    });
+
+    describe("clear", () => {
+        it("returns a new empty set", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1, 2, 3]);
+            const cleared: ImmutableSet<number> = original.clear();
+            expect(cleared.size).to.equal(0);
+            expect([...cleared.values()]).to.deep.equal([]);
+        });
+
+        it("does not mutate the original", () => {
+            const original: ImmutableSet<number> = new ImmutableSet([1, 2, 3]);
+            original.clear();
+            expect(original.size).to.equal(3);
+            expect(original.has(1)).to.equal(true);
+        });
+
+        it("cleared set preserves the comparer", () => {
+            const caseInsensitive: (a: string, b: string) => boolean = (a: string, b: string) =>
+                a.toLowerCase() === b.toLowerCase();
+
+            const original: ImmutableSet<string> = new ImmutableSet(["Hello"], caseInsensitive);
+            const cleared: ImmutableSet<string> = original.clear();
+            const result: ImmutableSet<string> = cleared.add("World").add("world");
+            expect(result.size).to.equal(1);
+        });
+    });
+
+    describe("values", () => {
+        it("returns all values", () => {
+            const set: ImmutableSet<number> = new ImmutableSet([1, 2, 3]);
+            expect([...set.values()]).to.have.members([1, 2, 3]);
+        });
+
+        it("returns empty iterator for empty set", () => {
+            const set: ImmutableSet<number> = new ImmutableSet();
+            expect([...set.values()]).to.deep.equal([]);
+        });
+    });
+
+    describe("size", () => {
+        it("reflects the number of elements", () => {
+            expect(new ImmutableSet().size).to.equal(0);
+            expect(new ImmutableSet([1]).size).to.equal(1);
+            expect(new ImmutableSet([1, 2, 3]).size).to.equal(3);
+        });
+    });
+});

--- a/src/test/libraryTest/common/orderedMap.test.ts
+++ b/src/test/libraryTest/common/orderedMap.test.ts
@@ -1,0 +1,252 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { expect } from "chai";
+
+import { OrderedMap } from "../../../powerquery-parser/common/orderedMap";
+
+describe("OrderedMap", () => {
+    describe("constructor", () => {
+        it("empty when no entries provided", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            expect(map.size).to.equal(0);
+            expect([...map.keys()]).to.deep.equal([]);
+        });
+
+        it("from array entries", () => {
+            const map: OrderedMap<string, number> = new OrderedMap([
+                ["a", 1],
+                ["b", 2],
+            ]);
+
+            expect(map.size).to.equal(2);
+            expect(map.get("a")).to.equal(1);
+            expect(map.get("b")).to.equal(2);
+        });
+
+        it("from Map", () => {
+            const source: Map<string, number> = new Map([
+                ["x", 10],
+                ["y", 20],
+            ]);
+
+            const map: OrderedMap<string, number> = new OrderedMap(source);
+            expect(map.size).to.equal(2);
+            expect(map.get("x")).to.equal(10);
+            expect(map.get("y")).to.equal(20);
+        });
+
+        it("from null", () => {
+            const map: OrderedMap<string, number> = new OrderedMap(null);
+            expect(map.size).to.equal(0);
+        });
+
+        it("from undefined", () => {
+            const map: OrderedMap<string, number> = new OrderedMap(undefined);
+            expect(map.size).to.equal(0);
+        });
+    });
+
+    describe("set", () => {
+        it("adds a new key and increments size", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("a", 1);
+            expect(map.size).to.equal(1);
+            expect(map.get("a")).to.equal(1);
+        });
+
+        it("updates value for existing key without changing size", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("a", 1);
+            map.set("a", 99);
+            expect(map.size).to.equal(1);
+            expect(map.get("a")).to.equal(99);
+        });
+
+        it("moves existing key to end by default", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("a", 1);
+            map.set("b", 2);
+            map.set("c", 3);
+            map.set("a", 99);
+            expect([...map.keys()]).to.deep.equal(["b", "c", "a"]);
+        });
+
+        it("preserves position with maintainIndex", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("a", 1);
+            map.set("b", 2);
+            map.set("c", 3);
+            map.set("a", 99, true);
+            expect([...map.keys()]).to.deep.equal(["a", "b", "c"]);
+            expect(map.get("a")).to.equal(99);
+        });
+
+        it("returns this for chaining", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            const result: OrderedMap<string, number> = map.set("a", 1);
+            expect(result).to.equal(map);
+        });
+    });
+
+    describe("get", () => {
+        it("returns value for existing key", () => {
+            const map: OrderedMap<string, number> = new OrderedMap([["a", 1]]);
+            expect(map.get("a")).to.equal(1);
+        });
+
+        it("returns undefined for missing key", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            expect(map.get("missing")).to.equal(undefined);
+        });
+    });
+
+    describe("has", () => {
+        it("returns true for existing key", () => {
+            const map: OrderedMap<string, number> = new OrderedMap([["a", 1]]);
+            expect(map.has("a")).to.equal(true);
+        });
+
+        it("returns false for missing key", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            expect(map.has("missing")).to.equal(false);
+        });
+    });
+
+    describe("delete", () => {
+        it("removes existing key and decrements size", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("a", 1);
+            map.set("b", 2);
+            expect(map.delete("a")).to.equal(true);
+            expect(map.size).to.equal(1);
+            expect(map.has("a")).to.equal(false);
+            expect(map.get("a")).to.equal(undefined);
+        });
+
+        it("returns false for missing key without changing size", () => {
+            const map: OrderedMap<string, number> = new OrderedMap([["a", 1]]);
+            expect(map.delete("missing")).to.equal(false);
+            expect(map.size).to.equal(1);
+        });
+
+        it("removes key from iteration order", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("a", 1);
+            map.set("b", 2);
+            map.set("c", 3);
+            map.delete("b");
+            expect([...map.keys()]).to.deep.equal(["a", "c"]);
+        });
+    });
+
+    describe("clear", () => {
+        it("removes all entries and resets size to 0", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("a", 1);
+            map.set("b", 2);
+            map.set("c", 3);
+            expect(map.size).to.equal(3);
+            map.clear();
+            expect(map.size).to.equal(0);
+            expect([...map.keys()]).to.deep.equal([]);
+            expect([...map.entries()]).to.deep.equal([]);
+        });
+    });
+
+    describe("keys", () => {
+        it("returns keys in insertion order", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("c", 3);
+            map.set("a", 1);
+            map.set("b", 2);
+            expect([...map.keys()]).to.deep.equal(["c", "a", "b"]);
+        });
+
+        it("returns empty iterator for empty map", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            expect([...map.keys()]).to.deep.equal([]);
+        });
+    });
+
+    describe("values", () => {
+        it("returns all values", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("a", 1);
+            map.set("b", 2);
+            expect([...map.values()]).to.have.members([1, 2]);
+        });
+
+        it("returns empty iterator for empty map", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            expect([...map.values()]).to.deep.equal([]);
+        });
+    });
+
+    describe("entries", () => {
+        it("returns key-value pairs in insertion order", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("c", 3);
+            map.set("a", 1);
+
+            expect([...map.entries()]).to.deep.equal([
+                ["c", 3],
+                ["a", 1],
+            ]);
+        });
+
+        it("returns empty iterator for empty map", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            expect([...map.entries()]).to.deep.equal([]);
+        });
+    });
+
+    describe("forEach", () => {
+        it("iterates over all entries in order", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("a", 1);
+            map.set("b", 2);
+
+            const collected: [string, number][] = [];
+            map.forEach((value: number, key: string) => collected.push([key, value]));
+
+            expect(collected).to.deep.equal([
+                ["a", 1],
+                ["b", 2],
+            ]);
+        });
+
+        it("does not call callback for empty map", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            let called: boolean = false;
+            map.forEach(() => (called = true));
+            expect(called).to.equal(false);
+        });
+    });
+
+    describe("[Symbol.iterator]", () => {
+        it("supports for-of iteration in insertion order", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("b", 2);
+            map.set("a", 1);
+
+            const collected: [string, number][] = [];
+
+            for (const entry of map) {
+                collected.push(entry);
+            }
+
+            expect(collected).to.deep.equal([
+                ["b", 2],
+                ["a", 1],
+            ]);
+        });
+
+        it("supports spread", () => {
+            const map: OrderedMap<string, number> = new OrderedMap();
+            map.set("x", 10);
+            expect([...map]).to.deep.equal([["x", 10]]);
+        });
+    });
+});

--- a/src/test/libraryTest/lexer/retokenizeLineNumbers.test.ts
+++ b/src/test/libraryTest/lexer/retokenizeLineNumbers.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { expect } from "chai";
+
+import { Lexer, ResultUtils } from "../../..";
+import { assertGetLexOk } from "../../testUtils/lexTestUtils";
+
+describe("Lexer.retokenizeLines line numbers", () => {
+    it("retokenized lines have correct line numbers after multiline string insertion", () => {
+        // Start with a 3-line document where line 0 starts an unterminated string,
+        // causing lines 1 and 2 to be retokenized in Text mode.
+        // The bug was that all retokenized lines received the same line number.
+        const text: string = `"\nbravo\ncharlie`;
+
+        const state: Lexer.State = assertGetLexOk(text);
+
+        // Verify each line tracks its own line number by checking lineModeStart.
+        // Lines 1 and 2 should be in Text mode (continuation of the unterminated string),
+        // and each should be a distinct line object (not collapsed).
+        expect(state.lines.length).to.equal(3, "expected 3 lines");
+
+        // Now update line 0 to close the string, which should retokenize lines 1 and 2
+        // back to Default mode with correct line numbers.
+        const triedUpdate: Lexer.TriedLex = Lexer.tryUpdateLine(state, 0, `"hello"`);
+        ResultUtils.assertIsOk(triedUpdate);
+
+        const updated: Lexer.State = triedUpdate.value;
+        expect(updated.lines.length).to.equal(3, "expected 3 lines after update");
+
+        // All lines should now be in Default mode since line 0 is a complete string
+        expect(updated.lines[0].lineModeEnd).to.equal(Lexer.LineMode.Default, "line 0 should end in Default mode");
+        expect(updated.lines[1].lineModeStart).to.equal(Lexer.LineMode.Default, "line 1 should start in Default mode");
+        expect(updated.lines[2].lineModeStart).to.equal(Lexer.LineMode.Default, "line 2 should start in Default mode");
+
+        // Now snapshot to get token positions and verify line numbers are correct.
+        const triedSnapshot: Lexer.TriedLexerSnapshot = Lexer.trySnapshot(updated);
+        ResultUtils.assertIsOk(triedSnapshot);
+
+        const snapshot: Lexer.LexerSnapshot = triedSnapshot.value;
+
+        for (const token of snapshot.tokens) {
+            expect(token.positionStart.lineNumber).to.be.at.most(
+                token.positionEnd.lineNumber,
+                "token start line should be <= end line",
+            );
+
+            // No token should claim to be on a line number beyond the last line
+            expect(token.positionStart.lineNumber).to.be.lessThan(
+                updated.lines.length,
+                `token line number ${token.positionStart.lineNumber} exceeds line count ${updated.lines.length}`,
+            );
+        }
+    });
+});


### PR DESCRIPTION
  Summary

  Comprehensive bug audit of the parser codebase uncovering and fixing correctness issues across the lexer, parser,
  common utilities, language types, localization, and task modules. All existing tests continue to pass; new tests
  added for the most impactful fixes.

  Bug Fixes

  Critical

   - OrderedMap.size never updated — set(), delete(), and clear() now correctly maintain the size property, restoring
  the Map interface contract.
   - Lexer retokenizeLines wrong line number — tokenize() was called with a stale offsetLineNumber captured once,
  instead of the incrementing lineNumber. All retokenized lines received the same line number, breaking downstream
  error reporting.

  High

   - OrderedMap.keys() bypassed insertion order — returned this.map.keys() instead of iterating the order array. Now
  returns keys in the correct custom order.
   - ImmutableSet.clear() mutated internal state — emptied the backing array but left readonly size stale. Now returns
   a new empty instance, consistent with add() and delete().
   - isTRelationalExpression wrong return type — type guard narrowed to TEqualityExpression instead of
  TRelationalExpression, causing incorrect type narrowing for callers.
   - Localization: KeywordNot → wrong template — mapped to tokenKind_notEqual instead of tokenKind_keywordNot.
   - Localization: KeywordHashShared → wrong template — mapped to tokenKind_keywordShared instead of
  tokenKind_keywordHashShared.
   - Locale code typo — ca_EZ corrected to ca_ES (Catalan-Spain).
   - traverseRecursion missing trace.exit() — early exit, cancellation, and await rejections all skipped trace.exit().
   Wrapped body in try/finally.

  Comment & Typo Fixes

   - recalculateIds comment: "BFS" → "DFS" (matches actual prepend-based traversal)
   - taskUtils: acutalTaskStage → actualTaskStage (×7 occurrences)
   - contextUtils: "one ore more" → "one or more"; "replcementId" → "replacementId"
   - disambiguationUtils: "corrosponding" → "corresponding"
   - lexer.ts: "propegation" → "propagation"; "accomodate" → "accommodate"; "existing existing" → "existing"
   - type.ts: added comment clarifying TypeKinds intentionally excludes internal-only types (None, NotApplicable,
  Unknown)

  Tests Added

  659 tests passing (up from 605 baseline).