### PR TITLE
Enable noUncheckedIndexedAccess with ArrayUtils.assertGet and StringUtils.assertGet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.19.0",
+    "version": "0.19.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-parser",
-            "version": "0.19.0",
+            "version": "0.19.1",
             "license": "MIT",
             "dependencies": {
                 "grapheme-splitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-parser",
-    "version": "0.19.0",
+    "version": "0.19.1",
     "description": "A parser for the Power Query/M formula language.",
     "author": "Microsoft",
     "license": "MIT",

--- a/src/powerquery-parser/common/arrayUtils.ts
+++ b/src/powerquery-parser/common/arrayUtils.ts
@@ -17,7 +17,11 @@ export function all<T>(
 }
 
 export function assertGet<T>(collection: ReadonlyArray<T>, index: number, message?: string, details?: object): T {
-    return Assert.asDefined(collection[index], message, details);
+    return Assert.asDefined(
+        collection[index],
+        message ?? "index out of bounds",
+        details ?? { index, collectionLength: collection.length },
+    );
 }
 
 export function assertIncludes<T>(collection: ReadonlyArray<T>, element: T, message?: string, details?: object): void {

--- a/src/powerquery-parser/common/stringUtils.ts
+++ b/src/powerquery-parser/common/stringUtils.ts
@@ -162,7 +162,7 @@ export function findQuotes(text: string, indexStart: number): FoundQuotes | unde
 }
 
 export function newlineKindAt(text: string, index: number): NewlineKind | undefined {
-    const chr1: string = text[index];
+    const chr1: string | undefined = text[index];
 
     switch (chr1) {
         case `\u000d`: {
@@ -199,7 +199,7 @@ export function isHex(text: string): boolean {
 }
 
 export function getSign(text: string): [boolean, number] {
-    let char: string = text[0];
+    let char: string | undefined = text[0];
     let charOffset: number = 0;
     let isPositive: boolean = true;
 

--- a/src/powerquery-parser/common/stringUtils.ts
+++ b/src/powerquery-parser/common/stringUtils.ts
@@ -5,6 +5,14 @@
 import GraphemeSplitter = require("grapheme-splitter");
 import { Assert, CommonError, Pattern } from ".";
 
+export function assertGet(text: string, index: number, message?: string, details?: object): string {
+    return Assert.asDefined(
+        text[index],
+        message ?? "index out of bounds",
+        details ?? { index, textLength: text.length },
+    );
+}
+
 export const graphemeSplitter: GraphemeSplitter = new GraphemeSplitter();
 
 export interface FoundQuotes {

--- a/src/powerquery-parser/language/identifierUtils.ts
+++ b/src/powerquery-parser/language/identifierUtils.ts
@@ -271,7 +271,7 @@ function getGeneralizedIdentifierLength(text: string, index: number): number | u
     let continueMatching: boolean = true;
 
     while (continueMatching) {
-        const currentChr: string = text[index];
+        const currentChr: string | undefined = text[index];
 
         if (currentChr === " ") {
             index += 1;

--- a/src/powerquery-parser/language/type/typeUtils/factories.ts
+++ b/src/powerquery-parser/language/type/typeUtils/factories.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Assert, CommonError, StringUtils } from "../../../common";
+import { ArrayUtils, Assert, CommonError, StringUtils } from "../../../common";
 import { PrimitiveTypeConstantMap, primitiveTypeMapKey } from "./primitive";
 import { Trace, TraceManager } from "../../../common/trace";
 import { simplify } from "./simplify";
@@ -31,7 +31,7 @@ export function anyUnion(
     if (simplified.length === 1) {
         trace.exit();
 
-        return Assert.asDefined(simplified[0]);
+        return ArrayUtils.assertGet(simplified, 0);
     }
 
     const result: Type.AnyUnion = {

--- a/src/powerquery-parser/language/type/typeUtils/factories.ts
+++ b/src/powerquery-parser/language/type/typeUtils/factories.ts
@@ -31,7 +31,7 @@ export function anyUnion(
     if (simplified.length === 1) {
         trace.exit();
 
-        return simplified[0];
+        return Assert.asDefined(simplified[0]);
     }
 
     const result: Type.AnyUnion = {

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Assert, CommonError, MapUtils } from "../../../common";
+import { ArrayUtils, Assert, CommonError, MapUtils } from "../../../common";
 import { isEqualFunctionSignature, isEqualType } from "./isEqualType";
 import { isFieldSpecificationList, isFunctionSignature } from "./isType";
 import { Trace, TraceManager } from "../../../common/trace";
@@ -777,7 +777,7 @@ function isCompatibleDefinedListOrDefinedListType<T extends Type.DefinedList | T
     const numElements: number = leftElements.length;
 
     for (let index: number = 0; index < numElements; index += 1) {
-        if (!isCompatible(Assert.asDefined(leftElements[index]), Assert.asDefined(rightElements[index]), traceManager, trace.id)) {
+        if (!isCompatible(ArrayUtils.assertGet(leftElements, index), ArrayUtils.assertGet(rightElements, index), traceManager, trace.id)) {
             trace.exit();
 
             return false;

--- a/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isCompatible.ts
@@ -777,7 +777,7 @@ function isCompatibleDefinedListOrDefinedListType<T extends Type.DefinedList | T
     const numElements: number = leftElements.length;
 
     for (let index: number = 0; index < numElements; index += 1) {
-        if (!isCompatible(leftElements[index], rightElements[index], traceManager, trace.id)) {
+        if (!isCompatible(Assert.asDefined(leftElements[index]), Assert.asDefined(rightElements[index]), traceManager, trace.id)) {
             trace.exit();
 
             return false;

--- a/src/powerquery-parser/language/type/typeUtils/isEqualType.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isEqualType.ts
@@ -56,7 +56,7 @@ export function isEqualTypes(
     const numTypes: number = leftTypes.length;
 
     for (let index: number = 0; index < numTypes; index += 1) {
-        if (!isTypeInArray(leftTypes, rightTypes[index])) {
+        if (!isTypeInArray(leftTypes, Assert.asDefined(rightTypes[index]))) {
             return false;
         }
     }
@@ -144,7 +144,7 @@ export function isEqualDefinedList(left: Type.DefinedList, right: Type.DefinedLi
 
     return ArrayUtils.all(
         left.elements.map((leftType: Type.TPowerQueryType, index: number) =>
-            isEqualType(leftType, rightElements[index]),
+            isEqualType(leftType, Assert.asDefined(rightElements[index])),
         ),
     );
 }
@@ -160,7 +160,7 @@ export function isEqualDefinedListType(left: Type.DefinedListType, right: Type.D
 
     return ArrayUtils.all(
         left.itemTypes.map((leftType: Type.TPowerQueryType, index: number) =>
-            isEqualType(leftType, rightElements[index]),
+            isEqualType(leftType, Assert.asDefined(rightElements[index])),
         ),
     );
 }
@@ -224,8 +224,8 @@ export function isEqualFunctionParameters(
     const numParameters: number = left.length;
 
     for (let index: number = 0; index < numParameters; index += 1) {
-        const nthLeft: Type.FunctionParameter = left[index];
-        const nthRight: Type.FunctionParameter = right[index];
+        const nthLeft: Type.FunctionParameter = Assert.asDefined(left[index]);
+        const nthRight: Type.FunctionParameter = Assert.asDefined(right[index]);
 
         if (!isEqualFunctionParameter(nthLeft, nthRight)) {
             return false;

--- a/src/powerquery-parser/language/type/typeUtils/isEqualType.ts
+++ b/src/powerquery-parser/language/type/typeUtils/isEqualType.ts
@@ -56,7 +56,7 @@ export function isEqualTypes(
     const numTypes: number = leftTypes.length;
 
     for (let index: number = 0; index < numTypes; index += 1) {
-        if (!isTypeInArray(leftTypes, Assert.asDefined(rightTypes[index]))) {
+        if (!isTypeInArray(leftTypes, ArrayUtils.assertGet(rightTypes, index))) {
             return false;
         }
     }
@@ -144,7 +144,7 @@ export function isEqualDefinedList(left: Type.DefinedList, right: Type.DefinedLi
 
     return ArrayUtils.all(
         left.elements.map((leftType: Type.TPowerQueryType, index: number) =>
-            isEqualType(leftType, Assert.asDefined(rightElements[index])),
+            isEqualType(leftType, ArrayUtils.assertGet(rightElements, index)),
         ),
     );
 }
@@ -160,7 +160,7 @@ export function isEqualDefinedListType(left: Type.DefinedListType, right: Type.D
 
     return ArrayUtils.all(
         left.itemTypes.map((leftType: Type.TPowerQueryType, index: number) =>
-            isEqualType(leftType, Assert.asDefined(rightElements[index])),
+            isEqualType(leftType, ArrayUtils.assertGet(rightElements, index)),
         ),
     );
 }
@@ -224,8 +224,8 @@ export function isEqualFunctionParameters(
     const numParameters: number = left.length;
 
     for (let index: number = 0; index < numParameters; index += 1) {
-        const nthLeft: Type.FunctionParameter = Assert.asDefined(left[index]);
-        const nthRight: Type.FunctionParameter = Assert.asDefined(right[index]);
+        const nthLeft: Type.FunctionParameter = ArrayUtils.assertGet(left, index);
+        const nthRight: Type.FunctionParameter = ArrayUtils.assertGet(right, index);
 
         if (!isEqualFunctionParameter(nthLeft, nthRight)) {
             return false;

--- a/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
@@ -3,7 +3,7 @@
 
 import { isCompatible, isCompatibleWithFunctionParameter } from "./isCompatible";
 import { Trace, TraceManager } from "../../../common/trace";
-import { ArrayUtils, Assert } from "../../../common";
+import { ArrayUtils } from "../../../common";
 import { isEqualFunctionParameter } from "./isEqualType";
 import { Type } from "..";
 import { TypeUtilsTraceConstant } from "./typeTraceConstant";
@@ -127,7 +127,7 @@ export function typeCheckInvocation(
 
     for (let index: number = 0; index < numParameters; index += 1) {
         const arg: Type.TPowerQueryType | undefined = args[index];
-        const parameter: Type.FunctionParameter = Assert.asDefined(parameters[index]);
+        const parameter: Type.FunctionParameter = ArrayUtils.assertGet(parameters, index);
 
         if (isCompatibleWithFunctionParameter(arg, parameter)) {
             validArgs.push(index);
@@ -257,8 +257,8 @@ function typeCheckGenericNumber<
     const mismatches: Map<number, IMismatch<Value, Schema>> = new Map();
 
     for (let index: number = 0; index < upperBound; index += 1) {
-        const element: Value = Assert.asDefined(valueElements[index]);
-        const schemaItemType: Schema = Assert.asDefined(schemaItemTypes[index]);
+        const element: Value = ArrayUtils.assertGet(valueElements, index);
+        const schemaItemType: Schema = ArrayUtils.assertGet(schemaItemTypes, index);
 
         if (comparer(element, schemaItemType, traceManager, trace.id)) {
             validIndices.push(index);

--- a/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeCheck.ts
@@ -3,7 +3,7 @@
 
 import { isCompatible, isCompatibleWithFunctionParameter } from "./isCompatible";
 import { Trace, TraceManager } from "../../../common/trace";
-import { ArrayUtils } from "../../../common";
+import { ArrayUtils, Assert } from "../../../common";
 import { isEqualFunctionParameter } from "./isEqualType";
 import { Type } from "..";
 import { TypeUtilsTraceConstant } from "./typeTraceConstant";
@@ -127,7 +127,7 @@ export function typeCheckInvocation(
 
     for (let index: number = 0; index < numParameters; index += 1) {
         const arg: Type.TPowerQueryType | undefined = args[index];
-        const parameter: Type.FunctionParameter = parameters[index];
+        const parameter: Type.FunctionParameter = Assert.asDefined(parameters[index]);
 
         if (isCompatibleWithFunctionParameter(arg, parameter)) {
             validArgs.push(index);
@@ -257,8 +257,8 @@ function typeCheckGenericNumber<
     const mismatches: Map<number, IMismatch<Value, Schema>> = new Map();
 
     for (let index: number = 0; index < upperBound; index += 1) {
-        const element: Value = valueElements[index];
-        const schemaItemType: Schema = schemaItemTypes[index];
+        const element: Value = Assert.asDefined(valueElements[index]);
+        const schemaItemType: Schema = Assert.asDefined(schemaItemTypes[index]);
 
         if (comparer(element, schemaItemType, traceManager, trace.id)) {
             validIndices.push(index);

--- a/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
+++ b/src/powerquery-parser/language/type/typeUtils/typeUtils.ts
@@ -4,7 +4,7 @@
 import { Ast, AstUtils } from "../..";
 import { NodeIdMap, NodeIdMapUtils, ParseContext, XorNode, XorNodeKind } from "../../../parser";
 import { Trace, TraceManager } from "../../../common/trace";
-import { Assert } from "../../../common";
+import { ArrayUtils, Assert } from "../../../common";
 import { isCompatible } from "./isCompatible";
 import { isEqualType } from "./isEqualType";
 import { primitiveType } from "./factories";
@@ -91,7 +91,7 @@ export function isValidInvocation(
     const numParameters: number = parameters.length;
 
     for (let index: number = 1; index < numParameters; index += 1) {
-        const parameter: Type.FunctionParameter = Assert.asDefined(parameters[index]);
+        const parameter: Type.FunctionParameter = ArrayUtils.assertGet(parameters, index);
         const argType: Type.TPowerQueryType | undefined = args[index];
 
         if (argType !== undefined) {

--- a/src/powerquery-parser/lexer/lexer.ts
+++ b/src/powerquery-parser/lexer/lexer.ts
@@ -148,8 +148,8 @@ export function equalLines(leftLines: ReadonlyArray<TLine>, rightLines: Readonly
     const numLines: number = leftLines.length;
 
     for (let lineIndex: number = 0; lineIndex < numLines; lineIndex += 1) {
-        const left: TLine = leftLines[lineIndex];
-        const right: TLine = rightLines[lineIndex];
+        const left: TLine = Assert.asDefined(leftLines[lineIndex]);
+        const right: TLine = Assert.asDefined(rightLines[lineIndex]);
         const leftTokens: ReadonlyArray<Token.LineToken> = left.tokens;
         const rightTokens: ReadonlyArray<Token.LineToken> = right.tokens;
 
@@ -168,7 +168,7 @@ export function equalLines(leftLines: ReadonlyArray<TLine>, rightLines: Readonly
         const numTokens: number = leftTokens.length;
 
         for (let tokenIndex: number = 0; tokenIndex < numTokens; tokenIndex += 1) {
-            if (!equalTokens(leftTokens[tokenIndex], rightTokens[tokenIndex])) {
+            if (!equalTokens(Assert.asDefined(leftTokens[tokenIndex]), Assert.asDefined(rightTokens[tokenIndex]))) {
                 return false;
             }
         }
@@ -265,7 +265,7 @@ function splitOnLineTerminators(startingText: string): SplitLine[] {
         let indexWasExpanded: boolean = false;
 
         for (const lineTerminator of lineTerminators) {
-            const splitLine: SplitLine = lines[index];
+            const splitLine: SplitLine = Assert.asDefined(lines[index]);
             const text: string = splitLine.text;
 
             if (text.indexOf(lineTerminator) !== -1) {
@@ -276,7 +276,7 @@ function splitOnLineTerminators(startingText: string): SplitLine[] {
                     lineTerminator,
                 }));
 
-                split[split.length - 1].lineTerminator = splitLine.lineTerminator;
+                Assert.asDefined(split[split.length - 1]).lineTerminator = splitLine.lineTerminator;
 
                 lines = [...lines.slice(0, index), ...split, ...lines.slice(index + 1)];
             }
@@ -287,7 +287,7 @@ function splitOnLineTerminators(startingText: string): SplitLine[] {
         }
     }
 
-    lines[lines.length - 1].lineTerminator = "";
+    Assert.asDefined(lines[lines.length - 1]).lineTerminator = "";
 
     return lines;
 }
@@ -356,7 +356,7 @@ function updateLine(state: State, lineNumber: number, text: string): State {
         throw error;
     }
 
-    const line: TLine = state.lines[lineNumber];
+    const line: TLine = Assert.asDefined(state.lines[lineNumber]);
     const range: Range = rangeFrom(line, lineNumber);
 
     return updateRange(state, range, text);
@@ -374,14 +374,14 @@ function updateRange(state: State, range: Range, text: string): State {
     const splitLines: SplitLine[] = splitOnLineTerminators(text);
 
     const rangeStart: RangePosition = range.start;
-    const lineStart: TLine = state.lines[rangeStart.lineNumber];
+    const lineStart: TLine = Assert.asDefined(state.lines[rangeStart.lineNumber]);
     const textPrefix: string = lineStart.text.substring(0, rangeStart.lineCodeUnit);
-    splitLines[0].text = textPrefix + splitLines[0].text;
+    Assert.asDefined(splitLines[0]).text = textPrefix + Assert.asDefined(splitLines[0]).text;
 
     const rangeEnd: RangePosition = range.end;
-    const lineEnd: TLine = state.lines[rangeEnd.lineNumber];
+    const lineEnd: TLine = Assert.asDefined(state.lines[rangeEnd.lineNumber]);
     const textSuffix: string = lineEnd.text.substr(rangeEnd.lineCodeUnit);
-    const lastSplitLine: SplitLine = splitLines[splitLines.length - 1];
+    const lastSplitLine: SplitLine = Assert.asDefined(splitLines[splitLines.length - 1]);
     lastSplitLine.text = lastSplitLine.text + textSuffix;
 
     // make sure we have a line terminator
@@ -400,7 +400,7 @@ function updateRange(state: State, range: Range, text: string): State {
     const lines: ReadonlyArray<TLine> = [
         ...state.lines.slice(0, rangeStart.lineNumber),
         ...newLines,
-        ...retokenizeLines(state, rangeEnd.lineNumber + 1, newLines[newLines.length - 1].lineModeEnd),
+        ...retokenizeLines(state, rangeEnd.lineNumber + 1, Assert.asDefined(newLines[newLines.length - 1]).lineModeEnd),
     ];
 
     return {
@@ -485,7 +485,7 @@ function retokenizeLines(state: State, lineNumber: number, previousLineModeEnd: 
 
     const retokenizedLines: TLine[] = [];
 
-    if (previousLineModeEnd !== lines[lineNumber].lineModeStart) {
+    if (previousLineModeEnd !== Assert.asDefined(lines[lineNumber]).lineModeStart) {
         let currentLine: TLine | undefined = lines[lineNumber];
 
         while (currentLine) {
@@ -793,7 +793,7 @@ function tokenizeTextLiteralContentOrEnd(line: TLine, currentPosition: number): 
 function tokenizeDefault(line: TLine, lineNumber: number, positionStart: number, locale: string): LineModeAlteringRead {
     const text: string = line.text;
 
-    const chr1: string = text[positionStart];
+    const chr1: string = Assert.asDefined(text[positionStart]);
     let token: Token.LineToken;
     let lineMode: LineMode = LineMode.Default;
 
@@ -855,7 +855,7 @@ function tokenizeDefault(line: TLine, lineNumber: number, positionStart: number,
         } else if ("1" <= chr2 && chr2 <= "9") {
             token = readNumericLiteral(text, lineNumber, positionStart, locale);
         } else if (chr2 === ".") {
-            const chr3: string = text[positionStart + 2];
+            const chr3: string = Assert.asDefined(text[positionStart + 2]);
 
             if (chr3 === ".") {
                 token = readConstant(Token.LineTokenKind.Ellipsis, text, positionStart, 3);
@@ -1321,8 +1321,8 @@ function testBadRangeError(state: State, range: Range): LexError.BadRangeError |
     const rangeStart: RangePosition = range.start;
     const rangeEnd: RangePosition = range.end;
 
-    const lineStart: TLine = lines[rangeStart.lineNumber];
-    const lineEnd: TLine = lines[rangeEnd.lineNumber];
+    const lineStart: TLine = Assert.asDefined(lines[rangeStart.lineNumber]);
+    const lineEnd: TLine = Assert.asDefined(lines[rangeEnd.lineNumber]);
 
     if (rangeStart.lineCodeUnit > lineStart.text.length) {
         kind = LexError.BadRangeKind.LineCodeUnitStart_GreaterThan_LineLength;

--- a/src/powerquery-parser/lexer/lexer.ts
+++ b/src/powerquery-parser/lexer/lexer.ts
@@ -148,8 +148,8 @@ export function equalLines(leftLines: ReadonlyArray<TLine>, rightLines: Readonly
     const numLines: number = leftLines.length;
 
     for (let lineIndex: number = 0; lineIndex < numLines; lineIndex += 1) {
-        const left: TLine = Assert.asDefined(leftLines[lineIndex]);
-        const right: TLine = Assert.asDefined(rightLines[lineIndex]);
+        const left: TLine = ArrayUtils.assertGet(leftLines, lineIndex);
+        const right: TLine = ArrayUtils.assertGet(rightLines, lineIndex);
         const leftTokens: ReadonlyArray<Token.LineToken> = left.tokens;
         const rightTokens: ReadonlyArray<Token.LineToken> = right.tokens;
 
@@ -168,7 +168,7 @@ export function equalLines(leftLines: ReadonlyArray<TLine>, rightLines: Readonly
         const numTokens: number = leftTokens.length;
 
         for (let tokenIndex: number = 0; tokenIndex < numTokens; tokenIndex += 1) {
-            if (!equalTokens(Assert.asDefined(leftTokens[tokenIndex]), Assert.asDefined(rightTokens[tokenIndex]))) {
+            if (!equalTokens(ArrayUtils.assertGet(leftTokens, tokenIndex), ArrayUtils.assertGet(rightTokens, tokenIndex))) {
                 return false;
             }
         }
@@ -265,7 +265,7 @@ function splitOnLineTerminators(startingText: string): SplitLine[] {
         let indexWasExpanded: boolean = false;
 
         for (const lineTerminator of lineTerminators) {
-            const splitLine: SplitLine = Assert.asDefined(lines[index]);
+            const splitLine: SplitLine = ArrayUtils.assertGet(lines, index);
             const text: string = splitLine.text;
 
             if (text.indexOf(lineTerminator) !== -1) {
@@ -276,7 +276,7 @@ function splitOnLineTerminators(startingText: string): SplitLine[] {
                     lineTerminator,
                 }));
 
-                Assert.asDefined(split[split.length - 1]).lineTerminator = splitLine.lineTerminator;
+                ArrayUtils.assertGet(split, split.length - 1).lineTerminator = splitLine.lineTerminator;
 
                 lines = [...lines.slice(0, index), ...split, ...lines.slice(index + 1)];
             }
@@ -287,7 +287,7 @@ function splitOnLineTerminators(startingText: string): SplitLine[] {
         }
     }
 
-    Assert.asDefined(lines[lines.length - 1]).lineTerminator = "";
+    ArrayUtils.assertGet(lines, lines.length - 1).lineTerminator = "";
 
     return lines;
 }
@@ -356,7 +356,7 @@ function updateLine(state: State, lineNumber: number, text: string): State {
         throw error;
     }
 
-    const line: TLine = Assert.asDefined(state.lines[lineNumber]);
+    const line: TLine = ArrayUtils.assertGet(state.lines, lineNumber);
     const range: Range = rangeFrom(line, lineNumber);
 
     return updateRange(state, range, text);
@@ -374,14 +374,14 @@ function updateRange(state: State, range: Range, text: string): State {
     const splitLines: SplitLine[] = splitOnLineTerminators(text);
 
     const rangeStart: RangePosition = range.start;
-    const lineStart: TLine = Assert.asDefined(state.lines[rangeStart.lineNumber]);
+    const lineStart: TLine = ArrayUtils.assertGet(state.lines, rangeStart.lineNumber);
     const textPrefix: string = lineStart.text.substring(0, rangeStart.lineCodeUnit);
-    Assert.asDefined(splitLines[0]).text = textPrefix + Assert.asDefined(splitLines[0]).text;
+    ArrayUtils.assertGet(splitLines, 0).text = textPrefix + ArrayUtils.assertGet(splitLines, 0).text;
 
     const rangeEnd: RangePosition = range.end;
-    const lineEnd: TLine = Assert.asDefined(state.lines[rangeEnd.lineNumber]);
+    const lineEnd: TLine = ArrayUtils.assertGet(state.lines, rangeEnd.lineNumber);
     const textSuffix: string = lineEnd.text.substr(rangeEnd.lineCodeUnit);
-    const lastSplitLine: SplitLine = Assert.asDefined(splitLines[splitLines.length - 1]);
+    const lastSplitLine: SplitLine = ArrayUtils.assertGet(splitLines, splitLines.length - 1);
     lastSplitLine.text = lastSplitLine.text + textSuffix;
 
     // make sure we have a line terminator
@@ -400,7 +400,7 @@ function updateRange(state: State, range: Range, text: string): State {
     const lines: ReadonlyArray<TLine> = [
         ...state.lines.slice(0, rangeStart.lineNumber),
         ...newLines,
-        ...retokenizeLines(state, rangeEnd.lineNumber + 1, Assert.asDefined(newLines[newLines.length - 1]).lineModeEnd),
+        ...retokenizeLines(state, rangeEnd.lineNumber + 1, ArrayUtils.assertGet(newLines, newLines.length - 1).lineModeEnd),
     ];
 
     return {
@@ -485,7 +485,7 @@ function retokenizeLines(state: State, lineNumber: number, previousLineModeEnd: 
 
     const retokenizedLines: TLine[] = [];
 
-    if (previousLineModeEnd !== Assert.asDefined(lines[lineNumber]).lineModeStart) {
+    if (previousLineModeEnd !== ArrayUtils.assertGet(lines, lineNumber).lineModeStart) {
         let currentLine: TLine | undefined = lines[lineNumber];
 
         while (currentLine) {
@@ -793,7 +793,7 @@ function tokenizeTextLiteralContentOrEnd(line: TLine, currentPosition: number): 
 function tokenizeDefault(line: TLine, lineNumber: number, positionStart: number, locale: string): LineModeAlteringRead {
     const text: string = line.text;
 
-    const chr1: string = Assert.asDefined(text[positionStart]);
+    const chr1: string = StringUtils.assertGet(text, positionStart);
     let token: Token.LineToken;
     let lineMode: LineMode = LineMode.Default;
 
@@ -855,7 +855,7 @@ function tokenizeDefault(line: TLine, lineNumber: number, positionStart: number,
         } else if ("1" <= chr2 && chr2 <= "9") {
             token = readNumericLiteral(text, lineNumber, positionStart, locale);
         } else if (chr2 === ".") {
-            const chr3: string = Assert.asDefined(text[positionStart + 2]);
+            const chr3: string = StringUtils.assertGet(text, positionStart + 2);
 
             if (chr3 === ".") {
                 token = readConstant(Token.LineTokenKind.Ellipsis, text, positionStart, 3);
@@ -1321,8 +1321,8 @@ function testBadRangeError(state: State, range: Range): LexError.BadRangeError |
     const rangeStart: RangePosition = range.start;
     const rangeEnd: RangePosition = range.end;
 
-    const lineStart: TLine = Assert.asDefined(lines[rangeStart.lineNumber]);
-    const lineEnd: TLine = Assert.asDefined(lines[rangeEnd.lineNumber]);
+    const lineStart: TLine = ArrayUtils.assertGet(lines, rangeStart.lineNumber);
+    const lineEnd: TLine = ArrayUtils.assertGet(lines, rangeEnd.lineNumber);
 
     if (rangeStart.lineCodeUnit > lineStart.text.length) {
         kind = LexError.BadRangeKind.LineCodeUnitStart_GreaterThan_LineLength;

--- a/src/powerquery-parser/lexer/lexer.ts
+++ b/src/powerquery-parser/lexer/lexer.ts
@@ -855,7 +855,7 @@ function tokenizeDefault(line: TLine, lineNumber: number, positionStart: number,
         } else if ("1" <= chr2 && chr2 <= "9") {
             token = readNumericLiteral(text, lineNumber, positionStart, locale);
         } else if (chr2 === ".") {
-            const chr3: string = StringUtils.assertGet(text, positionStart + 2);
+            const chr3: string | undefined = text[positionStart + 2];
 
             if (chr3 === ".") {
                 token = readConstant(Token.LineTokenKind.Ellipsis, text, positionStart, 3);

--- a/src/powerquery-parser/lexer/lexerSnapshot.ts
+++ b/src/powerquery-parser/lexer/lexerSnapshot.ts
@@ -135,7 +135,7 @@ function createSnapshot(state: Lexer.State): LexerSnapshot {
     while (flatIndex < numFlatTokens) {
         state.cancellationToken?.throwIfCancelled();
 
-        const flatToken: FlatLineToken = Assert.asDefined(flatTokens[flatIndex]);
+        const flatToken: FlatLineToken = ArrayUtils.assertGet(flatTokens, flatIndex);
         const lineTokenKind: Token.LineTokenKind = flatToken.kind;
 
         switch (lineTokenKind) {
@@ -553,7 +553,7 @@ function collectWhileContent<KindVariant extends Token.LineTokenKind>(
     while (flatIndex < numTokens) {
         cancellationToken?.throwIfCancelled();
 
-        const token: FlatLineToken = Assert.asDefined(flatTokens[flatIndex]);
+        const token: FlatLineToken = ArrayUtils.assertGet(flatTokens, flatIndex);
 
         if (token.kind !== contentKind) {
             break;

--- a/src/powerquery-parser/lexer/lexerSnapshot.ts
+++ b/src/powerquery-parser/lexer/lexerSnapshot.ts
@@ -135,7 +135,7 @@ function createSnapshot(state: Lexer.State): LexerSnapshot {
     while (flatIndex < numFlatTokens) {
         state.cancellationToken?.throwIfCancelled();
 
-        const flatToken: FlatLineToken = flatTokens[flatIndex];
+        const flatToken: FlatLineToken = Assert.asDefined(flatTokens[flatIndex]);
         const lineTokenKind: Token.LineTokenKind = flatToken.kind;
 
         switch (lineTokenKind) {
@@ -553,7 +553,7 @@ function collectWhileContent<KindVariant extends Token.LineTokenKind>(
     while (flatIndex < numTokens) {
         cancellationToken?.throwIfCancelled();
 
-        const token: FlatLineToken = flatTokens[flatIndex];
+        const token: FlatLineToken = Assert.asDefined(flatTokens[flatIndex]);
 
         if (token.kind !== contentKind) {
             break;

--- a/src/powerquery-parser/parser/context/contextUtils.ts
+++ b/src/powerquery-parser/parser/context/contextUtils.ts
@@ -335,7 +335,7 @@ export function deleteContext(state: ParseContext.State, nodeId: number): ParseC
     // Not a leaf node.
     if (childIds !== undefined) {
         ArrayUtils.assertNonZeroLength(childIds);
-        const childId: number = childIds[0];
+        const childId: number = Assert.asDefined(childIds[0]);
 
         // Not a leaf node, is the Root node.
         // Promote the child to the root if it's a Context node.

--- a/src/powerquery-parser/parser/context/contextUtils.ts
+++ b/src/powerquery-parser/parser/context/contextUtils.ts
@@ -335,7 +335,7 @@ export function deleteContext(state: ParseContext.State, nodeId: number): ParseC
     // Not a leaf node.
     if (childIds !== undefined) {
         ArrayUtils.assertNonZeroLength(childIds);
-        const childId: number = Assert.asDefined(childIds[0]);
+        const childId: number = ArrayUtils.assertGet(childIds, 0);
 
         // Not a leaf node, is the Root node.
         // Promote the child to the root if it's a Context node.

--- a/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
+++ b/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
@@ -213,7 +213,7 @@ export async function disambiguateParenthesis(
     let offsetTokenIndex: number = initialTokenIndex + 1;
 
     while (offsetTokenIndex < totalTokens) {
-        const offsetTokenKind: Token.TokenKind = tokens[offsetTokenIndex].kind;
+        const offsetTokenKind: Token.TokenKind = Assert.asDefined(tokens[offsetTokenIndex]).kind;
 
         if (offsetTokenKind === Token.TokenKind.LeftParenthesis) {
             nestedDepth += 1;
@@ -305,7 +305,7 @@ export function disambiguateBracket(
         offsetTokenIndex += 1;
 
         while (offsetTokenIndex < totalTokens) {
-            offsetTokenKind = tokens[offsetTokenIndex].kind;
+            offsetTokenKind = Assert.asDefined(tokens[offsetTokenIndex]).kind;
 
             if (offsetTokenKind === Token.TokenKind.Equal) {
                 result = BracketDisambiguation.RecordExpression;
@@ -472,7 +472,7 @@ function unsafeMoveTo(state: ParseState, tokenIndex: number): void {
     state.tokenIndex = tokenIndex;
 
     if (tokenIndex < tokens.length) {
-        state.currentToken = tokens[tokenIndex];
+        state.currentToken = Assert.asDefined(tokens[tokenIndex]);
         state.currentTokenKind = state.currentToken.kind;
     } else {
         state.currentToken = undefined;

--- a/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
+++ b/src/powerquery-parser/parser/disambiguation/disambiguationUtils.ts
@@ -213,7 +213,7 @@ export async function disambiguateParenthesis(
     let offsetTokenIndex: number = initialTokenIndex + 1;
 
     while (offsetTokenIndex < totalTokens) {
-        const offsetTokenKind: Token.TokenKind = Assert.asDefined(tokens[offsetTokenIndex]).kind;
+        const offsetTokenKind: Token.TokenKind = ArrayUtils.assertGet(tokens, offsetTokenIndex).kind;
 
         if (offsetTokenKind === Token.TokenKind.LeftParenthesis) {
             nestedDepth += 1;
@@ -305,7 +305,7 @@ export function disambiguateBracket(
         offsetTokenIndex += 1;
 
         while (offsetTokenIndex < totalTokens) {
-            offsetTokenKind = Assert.asDefined(tokens[offsetTokenIndex]).kind;
+            offsetTokenKind = ArrayUtils.assertGet(tokens, offsetTokenIndex).kind;
 
             if (offsetTokenKind === Token.TokenKind.Equal) {
                 result = BracketDisambiguation.RecordExpression;
@@ -472,7 +472,7 @@ function unsafeMoveTo(state: ParseState, tokenIndex: number): void {
     state.tokenIndex = tokenIndex;
 
     if (tokenIndex < tokens.length) {
-        state.currentToken = Assert.asDefined(tokens[tokenIndex]);
+        state.currentToken = ArrayUtils.assertGet(tokens, tokenIndex);
         state.currentTokenKind = state.currentToken.kind;
     } else {
         state.currentToken = undefined;

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -3,7 +3,7 @@
 
 import { Ast, Constant, IdentifierUtils } from "../../language";
 import { NodeIdMap, NodeIdMapUtils, TXorNode, XorNodeKind, XorNodeUtils } from ".";
-import { Assert } from "../../common";
+import { ArrayUtils, Assert } from "../../common";
 import { parameterIdentifier } from "./nodeIdMapUtils";
 import { XorNode } from "./xorNode";
 
@@ -128,7 +128,7 @@ export function nthSiblingXor(
         return undefined;
     }
 
-    return NodeIdMapUtils.xor(nodeIdMapCollection, Assert.asDefined(childIds[attributeIndex]));
+    return NodeIdMapUtils.xor(nodeIdMapCollection, ArrayUtils.assertGet(childIds, attributeIndex));
 }
 
 // ------------------------------------------

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapIterator.ts
@@ -128,7 +128,7 @@ export function nthSiblingXor(
         return undefined;
     }
 
-    return NodeIdMapUtils.xor(nodeIdMapCollection, childIds[attributeIndex]);
+    return NodeIdMapUtils.xor(nodeIdMapCollection, Assert.asDefined(childIds[attributeIndex]));
 }
 
 // ------------------------------------------

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { MapUtils, TypeScriptUtils } from "../../../common";
+import { Assert, MapUtils, TypeScriptUtils } from "../../../common";
 import { Trace, TraceConstant, TraceManager } from "../../../common/trace";
 import { Ast } from "../../../language";
 import { Collection } from "../nodeIdMap";
@@ -63,8 +63,8 @@ export function recalculateIds(
     const newIdByOldId: Map<number, number> = new Map();
 
     for (let index: number = 0; index < numIds; index += 1) {
-        const oldId: number = encounteredIds[index];
-        const newId: number = sortedIds[index];
+        const oldId: number = Assert.asDefined(encounteredIds[index]);
+        const newId: number = Assert.asDefined(sortedIds[index]);
 
         if (oldId !== newId) {
             newIdByOldId.set(oldId, newId);

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/idUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Assert, MapUtils, TypeScriptUtils } from "../../../common";
+import { ArrayUtils, MapUtils, TypeScriptUtils } from "../../../common";
 import { Trace, TraceConstant, TraceManager } from "../../../common/trace";
 import { Ast } from "../../../language";
 import { Collection } from "../nodeIdMap";
@@ -63,8 +63,8 @@ export function recalculateIds(
     const newIdByOldId: Map<number, number> = new Map();
 
     for (let index: number = 0; index < numIds; index += 1) {
-        const oldId: number = Assert.asDefined(encounteredIds[index]);
-        const newId: number = Assert.asDefined(sortedIds[index]);
+        const oldId: number = ArrayUtils.assertGet(encounteredIds, index);
+        const newId: number = ArrayUtils.assertGet(sortedIds, index);
 
         if (oldId !== newId) {
             newIdByOldId.set(oldId, newId);

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
@@ -3,7 +3,7 @@
 
 import { AstNodeById, Collection } from "../nodeIdMap";
 import { NodeIdMap, XorNodeUtils } from "..";
-import { Assert } from "../../../common";
+import { ArrayUtils, Assert } from "../../../common";
 import { Ast } from "../../../language";
 import { TXorNode } from "../xorNode";
 import { xor } from "./commonSelectors";
@@ -35,7 +35,7 @@ export function leftMostXor(nodeIdMapCollection: Collection, nodeId: number): TX
     let childIds: ReadonlyArray<number> | undefined = nodeIdMapCollection.childIdsById.get(currentNodeId);
 
     while (childIds?.length) {
-        currentNodeId = Assert.asDefined(childIds[0]);
+        currentNodeId = ArrayUtils.assertGet(childIds, 0);
         childIds = nodeIdMapCollection.childIdsById.get(currentNodeId);
     }
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/leafSelectors.ts
@@ -35,7 +35,7 @@ export function leftMostXor(nodeIdMapCollection: Collection, nodeId: number): TX
     let childIds: ReadonlyArray<number> | undefined = nodeIdMapCollection.childIdsById.get(currentNodeId);
 
     while (childIds?.length) {
-        currentNodeId = childIds[0];
+        currentNodeId = Assert.asDefined(childIds[0]);
         childIds = nodeIdMapCollection.childIdsById.get(currentNodeId);
     }
 

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/nodeIdMapUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/nodeIdMapUtils.ts
@@ -56,7 +56,7 @@ export function hasParsedToken(nodeIdMapCollection: Collection, nodeId: number):
         }
         // There might be a child under here.
         else if (numChildren === 1) {
-            const childId: number = childIds[0];
+            const childId: number = Assert.asDefined(childIds[0]);
 
             // We know it's an Ast Node, therefore something was parsed.
             if (nodeIdMapCollection.astNodeById.has(childId)) {

--- a/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/nodeIdMapUtils.ts
+++ b/src/powerquery-parser/parser/nodeIdMap/nodeIdMapUtils/nodeIdMapUtils.ts
@@ -4,7 +4,7 @@
 import { Ast, Token } from "../../../language";
 import { Collection, CollectionValidation, IdsByNodeKind, NodeSummary } from "../nodeIdMap";
 import { TXorNode, XorNodeKind, XorNodeTokenRange } from "../xorNode";
-import { Assert } from "../../../common";
+import { ArrayUtils, Assert } from "../../../common";
 import { ParseContext } from "../../context";
 import { rightMostLeaf } from "./leafSelectors";
 
@@ -56,7 +56,7 @@ export function hasParsedToken(nodeIdMapCollection: Collection, nodeId: number):
         }
         // There might be a child under here.
         else if (numChildren === 1) {
-            const childId: number = Assert.asDefined(childIds[0]);
+            const childId: number = ArrayUtils.assertGet(childIds, 0);
 
             // We know it's an Ast Node, therefore something was parsed.
             if (nodeIdMapCollection.astNodeById.has(childId)) {

--- a/src/powerquery-parser/parser/parseState/parseStateUtils.ts
+++ b/src/powerquery-parser/parser/parseState/parseStateUtils.ts
@@ -162,7 +162,7 @@ export function isOnTokenKind(
 
 export function isOnConstantKind(state: ParseState, constantKind: Constant.TConstant): boolean {
     if (isOnTokenKind(state, Token.TokenKind.Identifier)) {
-        const currentToken: Token.Token = Assert.asDefined(state.lexerSnapshot.tokens[state.tokenIndex]);
+        const currentToken: Token.Token = ArrayUtils.assertGet(state.lexerSnapshot.tokens, state.tokenIndex);
 
         if (currentToken?.data === undefined) {
             const details: { currentToken: Token.Token } = { currentToken };
@@ -283,7 +283,7 @@ export function assertGetContextNodeMetadata(state: ParseState): ContextNodeMeta
 
     // inclusive token index
     const tokenIndexEnd: number = state.tokenIndex - 1;
-    const tokenEnd: Token.Token = Assert.asDefined(state.lexerSnapshot.tokens[tokenIndexEnd]);
+    const tokenEnd: Token.Token = ArrayUtils.assertGet(state.lexerSnapshot.tokens, tokenIndexEnd);
 
     const tokenRange: Token.TokenRange = {
         tokenIndexStart: currentContextNode.tokenIndexStart,

--- a/src/powerquery-parser/parser/parseState/parseStateUtils.ts
+++ b/src/powerquery-parser/parser/parseState/parseStateUtils.ts
@@ -162,7 +162,7 @@ export function isOnTokenKind(
 
 export function isOnConstantKind(state: ParseState, constantKind: Constant.TConstant): boolean {
     if (isOnTokenKind(state, Token.TokenKind.Identifier)) {
-        const currentToken: Token.Token = state.lexerSnapshot.tokens[state.tokenIndex];
+        const currentToken: Token.Token = Assert.asDefined(state.lexerSnapshot.tokens[state.tokenIndex]);
 
         if (currentToken?.data === undefined) {
             const details: { currentToken: Token.Token } = { currentToken };

--- a/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
+++ b/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Assert, CommonError, Result, ResultUtils } from "../../common";
+import { ArrayUtils, Assert, CommonError, Result, ResultUtils } from "../../common";
 import { Ast, AstUtils, Comment, Constant, ConstantUtils, IdentifierUtils, Token } from "../../language";
 import { Disambiguation, DisambiguationUtils } from "../disambiguation";
 import { NaiveParseSteps, ParseError } from "..";
@@ -122,8 +122,8 @@ export async function readGeneralizedIdentifier(
 
     const lexerSnapshot: LexerSnapshot = state.lexerSnapshot;
     const tokens: ReadonlyArray<Token.Token> = lexerSnapshot.tokens;
-    const contiguousIdentifierStartIndex: number = Assert.asDefined(tokens[tokenRangeStartIndex]).positionStart.codeUnit;
-    const contiguousIdentifierEndIndex: number = Assert.asDefined(tokens[tokenRangeEndIndex - 1]).positionEnd.codeUnit;
+    const contiguousIdentifierStartIndex: number = ArrayUtils.assertGet(tokens, tokenRangeStartIndex).positionStart.codeUnit;
+    const contiguousIdentifierEndIndex: number = ArrayUtils.assertGet(tokens, tokenRangeEndIndex - 1).positionEnd.codeUnit;
     const literal: string = lexerSnapshot.text.slice(contiguousIdentifierStartIndex, contiguousIdentifierEndIndex);
 
     const literalKind: IdentifierUtils.IdentifierKind = IdentifierUtils.getIdentifierKind(literal, {
@@ -2806,7 +2806,7 @@ async function tryReadPrimitiveType(
     let primitiveTypeKind: Constant.PrimitiveTypeConstant;
 
     if (ParseStateUtils.isOnTokenKind(state, TokenKind.Identifier)) {
-        const currentTokenData: string = Assert.asDefined(state.lexerSnapshot.tokens[state.tokenIndex]).data;
+        const currentTokenData: string = ArrayUtils.assertGet(state.lexerSnapshot.tokens, state.tokenIndex).data;
 
         switch (currentTokenData) {
             case Constant.PrimitiveTypeConstant.Action:
@@ -3602,7 +3602,7 @@ export function readToken(state: ParseState): string {
         tokensLength: tokens.length,
     });
 
-    const data: string = Assert.asDefined(tokens[state.tokenIndex]).data;
+    const data: string = ArrayUtils.assertGet(tokens, state.tokenIndex).data;
     state.tokenIndex += 1;
 
     if (state.tokenIndex === tokens.length) {
@@ -3615,7 +3615,7 @@ export function readToken(state: ParseState): string {
         // So, for now when a IParseState is Eof when currentTokenKind === undefined.
         state.currentTokenKind = undefined;
     } else {
-        state.currentToken = Assert.asDefined(tokens[state.tokenIndex]);
+        state.currentToken = ArrayUtils.assertGet(tokens, state.tokenIndex);
         state.currentTokenKind = state.currentToken.kind;
     }
 
@@ -3867,7 +3867,7 @@ function testCatchFunction(
 
     if (
         parameters.length > 1 ||
-        (parameters.length === 1 && Assert.asDefined(parameters[0]).node.parameterType) ||
+        (parameters.length === 1 && ArrayUtils.assertGet(parameters, 0).node.parameterType) ||
         catchFunction.functionReturnType
     ) {
         const tokenStart: Token.Token = Assert.asDefined(

--- a/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
+++ b/src/powerquery-parser/parser/parsers/naiveParseSteps.ts
@@ -122,8 +122,8 @@ export async function readGeneralizedIdentifier(
 
     const lexerSnapshot: LexerSnapshot = state.lexerSnapshot;
     const tokens: ReadonlyArray<Token.Token> = lexerSnapshot.tokens;
-    const contiguousIdentifierStartIndex: number = tokens[tokenRangeStartIndex].positionStart.codeUnit;
-    const contiguousIdentifierEndIndex: number = tokens[tokenRangeEndIndex - 1].positionEnd.codeUnit;
+    const contiguousIdentifierStartIndex: number = Assert.asDefined(tokens[tokenRangeStartIndex]).positionStart.codeUnit;
+    const contiguousIdentifierEndIndex: number = Assert.asDefined(tokens[tokenRangeEndIndex - 1]).positionEnd.codeUnit;
     const literal: string = lexerSnapshot.text.slice(contiguousIdentifierStartIndex, contiguousIdentifierEndIndex);
 
     const literalKind: IdentifierUtils.IdentifierKind = IdentifierUtils.getIdentifierKind(literal, {
@@ -2806,7 +2806,7 @@ async function tryReadPrimitiveType(
     let primitiveTypeKind: Constant.PrimitiveTypeConstant;
 
     if (ParseStateUtils.isOnTokenKind(state, TokenKind.Identifier)) {
-        const currentTokenData: string = state.lexerSnapshot.tokens[state.tokenIndex].data;
+        const currentTokenData: string = Assert.asDefined(state.lexerSnapshot.tokens[state.tokenIndex]).data;
 
         switch (currentTokenData) {
             case Constant.PrimitiveTypeConstant.Action:
@@ -3602,7 +3602,7 @@ export function readToken(state: ParseState): string {
         tokensLength: tokens.length,
     });
 
-    const data: string = tokens[state.tokenIndex].data;
+    const data: string = Assert.asDefined(tokens[state.tokenIndex]).data;
     state.tokenIndex += 1;
 
     if (state.tokenIndex === tokens.length) {
@@ -3615,7 +3615,7 @@ export function readToken(state: ParseState): string {
         // So, for now when a IParseState is Eof when currentTokenKind === undefined.
         state.currentTokenKind = undefined;
     } else {
-        state.currentToken = tokens[state.tokenIndex];
+        state.currentToken = Assert.asDefined(tokens[state.tokenIndex]);
         state.currentTokenKind = state.currentToken.kind;
     }
 
@@ -3867,7 +3867,7 @@ function testCatchFunction(
 
     if (
         parameters.length > 1 ||
-        (parameters.length === 1 && parameters[0].node.parameterType) ||
+        (parameters.length === 1 && Assert.asDefined(parameters[0]).node.parameterType) ||
         catchFunction.functionReturnType
     ) {
         const tokenStart: Token.Token = Assert.asDefined(

--- a/src/test/libraryTest/language/typeUtils/typeCheck.test.ts
+++ b/src/test/libraryTest/language/typeUtils/typeCheck.test.ts
@@ -7,7 +7,7 @@ import { expect } from "chai";
 import { CheckedDefinedList, CheckedInvocation } from "../../../../powerquery-parser/language/type/typeUtils";
 import { Type, TypeUtils } from "../../../../powerquery-parser/language";
 import { Language } from "../../../..";
-import { Assert } from "../../../../powerquery-parser/common";
+import { ArrayUtils } from "../../../../powerquery-parser/common";
 import { NoOpTraceManagerInstance } from "../../../../powerquery-parser/common/trace";
 import { OrderedMap } from "../../../../powerquery-parser";
 
@@ -301,7 +301,7 @@ describe(`TypeUtils.typeCheck`, () => {
                         0,
                         {
                             actual: args[0],
-                            expected: Assert.asDefined(definedFunction.parameters[0]),
+                            expected: ArrayUtils.assertGet(definedFunction.parameters, 0),
                         },
                     ],
                 ]),
@@ -360,7 +360,7 @@ describe(`TypeUtils.typeCheck`, () => {
 
             const expected: TypeUtils.CheckedInvocation = {
                 valid: [],
-                invalid: new Map([[0, { actual: args[0], expected: Assert.asDefined(definedFunction.parameters[0]) }]]),
+                invalid: new Map([[0, { actual: args[0], expected: ArrayUtils.assertGet(definedFunction.parameters, 0) }]]),
                 extraneous: [],
                 missing: [],
             };
@@ -388,7 +388,7 @@ describe(`TypeUtils.typeCheck`, () => {
 
             const expected: TypeUtils.CheckedInvocation = {
                 valid: [],
-                invalid: new Map([[0, { actual: args[0], expected: Assert.asDefined(definedFunction.parameters[0]) }]]),
+                invalid: new Map([[0, { actual: args[0], expected: ArrayUtils.assertGet(definedFunction.parameters, 0) }]]),
                 extraneous: [],
                 missing: [],
             };
@@ -430,14 +430,14 @@ describe(`TypeUtils.typeCheck`, () => {
                         0,
                         {
                             actual: args[0],
-                            expected: Assert.asDefined(definedFunction.parameters[0]),
+                            expected: ArrayUtils.assertGet(definedFunction.parameters, 0),
                         },
                     ],
                     [
                         1,
                         {
                             actual: args[1],
-                            expected: Assert.asDefined(definedFunction.parameters[1]),
+                            expected: ArrayUtils.assertGet(definedFunction.parameters, 1),
                         },
                     ],
                 ]),

--- a/src/test/libraryTest/language/typeUtils/typeCheck.test.ts
+++ b/src/test/libraryTest/language/typeUtils/typeCheck.test.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 import { CheckedDefinedList, CheckedInvocation } from "../../../../powerquery-parser/language/type/typeUtils";
 import { Type, TypeUtils } from "../../../../powerquery-parser/language";
 import { Language } from "../../../..";
+import { Assert } from "../../../../powerquery-parser/common";
 import { NoOpTraceManagerInstance } from "../../../../powerquery-parser/common/trace";
 import { OrderedMap } from "../../../../powerquery-parser";
 
@@ -300,7 +301,7 @@ describe(`TypeUtils.typeCheck`, () => {
                         0,
                         {
                             actual: args[0],
-                            expected: definedFunction.parameters[0],
+                            expected: Assert.asDefined(definedFunction.parameters[0]),
                         },
                     ],
                 ]),
@@ -359,7 +360,7 @@ describe(`TypeUtils.typeCheck`, () => {
 
             const expected: TypeUtils.CheckedInvocation = {
                 valid: [],
-                invalid: new Map([[0, { actual: args[0], expected: definedFunction.parameters[0] }]]),
+                invalid: new Map([[0, { actual: args[0], expected: Assert.asDefined(definedFunction.parameters[0]) }]]),
                 extraneous: [],
                 missing: [],
             };
@@ -387,7 +388,7 @@ describe(`TypeUtils.typeCheck`, () => {
 
             const expected: TypeUtils.CheckedInvocation = {
                 valid: [],
-                invalid: new Map([[0, { actual: args[0], expected: definedFunction.parameters[0] }]]),
+                invalid: new Map([[0, { actual: args[0], expected: Assert.asDefined(definedFunction.parameters[0]) }]]),
                 extraneous: [],
                 missing: [],
             };
@@ -429,14 +430,14 @@ describe(`TypeUtils.typeCheck`, () => {
                         0,
                         {
                             actual: args[0],
-                            expected: definedFunction.parameters[0],
+                            expected: Assert.asDefined(definedFunction.parameters[0]),
                         },
                     ],
                     [
                         1,
                         {
                             actual: args[1],
-                            expected: definedFunction.parameters[1],
+                            expected: Assert.asDefined(definedFunction.parameters[1]),
                         },
                     ],
                 ]),

--- a/src/test/libraryTest/language/typeUtils/typeUtils.test.ts
+++ b/src/test/libraryTest/language/typeUtils/typeUtils.test.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 import { Type, TypeUtils } from "../../../../powerquery-parser/language";
 import { NoOpTraceManagerInstance } from "../../../../powerquery-parser/common/trace";
 import { OrderedMap } from "../../../../powerquery-parser";
+import { Assert } from "../../../../powerquery-parser/common";
 
 interface AbridgedType {
     readonly kind: Type.TypeKind;
@@ -137,7 +138,7 @@ describe(`TypeUtils`, () => {
 
             expect(simplified.length).to.equal(1);
 
-            const actual: AbridgedType = typeToAbridged(simplified[0]);
+            const actual: AbridgedType = typeToAbridged(Assert.asDefined(simplified[0]));
             const expected: AbridgedType = TypeUtils.primitiveType(false, Type.TypeKind.Record);
             expect(actual).deep.equal(expected);
         });
@@ -209,7 +210,7 @@ describe(`TypeUtils`, () => {
 
             expect(simplified.length).to.equal(1);
 
-            const actual: AbridgedType = typeToAbridged(simplified[0]);
+            const actual: AbridgedType = typeToAbridged(Assert.asDefined(simplified[0]));
             const expected: AbridgedType = typeToAbridged(Type.AnyInstance);
             expect(actual).deep.equal(expected);
         });

--- a/src/test/libraryTest/language/typeUtils/typeUtils.test.ts
+++ b/src/test/libraryTest/language/typeUtils/typeUtils.test.ts
@@ -7,7 +7,7 @@ import { expect } from "chai";
 import { Type, TypeUtils } from "../../../../powerquery-parser/language";
 import { NoOpTraceManagerInstance } from "../../../../powerquery-parser/common/trace";
 import { OrderedMap } from "../../../../powerquery-parser";
-import { Assert } from "../../../../powerquery-parser/common";
+import { ArrayUtils } from "../../../../powerquery-parser/common";
 
 interface AbridgedType {
     readonly kind: Type.TypeKind;
@@ -138,7 +138,7 @@ describe(`TypeUtils`, () => {
 
             expect(simplified.length).to.equal(1);
 
-            const actual: AbridgedType = typeToAbridged(Assert.asDefined(simplified[0]));
+            const actual: AbridgedType = typeToAbridged(ArrayUtils.assertGet(simplified, 0));
             const expected: AbridgedType = TypeUtils.primitiveType(false, Type.TypeKind.Record);
             expect(actual).deep.equal(expected);
         });
@@ -210,7 +210,7 @@ describe(`TypeUtils`, () => {
 
             expect(simplified.length).to.equal(1);
 
-            const actual: AbridgedType = typeToAbridged(Assert.asDefined(simplified[0]));
+            const actual: AbridgedType = typeToAbridged(ArrayUtils.assertGet(simplified, 0));
             const expected: AbridgedType = typeToAbridged(Type.AnyInstance);
             expect(actual).deep.equal(expected);
         });

--- a/src/test/libraryTest/lexer/lexError.test.ts
+++ b/src/test/libraryTest/lexer/lexError.test.ts
@@ -5,7 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { DefaultSettings, Lexer, ResultUtils } from "../../..";
-import { Assert } from "../../../powerquery-parser/common";
+import { ArrayUtils } from "../../../powerquery-parser/common";
 
 function assertBadLineNumberKind(lineNumber: number, expectedKind: Lexer.LexError.BadLineNumberKind): void {
     const triedLex: Lexer.TriedLex = Lexer.tryLex(DefaultSettings, `foo`);
@@ -37,7 +37,7 @@ function assertExpectedKind(text: string, expectedKind: Lexer.LexError.ExpectedK
     const state: Lexer.State = triedLex.value;
     expect(state.lines.length).to.equal(1);
 
-    const line: Lexer.TLine = Assert.asDefined(state.lines[0]);
+    const line: Lexer.TLine = ArrayUtils.assertGet(state.lines, 0);
 
     if (!Lexer.isErrorLine(line)) {
         throw new Error(`AssertFailed: Lexer.isErrorLine(line): ${JSON.stringify(line)}`);

--- a/src/test/libraryTest/lexer/lexError.test.ts
+++ b/src/test/libraryTest/lexer/lexError.test.ts
@@ -5,6 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { DefaultSettings, Lexer, ResultUtils } from "../../..";
+import { Assert } from "../../../powerquery-parser/common";
 
 function assertBadLineNumberKind(lineNumber: number, expectedKind: Lexer.LexError.BadLineNumberKind): void {
     const triedLex: Lexer.TriedLex = Lexer.tryLex(DefaultSettings, `foo`);
@@ -36,7 +37,7 @@ function assertExpectedKind(text: string, expectedKind: Lexer.LexError.ExpectedK
     const state: Lexer.State = triedLex.value;
     expect(state.lines.length).to.equal(1);
 
-    const line: Lexer.TLine = state.lines[0];
+    const line: Lexer.TLine = Assert.asDefined(state.lines[0]);
 
     if (!Lexer.isErrorLine(line)) {
         throw new Error(`AssertFailed: Lexer.isErrorLine(line): ${JSON.stringify(line)}`);

--- a/src/test/libraryTest/lexer/lexIncremental.test.ts
+++ b/src/test/libraryTest/lexer/lexIncremental.test.ts
@@ -5,7 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { Lexer, ResultUtils } from "../../..";
-import { Assert } from "../../../powerquery-parser/common";
+import { ArrayUtils } from "../../../powerquery-parser/common";
 import { assertGetLexOk } from "../../testUtils/lexTestUtils";
 
 const LINE_TERMINATOR: string = `\n`;
@@ -82,7 +82,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foobar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(Assert.asDefined(state.lines[0]).text).to.equal("Xfoobar");
+            expect(ArrayUtils.assertGet(state.lines, 0).text).to.equal("Xfoobar");
         });
 
         it(`foobar -> fooXbar`, () => {
@@ -99,7 +99,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foobar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(Assert.asDefined(state.lines[0]).text).to.equal("fooXbar");
+            expect(ArrayUtils.assertGet(state.lines, 0).text).to.equal("fooXbar");
         });
 
         it(`foobar -> Xoobar`, () => {
@@ -116,7 +116,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foobar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(Assert.asDefined(state.lines[0]).text).to.equal("Xoobar");
+            expect(ArrayUtils.assertGet(state.lines, 0).text).to.equal("Xoobar");
         });
 
         it(`foobar -> X`, () => {
@@ -133,7 +133,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foobar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(Assert.asDefined(state.lines[0]).text).to.equal("X");
+            expect(ArrayUtils.assertGet(state.lines, 0).text).to.equal("X");
         });
 
         it(`foo\\nbar -> X`, () => {
@@ -150,7 +150,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foo\nbar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(Assert.asDefined(state.lines[0]).text).to.equal("X");
+            expect(ArrayUtils.assertGet(state.lines, 0).text).to.equal("X");
         });
 
         it(`foo\\nbar -> fXr`, () => {
@@ -167,7 +167,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foo\nbar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(Assert.asDefined(state.lines[0]).text).to.equal("fXr");
+            expect(ArrayUtils.assertGet(state.lines, 0).text).to.equal("fXr");
         });
 
         it(`foo\\nbar\\baz -> foo\\nX\\nbaz`, () => {
@@ -184,9 +184,9 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foo\nbar\nbaz`, "X", range);
             expect(state.lines.length).to.equal(3);
-            expect(Assert.asDefined(state.lines[0]).text).to.equal("foo");
-            expect(Assert.asDefined(state.lines[1]).text).to.equal("X");
-            expect(Assert.asDefined(state.lines[2]).text).to.equal("baz");
+            expect(ArrayUtils.assertGet(state.lines, 0).text).to.equal("foo");
+            expect(ArrayUtils.assertGet(state.lines, 1).text).to.equal("X");
+            expect(ArrayUtils.assertGet(state.lines, 2).text).to.equal("baz");
         });
 
         it(`foo\\nbar\\baz -> foo\\nbXr\\nbaz`, () => {
@@ -203,9 +203,9 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foo\nbar\nbaz`, "X", range);
             expect(state.lines.length).to.equal(3);
-            expect(Assert.asDefined(state.lines[0]).text).to.equal("foo");
-            expect(Assert.asDefined(state.lines[1]).text).to.equal("bXr");
-            expect(Assert.asDefined(state.lines[2]).text).to.equal("baz");
+            expect(ArrayUtils.assertGet(state.lines, 0).text).to.equal("foo");
+            expect(ArrayUtils.assertGet(state.lines, 1).text).to.equal("bXr");
+            expect(ArrayUtils.assertGet(state.lines, 2).text).to.equal("baz");
         });
 
         it(`lineTerminator maintained on single line change`, () => {

--- a/src/test/libraryTest/lexer/lexIncremental.test.ts
+++ b/src/test/libraryTest/lexer/lexIncremental.test.ts
@@ -5,6 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { Lexer, ResultUtils } from "../../..";
+import { Assert } from "../../../powerquery-parser/common";
 import { assertGetLexOk } from "../../testUtils/lexTestUtils";
 
 const LINE_TERMINATOR: string = `\n`;
@@ -81,7 +82,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foobar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(state.lines[0].text).to.equal("Xfoobar");
+            expect(Assert.asDefined(state.lines[0]).text).to.equal("Xfoobar");
         });
 
         it(`foobar -> fooXbar`, () => {
@@ -98,7 +99,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foobar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(state.lines[0].text).to.equal("fooXbar");
+            expect(Assert.asDefined(state.lines[0]).text).to.equal("fooXbar");
         });
 
         it(`foobar -> Xoobar`, () => {
@@ -115,7 +116,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foobar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(state.lines[0].text).to.equal("Xoobar");
+            expect(Assert.asDefined(state.lines[0]).text).to.equal("Xoobar");
         });
 
         it(`foobar -> X`, () => {
@@ -132,7 +133,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foobar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(state.lines[0].text).to.equal("X");
+            expect(Assert.asDefined(state.lines[0]).text).to.equal("X");
         });
 
         it(`foo\\nbar -> X`, () => {
@@ -149,7 +150,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foo\nbar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(state.lines[0].text).to.equal("X");
+            expect(Assert.asDefined(state.lines[0]).text).to.equal("X");
         });
 
         it(`foo\\nbar -> fXr`, () => {
@@ -166,7 +167,7 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foo\nbar`, "X", range);
             expect(state.lines.length).to.equal(1);
-            expect(state.lines[0].text).to.equal("fXr");
+            expect(Assert.asDefined(state.lines[0]).text).to.equal("fXr");
         });
 
         it(`foo\\nbar\\baz -> foo\\nX\\nbaz`, () => {
@@ -183,9 +184,9 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foo\nbar\nbaz`, "X", range);
             expect(state.lines.length).to.equal(3);
-            expect(state.lines[0].text).to.equal("foo");
-            expect(state.lines[1].text).to.equal("X");
-            expect(state.lines[2].text).to.equal("baz");
+            expect(Assert.asDefined(state.lines[0]).text).to.equal("foo");
+            expect(Assert.asDefined(state.lines[1]).text).to.equal("X");
+            expect(Assert.asDefined(state.lines[2]).text).to.equal("baz");
         });
 
         it(`foo\\nbar\\baz -> foo\\nbXr\\nbaz`, () => {
@@ -202,9 +203,9 @@ describe(`Lexer.Incremental`, () => {
 
             const state: Lexer.State = assertGetLexerUpdateRangeOk(`foo\nbar\nbaz`, "X", range);
             expect(state.lines.length).to.equal(3);
-            expect(state.lines[0].text).to.equal("foo");
-            expect(state.lines[1].text).to.equal("bXr");
-            expect(state.lines[2].text).to.equal("baz");
+            expect(Assert.asDefined(state.lines[0]).text).to.equal("foo");
+            expect(Assert.asDefined(state.lines[1]).text).to.equal("bXr");
+            expect(Assert.asDefined(state.lines[2]).text).to.equal("baz");
         });
 
         it(`lineTerminator maintained on single line change`, () => {

--- a/src/test/libraryTest/lexer/lexerSnapshotCache.test.ts
+++ b/src/test/libraryTest/lexer/lexerSnapshotCache.test.ts
@@ -5,6 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { DefaultSettings, Language, Lexer, ResultUtils, StringUtils } from "../../..";
+import { Assert } from "../../../powerquery-parser/common";
 
 function assertGetLexerSnapshot(text: string): Lexer.LexerSnapshot {
     const triedLex: Lexer.TriedLex = Lexer.tryLex(DefaultSettings, text);
@@ -80,7 +81,7 @@ describe("LexerSnapshot.graphemePositionStartFrom cache", () => {
     describe("cache hit consistency", () => {
         it("repeated calls return identical results", () => {
             const snapshot: Lexer.LexerSnapshot = assertGetLexerSnapshot("let x = 1");
-            const token: Language.Token.Token = snapshot.tokens[0];
+            const token: Language.Token.Token = Assert.asDefined(snapshot.tokens[0]);
 
             const first: StringUtils.GraphemePosition = snapshot.graphemePositionStartFrom(token);
             const second: StringUtils.GraphemePosition = snapshot.graphemePositionStartFrom(token);
@@ -104,7 +105,7 @@ describe("LexerSnapshot.graphemePositionStartFrom cache", () => {
 
             // Column numbers should be increasing
             for (let i: number = 1; i < positions.length; i += 1) {
-                expect(positions[i].columnNumber).to.be.greaterThan(positions[i - 1].columnNumber);
+                expect(Assert.asDefined(positions[i]).columnNumber).to.be.greaterThan(Assert.asDefined(positions[i - 1]).columnNumber);
             }
         });
 
@@ -116,10 +117,10 @@ describe("LexerSnapshot.graphemePositionStartFrom cache", () => {
                 snapshot.graphemePositionStartFrom(token),
             );
 
-            expect(positions[0].lineNumber).to.equal(0);
-            expect(positions[1].lineNumber).to.equal(1);
-            expect(positions[2].lineNumber).to.equal(2);
-            expect(positions[3].lineNumber).to.equal(2);
+            expect(Assert.asDefined(positions[0]).lineNumber).to.equal(0);
+            expect(Assert.asDefined(positions[1]).lineNumber).to.equal(1);
+            expect(Assert.asDefined(positions[2]).lineNumber).to.equal(2);
+            expect(Assert.asDefined(positions[3]).lineNumber).to.equal(2);
         });
     });
 });

--- a/src/test/libraryTest/lexer/lexerSnapshotCache.test.ts
+++ b/src/test/libraryTest/lexer/lexerSnapshotCache.test.ts
@@ -5,7 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { DefaultSettings, Language, Lexer, ResultUtils, StringUtils } from "../../..";
-import { Assert } from "../../../powerquery-parser/common";
+import { ArrayUtils } from "../../../powerquery-parser/common";
 
 function assertGetLexerSnapshot(text: string): Lexer.LexerSnapshot {
     const triedLex: Lexer.TriedLex = Lexer.tryLex(DefaultSettings, text);
@@ -81,7 +81,7 @@ describe("LexerSnapshot.graphemePositionStartFrom cache", () => {
     describe("cache hit consistency", () => {
         it("repeated calls return identical results", () => {
             const snapshot: Lexer.LexerSnapshot = assertGetLexerSnapshot("let x = 1");
-            const token: Language.Token.Token = Assert.asDefined(snapshot.tokens[0]);
+            const token: Language.Token.Token = ArrayUtils.assertGet(snapshot.tokens, 0);
 
             const first: StringUtils.GraphemePosition = snapshot.graphemePositionStartFrom(token);
             const second: StringUtils.GraphemePosition = snapshot.graphemePositionStartFrom(token);
@@ -105,7 +105,7 @@ describe("LexerSnapshot.graphemePositionStartFrom cache", () => {
 
             // Column numbers should be increasing
             for (let i: number = 1; i < positions.length; i += 1) {
-                expect(Assert.asDefined(positions[i]).columnNumber).to.be.greaterThan(Assert.asDefined(positions[i - 1]).columnNumber);
+                expect(ArrayUtils.assertGet(positions, i).columnNumber).to.be.greaterThan(ArrayUtils.assertGet(positions, i - 1).columnNumber);
             }
         });
 
@@ -117,10 +117,10 @@ describe("LexerSnapshot.graphemePositionStartFrom cache", () => {
                 snapshot.graphemePositionStartFrom(token),
             );
 
-            expect(Assert.asDefined(positions[0]).lineNumber).to.equal(0);
-            expect(Assert.asDefined(positions[1]).lineNumber).to.equal(1);
-            expect(Assert.asDefined(positions[2]).lineNumber).to.equal(2);
-            expect(Assert.asDefined(positions[3]).lineNumber).to.equal(2);
+            expect(ArrayUtils.assertGet(positions, 0).lineNumber).to.equal(0);
+            expect(ArrayUtils.assertGet(positions, 1).lineNumber).to.equal(1);
+            expect(ArrayUtils.assertGet(positions, 2).lineNumber).to.equal(2);
+            expect(ArrayUtils.assertGet(positions, 3).lineNumber).to.equal(2);
         });
     });
 });

--- a/src/test/libraryTest/lexer/retokenizeLineNumbers.test.ts
+++ b/src/test/libraryTest/lexer/retokenizeLineNumbers.test.ts
@@ -5,6 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { Lexer, ResultUtils } from "../../..";
+import { Assert } from "../../../powerquery-parser/common";
 import { assertGetLexOk } from "../../testUtils/lexTestUtils";
 
 describe("Lexer.retokenizeLines line numbers", () => {
@@ -30,9 +31,9 @@ describe("Lexer.retokenizeLines line numbers", () => {
         expect(updated.lines.length).to.equal(3, "expected 3 lines after update");
 
         // All lines should now be in Default mode since line 0 is a complete string
-        expect(updated.lines[0].lineModeEnd).to.equal(Lexer.LineMode.Default, "line 0 should end in Default mode");
-        expect(updated.lines[1].lineModeStart).to.equal(Lexer.LineMode.Default, "line 1 should start in Default mode");
-        expect(updated.lines[2].lineModeStart).to.equal(Lexer.LineMode.Default, "line 2 should start in Default mode");
+        expect(Assert.asDefined(updated.lines[0]).lineModeEnd).to.equal(Lexer.LineMode.Default, "line 0 should end in Default mode");
+        expect(Assert.asDefined(updated.lines[1]).lineModeStart).to.equal(Lexer.LineMode.Default, "line 1 should start in Default mode");
+        expect(Assert.asDefined(updated.lines[2]).lineModeStart).to.equal(Lexer.LineMode.Default, "line 2 should start in Default mode");
 
         // Now snapshot to get token positions and verify line numbers are correct.
         const triedSnapshot: Lexer.TriedLexerSnapshot = Lexer.trySnapshot(updated);

--- a/src/test/libraryTest/lexer/retokenizeLineNumbers.test.ts
+++ b/src/test/libraryTest/lexer/retokenizeLineNumbers.test.ts
@@ -5,7 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { Lexer, ResultUtils } from "../../..";
-import { Assert } from "../../../powerquery-parser/common";
+import { ArrayUtils } from "../../../powerquery-parser/common";
 import { assertGetLexOk } from "../../testUtils/lexTestUtils";
 
 describe("Lexer.retokenizeLines line numbers", () => {
@@ -31,9 +31,9 @@ describe("Lexer.retokenizeLines line numbers", () => {
         expect(updated.lines.length).to.equal(3, "expected 3 lines after update");
 
         // All lines should now be in Default mode since line 0 is a complete string
-        expect(Assert.asDefined(updated.lines[0]).lineModeEnd).to.equal(Lexer.LineMode.Default, "line 0 should end in Default mode");
-        expect(Assert.asDefined(updated.lines[1]).lineModeStart).to.equal(Lexer.LineMode.Default, "line 1 should start in Default mode");
-        expect(Assert.asDefined(updated.lines[2]).lineModeStart).to.equal(Lexer.LineMode.Default, "line 2 should start in Default mode");
+        expect(ArrayUtils.assertGet(updated.lines, 0).lineModeEnd).to.equal(Lexer.LineMode.Default, "line 0 should end in Default mode");
+        expect(ArrayUtils.assertGet(updated.lines, 1).lineModeStart).to.equal(Lexer.LineMode.Default, "line 1 should start in Default mode");
+        expect(ArrayUtils.assertGet(updated.lines, 2).lineModeStart).to.equal(Lexer.LineMode.Default, "line 2 should start in Default mode");
 
         // Now snapshot to get token positions and verify line numbers are correct.
         const triedSnapshot: Lexer.TriedLexerSnapshot = Lexer.trySnapshot(updated);

--- a/src/test/libraryTest/parser/identifierContextKind.test.ts
+++ b/src/test/libraryTest/parser/identifierContextKind.test.ts
@@ -4,7 +4,7 @@
 import "mocha";
 import { expect } from "chai";
 
-import { Assert } from "../../../powerquery-parser/common";
+import { ArrayUtils } from "../../../powerquery-parser/common";
 import { NodeIdMap, NodeIdMapUtils, ParseOk } from "../../../powerquery-parser/parser";
 import { AssertTestUtils } from "../../testUtils";
 import { Ast } from "../../../powerquery-parser/language";
@@ -29,7 +29,7 @@ function assertGetIdentifierByLiteral(parseOk: ParseOk, identifierLiteral: strin
     if (matches.length === 0) {
         throw new Error(`could not find the following identifier in the ast: ${identifierLiteral}`);
     } else if (matches.length === 1) {
-        return Assert.asDefined(matches[0]);
+        return ArrayUtils.assertGet(matches, 0);
     } else {
         throw new Error(`found multiple instances of the following identifier: ${identifierLiteral}`);
     }

--- a/src/test/libraryTest/parser/identifierContextKind.test.ts
+++ b/src/test/libraryTest/parser/identifierContextKind.test.ts
@@ -4,6 +4,7 @@
 import "mocha";
 import { expect } from "chai";
 
+import { Assert } from "../../../powerquery-parser/common";
 import { NodeIdMap, NodeIdMapUtils, ParseOk } from "../../../powerquery-parser/parser";
 import { AssertTestUtils } from "../../testUtils";
 import { Ast } from "../../../powerquery-parser/language";
@@ -28,7 +29,7 @@ function assertGetIdentifierByLiteral(parseOk: ParseOk, identifierLiteral: strin
     if (matches.length === 0) {
         throw new Error(`could not find the following identifier in the ast: ${identifierLiteral}`);
     } else if (matches.length === 1) {
-        return matches[0];
+        return Assert.asDefined(matches[0]);
     } else {
         throw new Error(`found multiple instances of the following identifier: ${identifierLiteral}`);
     }

--- a/src/test/libraryTest/parser/parseNodeIdMapUtils.test.ts
+++ b/src/test/libraryTest/parser/parseNodeIdMapUtils.test.ts
@@ -4,7 +4,7 @@
 import "mocha";
 import { expect } from "chai";
 
-import { Assert, Language, MapUtils, Parser } from "../../../powerquery-parser";
+import { ArrayUtils, Assert, Language, MapUtils, Parser } from "../../../powerquery-parser";
 import { DefaultSettings, Task } from "../../..";
 import {
     FieldSpecificationKeyValuePair,
@@ -34,7 +34,7 @@ describe("nodeIdMapIterator", () => {
 
         expect(fieldSpecificationListIds.size).to.equal(1);
 
-        const fieldSpecificationListId: number = Assert.asDefined([...fieldSpecificationListIds.values()][0]);
+        const fieldSpecificationListId: number = ArrayUtils.assertGet([...fieldSpecificationListIds.values()], 0);
 
         const fieldSpecificationList: TXorNode = NodeIdMapUtils.assertXor(
             parseOk.nodeIdMapCollection,
@@ -46,11 +46,11 @@ describe("nodeIdMapIterator", () => {
 
         expect(fieldSpecificationKeyValuePairs.length).to.equal(2);
 
-        const firstKeyValuePair: FieldSpecificationKeyValuePair = Assert.asDefined(fieldSpecificationKeyValuePairs[0]);
+        const firstKeyValuePair: FieldSpecificationKeyValuePair = ArrayUtils.assertGet(fieldSpecificationKeyValuePairs, 0);
         expect(firstKeyValuePair.optional).to.equal(undefined);
         expect(firstKeyValuePair.normalizedKeyLiteral).to.equal("foo");
 
-        const secondKeyValuePair: FieldSpecificationKeyValuePair = Assert.asDefined(fieldSpecificationKeyValuePairs[1]);
+        const secondKeyValuePair: FieldSpecificationKeyValuePair = ArrayUtils.assertGet(fieldSpecificationKeyValuePairs, 1);
         expect(Boolean(secondKeyValuePair.optional)).to.equal(true);
         expect(secondKeyValuePair.normalizedKeyLiteral).to.equal("bar");
     });
@@ -67,7 +67,7 @@ describe("nodeIdMapIterator", () => {
 
             expect(functionExpressionIds.size).to.equal(1);
 
-            const functionExpressionId: number = Assert.asDefined([...functionExpressionIds.values()][0]);
+            const functionExpressionId: number = ArrayUtils.assertGet([...functionExpressionIds.values()], 0);
 
             const functionExpression: TXorNode = NodeIdMapUtils.assertXor(
                 parseOk.nodeIdMapCollection,
@@ -82,12 +82,12 @@ describe("nodeIdMapIterator", () => {
             expect(parameters.length).to.equal(2);
 
             const firstParameter: Ast.TParameter = Language.AstUtils.assertAsNodeKind<Ast.TParameter>(
-                XorNodeUtils.assertAst(Assert.asDefined(parameters[0])),
+                XorNodeUtils.assertAst(ArrayUtils.assertGet(parameters, 0)),
                 Ast.NodeKind.Parameter,
             );
 
             const secondParameter: Ast.TParameter = Language.AstUtils.assertAsNodeKind<Ast.TParameter>(
-                XorNodeUtils.assertAst(Assert.asDefined(parameters[1])),
+                XorNodeUtils.assertAst(ArrayUtils.assertGet(parameters, 1)),
                 Ast.NodeKind.Parameter,
             );
 
@@ -106,7 +106,7 @@ describe("nodeIdMapIterator", () => {
 
             expect(functionExpressionIds.size).to.equal(1);
 
-            const functionExpressionId: number = Assert.asDefined([...functionExpressionIds.values()][0]);
+            const functionExpressionId: number = ArrayUtils.assertGet([...functionExpressionIds.values()], 0);
 
             const functionExpression: TXorNode = NodeIdMapUtils.assertXor(
                 parseError.state.contextState.nodeIdMapCollection,
@@ -121,12 +121,12 @@ describe("nodeIdMapIterator", () => {
             expect(parameters.length).to.equal(2);
 
             const firstParameter: Ast.TParameter = Language.AstUtils.assertAsNodeKind<Ast.TParameter>(
-                XorNodeUtils.assertAst(Assert.asDefined(parameters[0])),
+                XorNodeUtils.assertAst(ArrayUtils.assertGet(parameters, 0)),
                 Ast.NodeKind.Parameter,
             );
 
             const secondParameter: Ast.TParameter = Language.AstUtils.assertAsNodeKind<Ast.TParameter>(
-                XorNodeUtils.assertAst(Assert.asDefined(parameters[1])),
+                XorNodeUtils.assertAst(ArrayUtils.assertGet(parameters, 1)),
                 Ast.NodeKind.Parameter,
             );
 
@@ -147,7 +147,7 @@ describe("nodeIdMapIterator", () => {
 
             expect(functionExpressionIds.size).to.equal(1);
 
-            const functionExpressionId: number = Assert.asDefined([...functionExpressionIds.values()][0]);
+            const functionExpressionId: number = ArrayUtils.assertGet([...functionExpressionIds.values()], 0);
 
             const functionExpression: TXorNode = NodeIdMapUtils.assertXor(
                 parseOk.nodeIdMapCollection,
@@ -173,7 +173,7 @@ describe("nodeIdMapIterator", () => {
 
             expect(functionExpressionIds.size).to.equal(1);
 
-            const functionExpressionId: number = Assert.asDefined([...functionExpressionIds.values()][0]);
+            const functionExpressionId: number = ArrayUtils.assertGet([...functionExpressionIds.values()], 0);
 
             const functionExpression: TXorNode = NodeIdMapUtils.assertXor(
                 parseError.state.contextState.nodeIdMapCollection,
@@ -201,7 +201,7 @@ describe("nodeIdMapIterator", () => {
 
             expect(recordIds.size).to.equal(1);
 
-            const recordId: number = Assert.asDefined([...recordIds.values()][0]);
+            const recordId: number = ArrayUtils.assertGet([...recordIds.values()], 0);
             const record: TXorNode = NodeIdMapUtils.assertXor(parseOk.nodeIdMapCollection, recordId);
 
             const recordKeyValuePairs: ReadonlyArray<RecordKeyValuePair> = NodeIdMapIterator.iterRecord(
@@ -211,7 +211,7 @@ describe("nodeIdMapIterator", () => {
 
             expect(recordKeyValuePairs.length).to.equal(1);
 
-            const keyValuePair: RecordKeyValuePair = Assert.asDefined(recordKeyValuePairs[0]);
+            const keyValuePair: RecordKeyValuePair = ArrayUtils.assertGet(recordKeyValuePairs, 0);
             expect(keyValuePair.normalizedKeyLiteral).to.equal("foo");
         });
     });
@@ -227,7 +227,7 @@ describe("nodeIdMapIterator", () => {
 
         expect(recordTypeIds.size).to.equal(1);
 
-        const recordTypeId: number = Assert.asDefined([...recordTypeIds.values()][0]);
+        const recordTypeId: number = ArrayUtils.assertGet([...recordTypeIds.values()], 0);
         const recordType: TXorNode = NodeIdMapUtils.assertXor(parseOk.nodeIdMapCollection, recordTypeId);
 
         const fieldSpecificationKeyValuePairs: ReadonlyArray<FieldSpecificationKeyValuePair> =
@@ -235,11 +235,11 @@ describe("nodeIdMapIterator", () => {
 
         expect(fieldSpecificationKeyValuePairs.length).to.equal(2);
 
-        const firstKeyValuePair: FieldSpecificationKeyValuePair = Assert.asDefined(fieldSpecificationKeyValuePairs[0]);
+        const firstKeyValuePair: FieldSpecificationKeyValuePair = ArrayUtils.assertGet(fieldSpecificationKeyValuePairs, 0);
         expect(firstKeyValuePair.optional).to.equal(undefined);
         expect(firstKeyValuePair.normalizedKeyLiteral).to.equal("foo");
 
-        const secondKeyValuePair: FieldSpecificationKeyValuePair = Assert.asDefined(fieldSpecificationKeyValuePairs[1]);
+        const secondKeyValuePair: FieldSpecificationKeyValuePair = ArrayUtils.assertGet(fieldSpecificationKeyValuePairs, 1);
         expect(Boolean(secondKeyValuePair.optional)).to.equal(true);
         expect(secondKeyValuePair.normalizedKeyLiteral).to.equal("bar");
     });

--- a/src/test/libraryTest/parser/parseNodeIdMapUtils.test.ts
+++ b/src/test/libraryTest/parser/parseNodeIdMapUtils.test.ts
@@ -46,11 +46,11 @@ describe("nodeIdMapIterator", () => {
 
         expect(fieldSpecificationKeyValuePairs.length).to.equal(2);
 
-        const firstKeyValuePair: FieldSpecificationKeyValuePair = fieldSpecificationKeyValuePairs[0];
+        const firstKeyValuePair: FieldSpecificationKeyValuePair = Assert.asDefined(fieldSpecificationKeyValuePairs[0]);
         expect(firstKeyValuePair.optional).to.equal(undefined);
         expect(firstKeyValuePair.normalizedKeyLiteral).to.equal("foo");
 
-        const secondKeyValuePair: FieldSpecificationKeyValuePair = fieldSpecificationKeyValuePairs[1];
+        const secondKeyValuePair: FieldSpecificationKeyValuePair = Assert.asDefined(fieldSpecificationKeyValuePairs[1]);
         expect(Boolean(secondKeyValuePair.optional)).to.equal(true);
         expect(secondKeyValuePair.normalizedKeyLiteral).to.equal("bar");
     });
@@ -82,12 +82,12 @@ describe("nodeIdMapIterator", () => {
             expect(parameters.length).to.equal(2);
 
             const firstParameter: Ast.TParameter = Language.AstUtils.assertAsNodeKind<Ast.TParameter>(
-                XorNodeUtils.assertAst(parameters[0]),
+                XorNodeUtils.assertAst(Assert.asDefined(parameters[0])),
                 Ast.NodeKind.Parameter,
             );
 
             const secondParameter: Ast.TParameter = Language.AstUtils.assertAsNodeKind<Ast.TParameter>(
-                XorNodeUtils.assertAst(parameters[1]),
+                XorNodeUtils.assertAst(Assert.asDefined(parameters[1])),
                 Ast.NodeKind.Parameter,
             );
 
@@ -121,12 +121,12 @@ describe("nodeIdMapIterator", () => {
             expect(parameters.length).to.equal(2);
 
             const firstParameter: Ast.TParameter = Language.AstUtils.assertAsNodeKind<Ast.TParameter>(
-                XorNodeUtils.assertAst(parameters[0]),
+                XorNodeUtils.assertAst(Assert.asDefined(parameters[0])),
                 Ast.NodeKind.Parameter,
             );
 
             const secondParameter: Ast.TParameter = Language.AstUtils.assertAsNodeKind<Ast.TParameter>(
-                XorNodeUtils.assertAst(parameters[1]),
+                XorNodeUtils.assertAst(Assert.asDefined(parameters[1])),
                 Ast.NodeKind.Parameter,
             );
 
@@ -211,7 +211,7 @@ describe("nodeIdMapIterator", () => {
 
             expect(recordKeyValuePairs.length).to.equal(1);
 
-            const keyValuePair: RecordKeyValuePair = recordKeyValuePairs[0];
+            const keyValuePair: RecordKeyValuePair = Assert.asDefined(recordKeyValuePairs[0]);
             expect(keyValuePair.normalizedKeyLiteral).to.equal("foo");
         });
     });
@@ -235,11 +235,11 @@ describe("nodeIdMapIterator", () => {
 
         expect(fieldSpecificationKeyValuePairs.length).to.equal(2);
 
-        const firstKeyValuePair: FieldSpecificationKeyValuePair = fieldSpecificationKeyValuePairs[0];
+        const firstKeyValuePair: FieldSpecificationKeyValuePair = Assert.asDefined(fieldSpecificationKeyValuePairs[0]);
         expect(firstKeyValuePair.optional).to.equal(undefined);
         expect(firstKeyValuePair.normalizedKeyLiteral).to.equal("foo");
 
-        const secondKeyValuePair: FieldSpecificationKeyValuePair = fieldSpecificationKeyValuePairs[1];
+        const secondKeyValuePair: FieldSpecificationKeyValuePair = Assert.asDefined(fieldSpecificationKeyValuePairs[1]);
         expect(Boolean(secondKeyValuePair.optional)).to.equal(true);
         expect(secondKeyValuePair.normalizedKeyLiteral).to.equal("bar");
     });

--- a/src/test/libraryTest/parser/typeDirective.test.ts
+++ b/src/test/libraryTest/parser/typeDirective.test.ts
@@ -6,6 +6,7 @@ import { expect } from "chai";
 
 import * as AssertTestUtils from "../../testUtils/assertTestUtils";
 import { DefaultSettings, Language } from "../../../powerquery-parser";
+import { Assert } from "../../../powerquery-parser/common";
 
 type ParseOk = Awaited<ReturnType<typeof AssertTestUtils.assertGetLexParseOk>>;
 
@@ -21,7 +22,7 @@ in
         );
 
         const letExpression: Language.Ast.LetExpression = parseOk.ast as Language.Ast.LetExpression;
-        const variable: Language.Ast.IdentifierPairedExpression = letExpression.variableList.elements[0].node;
+        const variable: Language.Ast.IdentifierPairedExpression = Assert.asDefined(letExpression.variableList.elements[0]).node;
 
         expect(variable.precedingDirectives).to.equal(undefined);
     });
@@ -40,7 +41,7 @@ in
         );
 
         const letExpression: Language.Ast.LetExpression = parseOk.ast as Language.Ast.LetExpression;
-        const variable: Language.Ast.IdentifierPairedExpression = letExpression.variableList.elements[0].node;
+        const variable: Language.Ast.IdentifierPairedExpression = Assert.asDefined(letExpression.variableList.elements[0]).node;
 
         expect(variable.precedingDirectives).to.not.equal(undefined);
 
@@ -61,7 +62,7 @@ shared Value = [];`,
         );
 
         const section: Language.Ast.Section = parseOk.ast as Language.Ast.Section;
-        const sectionMember: Language.Ast.SectionMember = section.sectionMembers.elements[0];
+        const sectionMember: Language.Ast.SectionMember = Assert.asDefined(section.sectionMembers.elements[0]);
 
         expect(
             sectionMember.precedingDirectives?.map((directive: Language.Comment.TDirective) => directive.value),
@@ -82,7 +83,7 @@ in
         );
 
         const letExpression: Language.Ast.LetExpression = parseOk.ast as Language.Ast.LetExpression;
-        const variable: Language.Ast.IdentifierPairedExpression = letExpression.variableList.elements[0].node;
+        const variable: Language.Ast.IdentifierPairedExpression = Assert.asDefined(letExpression.variableList.elements[0]).node;
 
         expect(
             variable.precedingDirectives?.map((directive: Language.Comment.TDirective) => directive.value),
@@ -104,7 +105,7 @@ in
         );
 
         const letExpression: Language.Ast.LetExpression = parseOk.ast as Language.Ast.LetExpression;
-        const variable: Language.Ast.IdentifierPairedExpression = letExpression.variableList.elements[0].node;
+        const variable: Language.Ast.IdentifierPairedExpression = Assert.asDefined(letExpression.variableList.elements[0]).node;
 
         expect(variable.precedingDirectives).to.equal(undefined);
     });

--- a/src/test/libraryTest/parser/typeDirective.test.ts
+++ b/src/test/libraryTest/parser/typeDirective.test.ts
@@ -6,7 +6,7 @@ import { expect } from "chai";
 
 import * as AssertTestUtils from "../../testUtils/assertTestUtils";
 import { DefaultSettings, Language } from "../../../powerquery-parser";
-import { Assert } from "../../../powerquery-parser/common";
+import { ArrayUtils } from "../../../powerquery-parser/common";
 
 type ParseOk = Awaited<ReturnType<typeof AssertTestUtils.assertGetLexParseOk>>;
 
@@ -22,7 +22,7 @@ in
         );
 
         const letExpression: Language.Ast.LetExpression = parseOk.ast as Language.Ast.LetExpression;
-        const variable: Language.Ast.IdentifierPairedExpression = Assert.asDefined(letExpression.variableList.elements[0]).node;
+        const variable: Language.Ast.IdentifierPairedExpression = ArrayUtils.assertGet(letExpression.variableList.elements, 0).node;
 
         expect(variable.precedingDirectives).to.equal(undefined);
     });
@@ -41,7 +41,7 @@ in
         );
 
         const letExpression: Language.Ast.LetExpression = parseOk.ast as Language.Ast.LetExpression;
-        const variable: Language.Ast.IdentifierPairedExpression = Assert.asDefined(letExpression.variableList.elements[0]).node;
+        const variable: Language.Ast.IdentifierPairedExpression = ArrayUtils.assertGet(letExpression.variableList.elements, 0).node;
 
         expect(variable.precedingDirectives).to.not.equal(undefined);
 
@@ -62,7 +62,7 @@ shared Value = [];`,
         );
 
         const section: Language.Ast.Section = parseOk.ast as Language.Ast.Section;
-        const sectionMember: Language.Ast.SectionMember = Assert.asDefined(section.sectionMembers.elements[0]);
+        const sectionMember: Language.Ast.SectionMember = ArrayUtils.assertGet(section.sectionMembers.elements, 0);
 
         expect(
             sectionMember.precedingDirectives?.map((directive: Language.Comment.TDirective) => directive.value),
@@ -83,7 +83,7 @@ in
         );
 
         const letExpression: Language.Ast.LetExpression = parseOk.ast as Language.Ast.LetExpression;
-        const variable: Language.Ast.IdentifierPairedExpression = Assert.asDefined(letExpression.variableList.elements[0]).node;
+        const variable: Language.Ast.IdentifierPairedExpression = ArrayUtils.assertGet(letExpression.variableList.elements, 0).node;
 
         expect(
             variable.precedingDirectives?.map((directive: Language.Comment.TDirective) => directive.value),
@@ -105,7 +105,7 @@ in
         );
 
         const letExpression: Language.Ast.LetExpression = parseOk.ast as Language.Ast.LetExpression;
-        const variable: Language.Ast.IdentifierPairedExpression = Assert.asDefined(letExpression.variableList.elements[0]).node;
+        const variable: Language.Ast.IdentifierPairedExpression = ArrayUtils.assertGet(letExpression.variableList.elements, 0).node;
 
         expect(variable.precedingDirectives).to.equal(undefined);
     });

--- a/src/test/libraryTest/tokenizer/tokenizerIncremental.test.ts
+++ b/src/test/libraryTest/tokenizer/tokenizerIncremental.test.ts
@@ -5,7 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { DefaultSettings, Lexer, ResultUtils } from "../../..";
-import { Assert } from "../../../powerquery-parser/common";
+import { ArrayUtils } from "../../../powerquery-parser/common";
 import { ILineTokens, IState, IToken, Tokenizer } from "../../testUtils/tokenizerTestUtils";
 
 const tokenizer: Tokenizer = new Tokenizer("\n");
@@ -75,11 +75,11 @@ class MockDocument {
         if (startingIndex === 0 || this.lineEndStates[startingIndex - 1] === undefined) {
             state = this.tokenizer.getInitialState();
         } else {
-            state = Assert.asDefined(this.lineEndStates[startingIndex - 1]);
+            state = ArrayUtils.assertGet(this.lineEndStates, startingIndex - 1);
         }
 
         for (let index: number = startingIndex; index < this.lines.length; index += 1) {
-            const result: ILineTokens = tokenizer.tokenize(Assert.asDefined(this.lines[index]), state);
+            const result: ILineTokens = tokenizer.tokenize(ArrayUtils.assertGet(this.lines, index), state);
             this.lineTokens[index] = result.tokens;
             tokenizedLineCount += 1;
 
@@ -161,14 +161,14 @@ describe("MockDocument validation", () => {
 describe("Incremental updates", () => {
     it("Re-parse with no change", () => {
         const document: MockDocument = new MockDocument(ORIGINAL_QUERY);
-        const originalLine: string = Assert.asDefined(document.lines[2]);
+        const originalLine: string = ArrayUtils.assertGet(document.lines, 2);
         const count: number = document.applyChangeAndTokenize(originalLine, 2);
         expect(count).equals(1, "we should not have tokenized more than one line");
     });
 
     it("Re-parse with simple change", () => {
         const document: MockDocument = new MockDocument(ORIGINAL_QUERY);
-        const modified: string = Assert.asDefined(document.lines[2]).replace("source", "source123");
+        const modified: string = ArrayUtils.assertGet(document.lines, 2).replace("source", "source123");
         const count: number = document.applyChangeAndTokenize(modified, 2);
         expect(count).equals(1, "we should not have tokenized more than one line");
     });
@@ -176,12 +176,12 @@ describe("Incremental updates", () => {
     it("Re-parse with unterminated string", () => {
         const lineNumber: number = 4;
         const document: MockDocument = new MockDocument(ORIGINAL_QUERY);
-        const modified: string = Assert.asDefined(document.lines[lineNumber]).replace(`"text",`, `"text`);
+        const modified: string = ArrayUtils.assertGet(document.lines, lineNumber).replace(`"text",`, `"text`);
         const count: number = document.applyChangeAndTokenize(modified, lineNumber);
         expect(count).equals(document.lines.length - lineNumber, "remaining lines should have been tokenized");
 
         for (let index: number = lineNumber + 1; index < document.lineTokens.length; index += 1) {
-            const lineTokens: ReadonlyArray<IToken> = Assert.asDefined(document.lineTokens[index]);
+            const lineTokens: ReadonlyArray<IToken> = ArrayUtils.assertGet(document.lineTokens, index);
 
             lineTokens.forEach((token: IToken) => {
                 expect(token.scopes).equals("TextContent", "expecting remaining tokens to be strings");
@@ -192,12 +192,12 @@ describe("Incremental updates", () => {
     it("Re-parse with unterminated block comment", () => {
         const lineNumber: number = 3;
         const document: MockDocument = new MockDocument(ORIGINAL_QUERY);
-        const modified: string = Assert.asDefined(document.lines[lineNumber]).replace(`rce),`, `rce), /* my open comment`);
+        const modified: string = ArrayUtils.assertGet(document.lines, lineNumber).replace(`rce),`, `rce), /* my open comment`);
         const count: number = document.applyChangeAndTokenize(modified, lineNumber);
         expect(count).equals(document.lines.length - lineNumber, "remaining lines should have been tokenized");
 
         for (let index: number = lineNumber + 1; index < document.lineTokens.length; index += 1) {
-            const lineTokens: ReadonlyArray<IToken> = Assert.asDefined(document.lineTokens[index]);
+            const lineTokens: ReadonlyArray<IToken> = ArrayUtils.assertGet(document.lineTokens, index);
 
             lineTokens.forEach((token: IToken) => {
                 expect(token.scopes).equals("MultilineCommentContent", "expecting remaining tokens to be comments");

--- a/src/test/libraryTest/tokenizer/tokenizerIncremental.test.ts
+++ b/src/test/libraryTest/tokenizer/tokenizerIncremental.test.ts
@@ -5,6 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { DefaultSettings, Lexer, ResultUtils } from "../../..";
+import { Assert } from "../../../powerquery-parser/common";
 import { ILineTokens, IState, IToken, Tokenizer } from "../../testUtils/tokenizerTestUtils";
 
 const tokenizer: Tokenizer = new Tokenizer("\n");
@@ -74,16 +75,18 @@ class MockDocument {
         if (startingIndex === 0 || this.lineEndStates[startingIndex - 1] === undefined) {
             state = this.tokenizer.getInitialState();
         } else {
-            state = this.lineEndStates[startingIndex - 1];
+            state = Assert.asDefined(this.lineEndStates[startingIndex - 1]);
         }
 
         for (let index: number = startingIndex; index < this.lines.length; index += 1) {
-            const result: ILineTokens = tokenizer.tokenize(this.lines[index], state);
+            const result: ILineTokens = tokenizer.tokenize(Assert.asDefined(this.lines[index]), state);
             this.lineTokens[index] = result.tokens;
             tokenizedLineCount += 1;
 
             // If the new end state matches the previous state, we can stop tokenizing
-            if (result.endState.equals(this.lineEndStates[index])) {
+            const previousEndState: IState | undefined = this.lineEndStates[index];
+
+            if (previousEndState !== undefined && result.endState.equals(previousEndState)) {
                 break;
             }
 
@@ -158,14 +161,14 @@ describe("MockDocument validation", () => {
 describe("Incremental updates", () => {
     it("Re-parse with no change", () => {
         const document: MockDocument = new MockDocument(ORIGINAL_QUERY);
-        const originalLine: string = document.lines[2];
+        const originalLine: string = Assert.asDefined(document.lines[2]);
         const count: number = document.applyChangeAndTokenize(originalLine, 2);
         expect(count).equals(1, "we should not have tokenized more than one line");
     });
 
     it("Re-parse with simple change", () => {
         const document: MockDocument = new MockDocument(ORIGINAL_QUERY);
-        const modified: string = document.lines[2].replace("source", "source123");
+        const modified: string = Assert.asDefined(document.lines[2]).replace("source", "source123");
         const count: number = document.applyChangeAndTokenize(modified, 2);
         expect(count).equals(1, "we should not have tokenized more than one line");
     });
@@ -173,12 +176,12 @@ describe("Incremental updates", () => {
     it("Re-parse with unterminated string", () => {
         const lineNumber: number = 4;
         const document: MockDocument = new MockDocument(ORIGINAL_QUERY);
-        const modified: string = document.lines[lineNumber].replace(`"text",`, `"text`);
+        const modified: string = Assert.asDefined(document.lines[lineNumber]).replace(`"text",`, `"text`);
         const count: number = document.applyChangeAndTokenize(modified, lineNumber);
         expect(count).equals(document.lines.length - lineNumber, "remaining lines should have been tokenized");
 
         for (let index: number = lineNumber + 1; index < document.lineTokens.length; index += 1) {
-            const lineTokens: ReadonlyArray<IToken> = document.lineTokens[index];
+            const lineTokens: ReadonlyArray<IToken> = Assert.asDefined(document.lineTokens[index]);
 
             lineTokens.forEach((token: IToken) => {
                 expect(token.scopes).equals("TextContent", "expecting remaining tokens to be strings");
@@ -189,12 +192,12 @@ describe("Incremental updates", () => {
     it("Re-parse with unterminated block comment", () => {
         const lineNumber: number = 3;
         const document: MockDocument = new MockDocument(ORIGINAL_QUERY);
-        const modified: string = document.lines[lineNumber].replace(`rce),`, `rce), /* my open comment`);
+        const modified: string = Assert.asDefined(document.lines[lineNumber]).replace(`rce),`, `rce), /* my open comment`);
         const count: number = document.applyChangeAndTokenize(modified, lineNumber);
         expect(count).equals(document.lines.length - lineNumber, "remaining lines should have been tokenized");
 
         for (let index: number = lineNumber + 1; index < document.lineTokens.length; index += 1) {
-            const lineTokens: ReadonlyArray<IToken> = document.lineTokens[index];
+            const lineTokens: ReadonlyArray<IToken> = Assert.asDefined(document.lineTokens[index]);
 
             lineTokens.forEach((token: IToken) => {
                 expect(token.scopes).equals("MultilineCommentContent", "expecting remaining tokens to be comments");

--- a/src/test/libraryTest/tokenizer/tokenizerSimple.test.ts
+++ b/src/test/libraryTest/tokenizer/tokenizerSimple.test.ts
@@ -5,6 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { ILineTokens, IState, IToken, Tokenizer, TokenizerState } from "../../testUtils/tokenizerTestUtils";
+import { Assert } from "../../../powerquery-parser/common";
 
 const tokenizer: Tokenizer = new Tokenizer(`\n`);
 const initialState: TokenizerState = tokenizer.getInitialState() as TokenizerState;
@@ -16,14 +17,14 @@ function tokenizeLines(query: string, expectedTokenCounts: number[]): void {
     expect(lines.length).equals(expectedTokenCounts.length);
 
     for (let index: number = 0; index < lines.length; index += 1) {
-        const r: ILineTokens = tokenizer.tokenize(lines[index], state);
+        const r: ILineTokens = tokenizer.tokenize(Assert.asDefined(lines[index]), state);
         expect(!state.equals(r.endState), `state should have changed.`);
-        expect(r.tokens.length).equals(expectedTokenCounts[index], `unexpected token count`);
+        expect(r.tokens.length).equals(Assert.asDefined(expectedTokenCounts[index]), `unexpected token count`);
 
         state = r.endState as TokenizerState;
 
         r.tokens.forEach((token: IToken) => {
-            expect(token.startIndex).is.lessThan(lines[index].length);
+            expect(token.startIndex).is.lessThan(Assert.asDefined(lines[index]).length);
         });
     }
 }

--- a/src/test/libraryTest/tokenizer/tokenizerSimple.test.ts
+++ b/src/test/libraryTest/tokenizer/tokenizerSimple.test.ts
@@ -5,7 +5,7 @@ import "mocha";
 import { expect } from "chai";
 
 import { ILineTokens, IState, IToken, Tokenizer, TokenizerState } from "../../testUtils/tokenizerTestUtils";
-import { Assert } from "../../../powerquery-parser/common";
+import { ArrayUtils } from "../../../powerquery-parser/common";
 
 const tokenizer: Tokenizer = new Tokenizer(`\n`);
 const initialState: TokenizerState = tokenizer.getInitialState() as TokenizerState;
@@ -17,14 +17,14 @@ function tokenizeLines(query: string, expectedTokenCounts: number[]): void {
     expect(lines.length).equals(expectedTokenCounts.length);
 
     for (let index: number = 0; index < lines.length; index += 1) {
-        const r: ILineTokens = tokenizer.tokenize(Assert.asDefined(lines[index]), state);
+        const r: ILineTokens = tokenizer.tokenize(ArrayUtils.assertGet(lines, index), state);
         expect(!state.equals(r.endState), `state should have changed.`);
-        expect(r.tokens.length).equals(Assert.asDefined(expectedTokenCounts[index]), `unexpected token count`);
+        expect(r.tokens.length).equals(ArrayUtils.assertGet(expectedTokenCounts, index), `unexpected token count`);
 
         state = r.endState as TokenizerState;
 
         r.tokens.forEach((token: IToken) => {
-            expect(token.startIndex).is.lessThan(Assert.asDefined(lines[index]).length);
+            expect(token.startIndex).is.lessThan(ArrayUtils.assertGet(lines, index).length);
         });
     }
 }

--- a/src/test/testUtils/tokenizerTestUtils.ts
+++ b/src/test/testUtils/tokenizerTestUtils.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { Assert } from "../../powerquery-parser/common";
 import { DefaultLocale, Language, ResultUtils } from "../../powerquery-parser";
 import { Lexer } from "../..";
 
@@ -49,7 +50,7 @@ export class Tokenizer implements TokensProvider {
         const newLexerState: Lexer.State = triedLex.value;
 
         return {
-            tokens: newLexerState.lines[newLexerState.lines.length - 1].tokens.map(Tokenizer.ITokenFrom),
+            tokens: Assert.asDefined(newLexerState.lines[newLexerState.lines.length - 1]).tokens.map(Tokenizer.ITokenFrom),
             endState: new TokenizerState(newLexerState),
         };
     }
@@ -82,8 +83,8 @@ export class TokenizerState implements IState {
         }
 
         // Compare last line state.
-        const leftLastLine: Lexer.TLine = this.lexerState.lines[this.lexerState.lines.length - 1];
-        const rightLastLine: Lexer.TLine = rightLexerState.lines[rightLexerState.lines.length - 1];
+        const leftLastLine: Lexer.TLine = Assert.asDefined(this.lexerState.lines[this.lexerState.lines.length - 1]);
+        const rightLastLine: Lexer.TLine = Assert.asDefined(rightLexerState.lines[rightLexerState.lines.length - 1]);
 
         return leftLastLine.lineModeEnd === rightLastLine.lineModeEnd;
     }

--- a/src/test/testUtils/tokenizerTestUtils.ts
+++ b/src/test/testUtils/tokenizerTestUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Assert } from "../../powerquery-parser/common";
+import { ArrayUtils } from "../../powerquery-parser/common";
 import { DefaultLocale, Language, ResultUtils } from "../../powerquery-parser";
 import { Lexer } from "../..";
 
@@ -50,7 +50,7 @@ export class Tokenizer implements TokensProvider {
         const newLexerState: Lexer.State = triedLex.value;
 
         return {
-            tokens: Assert.asDefined(newLexerState.lines[newLexerState.lines.length - 1]).tokens.map(Tokenizer.ITokenFrom),
+            tokens: ArrayUtils.assertGet(newLexerState.lines, newLexerState.lines.length - 1).tokens.map(Tokenizer.ITokenFrom),
             endState: new TokenizerState(newLexerState),
         };
     }
@@ -83,8 +83,8 @@ export class TokenizerState implements IState {
         }
 
         // Compare last line state.
-        const leftLastLine: Lexer.TLine = Assert.asDefined(this.lexerState.lines[this.lexerState.lines.length - 1]);
-        const rightLastLine: Lexer.TLine = Assert.asDefined(rightLexerState.lines[rightLexerState.lines.length - 1]);
+        const leftLastLine: Lexer.TLine = ArrayUtils.assertGet(this.lexerState.lines, this.lexerState.lines.length - 1);
+        const rightLastLine: Lexer.TLine = ArrayUtils.assertGet(rightLexerState.lines, rightLexerState.lines.length - 1);
 
         return leftLastLine.lineModeEnd === rightLastLine.lineModeEnd;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
         "noFallthroughCasesInSwitch": true,
         "noImplicitOverride": true,
         "noImplicitReturns": true,
+        "noUncheckedIndexedAccess": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "outDir": "lib",


### PR DESCRIPTION
## Summary

Enables `noUncheckedIndexedAccess: true` in tsconfig.json. All indexed array and string accesses are now explicitly checked at compile time, with runtime safety provided by dedicated assert helpers.

## Changes

- **tsconfig.json**: Added `noUncheckedIndexedAccess: true`
- **ArrayUtils.assertGet**: Updated default error message/details to include index and collection length
- **StringUtils.assertGet**: New helper for safe string character access with diagnostics
- **~30 source and test files**: Replaced raw indexed accesses with `ArrayUtils.assertGet(arr, i)` or `StringUtils.assertGet(str, i)`
- Audited existing `Assert.asDefined` calls and migrated array-indexed ones to the new helpers

## Rationale

`noUncheckedIndexedAccess` forces the compiler to treat every `arr[i]` as `T | undefined`, catching potential out-of-bounds bugs at compile time. The dedicated `assertGet` helpers provide:

1. **Runtime safety** - throws `InvariantError` if the index is out of bounds
2. **Diagnosability** - error messages include the index and collection/string length
3. **Readability** - clearly communicates intent vs raw `!` or `Assert.asDefined`